### PR TITLE
feat: migrate renameTable to typescript

### DIFF
--- a/packages/core/src/dialects/abstract/index.ts
+++ b/packages/core/src/dialects/abstract/index.ts
@@ -233,6 +233,10 @@ export type DialectSupports = {
     cascade: boolean,
     ifExists: boolean,
   },
+  renameTable: {
+    changeSchema: boolean,
+    changeSchemaAndTable: boolean,
+  },
 };
 
 type TypeParser = (...params: any[]) => unknown;
@@ -373,6 +377,10 @@ export abstract class AbstractDialect {
     removeColumn: {
       cascade: false,
       ifExists: false,
+    },
+    renameTable: {
+      changeSchema: true,
+      changeSchemaAndTable: true,
     },
   };
 

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -44,6 +44,7 @@ import type {
   QuoteTableOptions,
   RemoveColumnQueryOptions,
   RemoveConstraintQueryOptions,
+  RenameTableQueryOptions,
   ShowConstraintsQueryOptions,
 } from './query-generator.types.js';
 import type { TableName, TableNameWithSchema } from './query-interface.js';
@@ -219,6 +220,21 @@ export class AbstractQueryGeneratorTypeScript {
 
   listTablesQuery(_options?: ListTablesQueryOptions): string {
     throw new Error(`listTablesQuery has not been implemented in ${this.dialect.name}.`);
+  }
+
+  renameTableQuery(
+    beforeTableName: TableNameOrModel,
+    afterTableName: TableNameOrModel,
+    options?: RenameTableQueryOptions,
+  ): string {
+    const beforeTable = this.extractTableDetails(beforeTableName);
+    const afterTable = this.extractTableDetails(afterTableName);
+
+    if (beforeTable.schema !== afterTable.schema && !options?.changeSchema) {
+      throw new Error('To move a table between schemas, you must set `options.changeSchema` to true.');
+    }
+
+    return `ALTER TABLE ${this.quoteTable(beforeTableName)} RENAME TO ${this.quoteTable(afterTableName)}`;
   }
 
   removeColumnQuery(tableName: TableNameOrModel, columnName: string, options?: RemoveColumnQueryOptions): string {

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -69,6 +69,7 @@ export const QUOTE_TABLE_SUPPORTABLE_OPTIONS = new Set<keyof QuoteTableOptions>(
 export const REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof RemoveColumnQueryOptions>(['ifExists', 'cascade']);
 export const REMOVE_CONSTRAINT_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof RemoveConstraintQueryOptions>(['ifExists', 'cascade']);
 export const REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['concurrently', 'ifExists', 'cascade']);
+export const RENAME_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof RenameTableQueryOptions>(['changeSchema']);
 export const SHOW_CONSTRAINTS_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ShowConstraintsQueryOptions>(['columnName', 'constraintName', 'constraintType']);
 
 export interface QueryGeneratorOptions {

--- a/packages/core/src/dialects/abstract/query-generator.d.ts
+++ b/packages/core/src/dialects/abstract/query-generator.d.ts
@@ -148,7 +148,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     columns: { [columnName: string]: string },
     options?: CreateTableQueryOptions
   ): string;
-  renameTableQuery(before: TableNameOrModel, after: TableNameOrModel): string;
 
   createSchemaQuery(schemaName: string, options?: CreateSchemaQueryOptions): string;
   dropSchemaQuery(schemaName: string): string | QueryWithBindParams;

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -64,10 +64,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
   }
 
-  renameTableQuery(before, after) {
-    return `ALTER TABLE ${this.quoteTable(before)} RENAME TO ${this.quoteTable(after)};`;
-  }
-
   /**
    * Returns an insert into command
    *

--- a/packages/core/src/dialects/abstract/query-generator.types.ts
+++ b/packages/core/src/dialects/abstract/query-generator.types.ts
@@ -43,6 +43,10 @@ export interface ListTablesQueryOptions {
   schema?: string;
 }
 
+export interface RenameTableQueryOptions {
+  changeSchema?: boolean;
+}
+
 // keep REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
 export interface RemoveColumnQueryOptions {
   cascade?: boolean;

--- a/packages/core/src/dialects/abstract/query-generator.types.ts
+++ b/packages/core/src/dialects/abstract/query-generator.types.ts
@@ -43,6 +43,7 @@ export interface ListTablesQueryOptions {
   schema?: string;
 }
 
+// keep RENAME_TABLE_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
 export interface RenameTableQueryOptions {
   changeSchema?: boolean;
 }

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -35,6 +35,7 @@ import type {
   QiListTablesOptions,
   RemoveColumnOptions,
   RemoveConstraintOptions,
+  RenameTableOptions,
   ShowConstraintsOptions,
 } from './query-interface.types';
 
@@ -251,6 +252,23 @@ export class AbstractQueryInterfaceTypeScript {
     showAllToListTables();
 
     return this.listTables(options);
+  }
+
+  /**
+   * Rename a table
+   *
+   * @param beforeTableName
+   * @param afterTableName
+   * @param options
+   */
+  async renameTable(
+    beforeTableName: TableNameOrModel,
+    afterTableName: TableNameOrModel,
+    options?: RenameTableOptions,
+  ): Promise<void> {
+    const sql = this.queryGenerator.renameTableQuery(beforeTableName, afterTableName, options);
+
+    await this.sequelize.queryRaw(sql, options);
   }
 
   /**

--- a/packages/core/src/dialects/abstract/query-interface.d.ts
+++ b/packages/core/src/dialects/abstract/query-interface.d.ts
@@ -272,11 +272,6 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   dropAllEnums(options?: QueryRawOptions): Promise<void>;
 
   /**
-   * Renames a table
-   */
-  renameTable(before: TableName, after: TableName, options?: QueryRawOptions): Promise<void>;
-
-  /**
    * Adds a new column to a table
    */
   addColumn(

--- a/packages/core/src/dialects/abstract/query-interface.js
+++ b/packages/core/src/dialects/abstract/query-interface.js
@@ -136,22 +136,6 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   }
 
   /**
-   * Rename a table
-   *
-   * @param {string} before    Current name of table
-   * @param {string} after     New name from table
-   * @param {object} [options] Query options
-   *
-   * @returns {Promise}
-   */
-  async renameTable(before, after, options) {
-    options = options || {};
-    const sql = this.queryGenerator.renameTableQuery(before, after);
-
-    return await this.sequelize.queryRaw(sql, options);
-  }
-
-  /**
    * Add a new column to a table
    *
    * ```js

--- a/packages/core/src/dialects/abstract/query-interface.types.ts
+++ b/packages/core/src/dialects/abstract/query-interface.types.ts
@@ -10,6 +10,7 @@ import type {
   ListTablesQueryOptions,
   RemoveColumnQueryOptions,
   RemoveConstraintQueryOptions,
+  RenameTableQueryOptions,
   ShowConstraintsQueryOptions,
 } from './query-generator.types';
 
@@ -109,6 +110,9 @@ export interface QiDropTableOptions extends DropTableQueryOptions, QueryRawOptio
 export interface QiDropAllTablesOptions extends QiDropTableOptions {
   skip?: string[];
 }
+
+/** Options accepted by {@link AbstractQueryInterface#renameTable} */
+export interface RenameTableOptions extends RenameTableQueryOptions, QueryRawOptions { }
 
 export interface FetchDatabaseVersionOptions extends Omit<QueryRawOptions, 'type' | 'plain'> {}
 

--- a/packages/core/src/dialects/db2/index.ts
+++ b/packages/core/src/dialects/db2/index.ts
@@ -37,6 +37,10 @@ export class Db2Dialect extends AbstractDialect {
     removeColumn: {
       cascade: true,
     },
+    renameTable: {
+      changeSchema: false,
+      changeSchemaAndTable: false,
+    },
   });
 
   readonly defaultVersion = '1.0.0';

--- a/packages/core/src/dialects/db2/query-generator-typescript.ts
+++ b/packages/core/src/dialects/db2/query-generator-typescript.ts
@@ -2,7 +2,10 @@ import { rejectInvalidOptions } from '../../utils/check';
 import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import {
+  REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+  RENAME_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+} from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import type {
   AddLimitOffsetOptions,
@@ -14,6 +17,7 @@ import type {
 import type { ConstraintType } from '../abstract/query-interface.types';
 
 const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
+const RENAME_TABLE_QUERY_SUPPORTED_OPTIONS = new Set<keyof RenameTableQueryOptions>();
 
 /**
  * Temporary class to ease the TypeScript migration
@@ -73,8 +77,18 @@ export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
   renameTableQuery(
     beforeTableName: TableNameOrModel,
     afterTableName: TableNameOrModel,
-    _options?: RenameTableQueryOptions,
+    options?: RenameTableQueryOptions,
   ): string {
+    if (options) {
+      rejectInvalidOptions(
+        'renameTableQuery',
+        this.dialect.name,
+        RENAME_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+        RENAME_TABLE_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
     const beforeTable = this.extractTableDetails(beforeTableName);
     const afterTable = this.extractTableDetails(afterTableName);
 

--- a/packages/core/src/dialects/db2/query-generator-typescript.ts
+++ b/packages/core/src/dialects/db2/query-generator-typescript.ts
@@ -8,6 +8,7 @@ import type {
   AddLimitOffsetOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
+  RenameTableQueryOptions,
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 import type { ConstraintType } from '../abstract/query-interface.types';
@@ -67,6 +68,21 @@ export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
         : `AND TABSCHEMA NOT LIKE 'SYS%' AND TABSCHEMA NOT IN (${this._getTechnicalSchemaNames().map(schema => this.escape(schema)).join(', ')})`,
       'ORDER BY TABSCHEMA, TABNAME',
     ]);
+  }
+
+  renameTableQuery(
+    beforeTableName: TableNameOrModel,
+    afterTableName: TableNameOrModel,
+    _options?: RenameTableQueryOptions,
+  ): string {
+    const beforeTable = this.extractTableDetails(beforeTableName);
+    const afterTable = this.extractTableDetails(afterTableName);
+
+    if (beforeTable.schema !== afterTable.schema) {
+      throw new Error(`Moving tables between schemas is not supported by ${this.dialect.name} dialect.`);
+    }
+
+    return `RENAME TABLE ${this.quoteTable(beforeTableName)} TO ${this.quoteIdentifier(afterTable.tableName)}`;
   }
 
   private _getConstraintType(type: ConstraintType): string {

--- a/packages/core/src/dialects/db2/query-generator.js
+++ b/packages/core/src/dialects/db2/query-generator.js
@@ -185,15 +185,6 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     return `${template(query, this._templateSettings)(values).trim()};${commentStr}`;
   }
 
-  renameTableQuery(before, after) {
-    const query = 'RENAME TABLE <%= before %> TO <%= after %>;';
-
-    return template(query, this._templateSettings)({
-      before: this.quoteTable(before),
-      after: this.quoteTable(after),
-    });
-  }
-
   addColumnQuery(table, key, dataType, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/ibmi/index.ts
+++ b/packages/core/src/dialects/ibmi/index.ts
@@ -34,6 +34,10 @@ export class IBMiDialect extends AbstractDialect {
       removeColumn: {
         cascade: true,
       },
+      renameTable: {
+        changeSchema: false,
+        changeSchemaAndTable: false,
+      },
     },
   );
 

--- a/packages/core/src/dialects/ibmi/query-generator-typescript.ts
+++ b/packages/core/src/dialects/ibmi/query-generator-typescript.ts
@@ -2,7 +2,10 @@ import { rejectInvalidOptions } from '../../utils/check';
 import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import {
+  REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+  RENAME_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+} from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import type {
   AddLimitOffsetOptions,
@@ -13,6 +16,7 @@ import type {
 } from '../abstract/query-generator.types';
 
 const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
+const RENAME_TABLE_QUERY_SUPPORTED_OPTIONS = new Set<keyof RenameTableQueryOptions>();
 
 /**
  * Temporary class to ease the TypeScript migration
@@ -65,8 +69,18 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
   renameTableQuery(
     beforeTableName: TableNameOrModel,
     afterTableName: TableNameOrModel,
-    _options?: RenameTableQueryOptions,
+    options?: RenameTableQueryOptions,
   ): string {
+    if (options) {
+      rejectInvalidOptions(
+        'renameTableQuery',
+        this.dialect.name,
+        RENAME_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+        RENAME_TABLE_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
     const beforeTable = this.extractTableDetails(beforeTableName);
     const afterTable = this.extractTableDetails(afterTableName);
 

--- a/packages/core/src/dialects/ibmi/query-generator-typescript.ts
+++ b/packages/core/src/dialects/ibmi/query-generator-typescript.ts
@@ -8,6 +8,7 @@ import type {
   AddLimitOffsetOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
+  RenameTableQueryOptions,
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 
@@ -59,6 +60,21 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
         : `AND TABLE_SCHEMA NOT LIKE 'Q%' AND TABLE_SCHEMA NOT LIKE 'SYS%'`,
       'ORDER BY TABLE_SCHEMA, TABLE_NAME',
     ]);
+  }
+
+  renameTableQuery(
+    beforeTableName: TableNameOrModel,
+    afterTableName: TableNameOrModel,
+    _options?: RenameTableQueryOptions,
+  ): string {
+    const beforeTable = this.extractTableDetails(beforeTableName);
+    const afterTable = this.extractTableDetails(afterTableName);
+
+    if (beforeTable.schema !== afterTable.schema) {
+      throw new Error(`Moving tables between schemas is not supported by ${this.dialect.name} dialect.`);
+    }
+
+    return `RENAME TABLE ${this.quoteTable(beforeTableName)} TO ${this.quoteIdentifier(afterTable.tableName)}`;
   }
 
   showConstraintsQuery(tableName: TableNameOrModel, options?: ShowConstraintsQueryOptions) {

--- a/packages/core/src/dialects/ibmi/query-generator.js
+++ b/packages/core/src/dialects/ibmi/query-generator.js
@@ -187,10 +187,6 @@ export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
     return `ALTER TABLE ${this.quoteTable(tableName)} ${finalQuery}`;
   }
 
-  renameTableQuery(before, after) {
-    return `RENAME TABLE ${this.quoteTable(before)} TO ${this.quoteTable(after)}`;
-  }
-
   renameColumnQuery(tableName, attrBefore, attributes) {
     const attrString = [];
 

--- a/packages/core/src/dialects/mssql/index.ts
+++ b/packages/core/src/dialects/mssql/index.ts
@@ -53,6 +53,9 @@ export class MssqlDialect extends AbstractDialect {
     removeColumn: {
       ifExists: true,
     },
+    renameTable: {
+      changeSchemaAndTable: false,
+    },
   });
 
   readonly connectionManager: MsSqlConnectionManager;

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -180,10 +180,6 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
     ]);
   }
 
-  renameTableQuery(before, after) {
-    return `EXEC sp_rename ${this.quoteTable(before)}, ${this.quoteTable(after)};`;
-  }
-
   addColumnQuery(table, key, dataType, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/postgres/index.ts
+++ b/packages/core/src/dialects/postgres/index.ts
@@ -82,6 +82,9 @@ export class PostgresDialect extends AbstractDialect {
       cascade: true,
       ifExists: true,
     },
+    renameTable: {
+      changeSchemaAndTable: false,
+    },
   });
 
   readonly connectionManager: PostgresConnectionManager;

--- a/packages/core/test/integration/query-interface.test.js
+++ b/packages/core/test/integration/query-interface.test.js
@@ -41,20 +41,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     });
   }
 
-  describe('renameTable', () => {
-    it('should rename table', async function () {
-      await this.queryInterface.createTable('my_test_table', {
-        name: DataTypes.STRING,
-      });
-      await this.queryInterface.renameTable('my_test_table', 'my_test_table_new');
-      const result = await this.queryInterface.listTables();
-      const tableNames = result.map(v => v.tableName);
-
-      expect(tableNames).to.contain('my_test_table_new');
-      expect(tableNames).to.not.contain('my_test_table');
-    });
-  });
-
   describe('dropAllTables', () => {
     it('should drop all tables', async function () {
       await this.queryInterface.dropAllTables();

--- a/packages/core/test/integration/query-interface/rename-table.test.ts
+++ b/packages/core/test/integration/query-interface/rename-table.test.ts
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import { DataTypes } from '@sequelize/core';
+import { sequelize } from '../support';
+
+const dialect = sequelize.dialect;
+const queryInterface = sequelize.queryInterface;
+
+describe('QueryInterface#renameTable', () => {
+  describe('without schema', () => {
+    beforeEach(async () => {
+      await queryInterface.createTable('my_test_table', {
+        name: DataTypes.STRING,
+      });
+    });
+
+    it('should rename table', async () => {
+      await queryInterface.renameTable('my_test_table', 'my_test_table_new');
+      const result = await queryInterface.listTables();
+      const tableNames = result.map(v => v.tableName);
+
+      expect(tableNames).to.contain('my_test_table_new');
+      expect(tableNames).to.not.contain('my_test_table');
+    });
+  });
+
+  if (sequelize.dialect.supports.schemas) {
+    describe('with schemas', () => {
+      const schema = 'my_schema';
+      beforeEach(async () => {
+        await queryInterface.createSchema(schema);
+        await queryInterface.createTable({ tableName: 'my_test_table', schema }, {
+          name: DataTypes.STRING,
+        });
+      });
+
+      it('should rename table with schema', async () => {
+        await queryInterface.renameTable({ tableName: 'my_test_table', schema }, { tableName: 'my_test_table_new', schema });
+        const result = await queryInterface.listTables({ schema: 'my_schema' });
+        const tableNames = result.map(v => v.tableName);
+
+        expect(tableNames).to.contain('my_test_table_new');
+        expect(tableNames).to.not.contain('my_test_table');
+      });
+
+      it('should throw error when moving table to another schema if changeSchema is not set', async () => {
+        const promise = queryInterface.renameTable(
+          { tableName: 'my_test_table', schema },
+          { tableName: 'my_test_table', schema: dialect.getDefaultSchema() },
+        );
+
+        if (['db2', 'ibmi'].includes(dialect.name)) {
+          await expect(promise).to.be.rejectedWith(`Moving tables between schemas is not supported by ${dialect.name} dialect.`);
+        } else {
+          await expect(promise).to.be.rejectedWith('To move a table between schemas, you must set `options.changeSchema` to true.');
+        }
+
+      });
+
+      it('should move table to another schema', async () => {
+        const promise = queryInterface.renameTable(
+          { tableName: 'my_test_table', schema },
+          { tableName: 'my_test_table', schema: dialect.getDefaultSchema() },
+          { changeSchema: true },
+        );
+
+        if (['db2', 'ibmi'].includes(dialect.name)) {
+          await expect(promise).to.be.rejectedWith(`Moving tables between schemas is not supported by ${dialect.name} dialect.`);
+        } else {
+          await promise;
+          const previousSchemaResult = await queryInterface.listTables({ schema });
+          const previousSchemaTableNames = previousSchemaResult.map(v => v.tableName);
+          expect(previousSchemaTableNames).to.not.contain('my_test_table');
+
+          const defaultSchemaResult = await queryInterface.listTables({ schema: dialect.getDefaultSchema() });
+          const defaultSchemaTableNames = defaultSchemaResult.map(v => v.tableName);
+          expect(defaultSchemaTableNames).to.contain('my_test_table');
+        }
+      });
+
+      it('should move table to another schema with new table name', async () => {
+        const promise = queryInterface.renameTable(
+          { tableName: 'my_test_table', schema },
+          { tableName: 'my_test_table_new', schema: dialect.getDefaultSchema() },
+          { changeSchema: true },
+        );
+
+        if (['db2', 'ibmi'].includes(dialect.name)) {
+          await expect(promise).to.be.rejectedWith(`Moving tables between schemas is not supported by ${dialect.name} dialect.`);
+        } else if (['mssql', 'postgres'].includes(dialect.name)) {
+          await expect(promise).to.be.rejectedWith(`Renaming a table and moving it to a different schema is not supported by ${dialect.name}.`);
+        } else {
+          await promise;
+          const previousSchemaResult = await queryInterface.listTables({ schema });
+          const previousSchemaTableNames = previousSchemaResult.map(v => v.tableName);
+          expect(previousSchemaTableNames).to.not.contain('my_test_table');
+
+          const defaultSchemaResult = await queryInterface.listTables({ schema: dialect.getDefaultSchema() });
+          const defaultSchemaTableNames = defaultSchemaResult.map(v => v.tableName);
+          expect(defaultSchemaTableNames).to.contain('my_test_table_new');
+        }
+      });
+    });
+  }
+});

--- a/packages/core/test/unit/query-generator/rename-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/rename-table-query.test.ts
@@ -1,3 +1,4 @@
+import { buildInvalidOptionReceivedError } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
 import { createSequelizeInstance, expectsql, sequelize } from '../../support';
 
 const dialect = sequelize.dialect;
@@ -30,16 +31,15 @@ describe('QueryGenerator#renameTableQuery', () => {
   it('throws an error if `options.changeSchema` is not set when moving table to another schema', () => {
     expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema' }, { tableName: 'newTable', schema: 'newSchema' }), {
       default: changeSchemaNotSetError,
-      mssql: changeSchemaNotSetError,
       'db2 ibmi': moveSchemaNotSupportedError,
     });
   });
 
-  it('produces a query that renames the table with schema', () => {
+  it('produces a query that moves a table to a different schema', () => {
     expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema' }, { tableName: 'newTable', schema: 'newSchema' }, { changeSchema: true }), {
       default: 'ALTER TABLE [oldSchema].[oldTable] RENAME TO [newSchema].[newTable]',
       sqlite: 'ALTER TABLE `oldSchema.oldTable` RENAME TO `newSchema.newTable`',
-      'db2 ibmi': moveSchemaNotSupportedError,
+      'db2 ibmi': buildInvalidOptionReceivedError('renameTableQuery', dialect.name, ['changeSchema']),
       'mssql postgres': moveSchemaWithRenameNotSupportedError,
     });
   });

--- a/packages/core/test/unit/query-generator/rename-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/rename-table-query.test.ts
@@ -36,6 +36,16 @@ describe('QueryGenerator#renameTableQuery', () => {
   });
 
   it('produces a query that moves a table to a different schema', () => {
+    expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema' }, { tableName: 'oldTable', schema: 'newSchema' }, { changeSchema: true }), {
+      default: 'ALTER TABLE [oldSchema].[oldTable] RENAME TO [newSchema].[oldTable]',
+      mssql: `ALTER SCHEMA [newSchema] TRANSFER [oldSchema].[oldTable]`,
+      sqlite: 'ALTER TABLE `oldSchema.oldTable` RENAME TO `newSchema.oldTable`',
+      postgres: `ALTER TABLE "oldSchema"."oldTable" SET SCHEMA "newSchema"`,
+      'db2 ibmi': buildInvalidOptionReceivedError('renameTableQuery', dialect.name, ['changeSchema']),
+    });
+  });
+
+  it('produces a query that moves a table to a different schema with a different name', () => {
     expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema' }, { tableName: 'newTable', schema: 'newSchema' }, { changeSchema: true }), {
       default: 'ALTER TABLE [oldSchema].[oldTable] RENAME TO [newSchema].[newTable]',
       sqlite: 'ALTER TABLE `oldSchema.oldTable` RENAME TO `newSchema.newTable`',

--- a/packages/core/test/unit/query-generator/rename-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/rename-table-query.test.ts
@@ -1,15 +1,18 @@
 import { createSequelizeInstance, expectsql, sequelize } from '../../support';
 
 const dialect = sequelize.dialect;
+const changeSchemaNotSetError = new Error('To move a table between schemas, you must set `options.changeSchema` to true.');
+const moveSchemaNotSupportedError = new Error(`Moving tables between schemas is not supported by ${dialect.name} dialect.`);
+const moveSchemaWithRenameNotSupportedError = new Error(`Renaming a table and moving it to a different schema is not supported by ${dialect.name}.`);
 
 describe('QueryGenerator#renameTableQuery', () => {
   const queryGenerator = sequelize.queryGenerator;
 
   it('produces a query that renames the table', () => {
     expectsql(() => queryGenerator.renameTableQuery('oldTable', 'newTable'), {
-      default: 'ALTER TABLE [oldTable] RENAME TO [newTable];',
-      mssql: 'EXEC sp_rename [oldTable], [newTable];',
-      'db2 ibmi': 'RENAME TABLE "oldTable" TO "newTable";',
+      default: 'ALTER TABLE [oldTable] RENAME TO [newTable]',
+      mssql: `EXEC sp_rename '[oldTable]', N'newTable'`,
+      'db2 ibmi': 'RENAME TABLE "oldTable" TO "newTable"',
     });
   });
 
@@ -18,26 +21,34 @@ describe('QueryGenerator#renameTableQuery', () => {
     const NewModel = sequelize.define('newModel', {});
 
     expectsql(() => queryGenerator.renameTableQuery(OldModel, NewModel), {
-      default: 'ALTER TABLE [oldModels] RENAME TO [newModels];',
-      mssql: 'EXEC sp_rename [oldModels], [newModels];',
-      'db2 ibmi': 'RENAME TABLE "oldModels" TO "newModels";',
+      default: 'ALTER TABLE [oldModels] RENAME TO [newModels]',
+      mssql: `EXEC sp_rename '[oldModels]', N'newModels'`,
+      'db2 ibmi': 'RENAME TABLE "oldModels" TO "newModels"',
+    });
+  });
+
+  it('throws an error if `options.changeSchema` is not set when moving table to another schema', () => {
+    expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema' }, { tableName: 'newTable', schema: 'newSchema' }), {
+      default: changeSchemaNotSetError,
+      mssql: changeSchemaNotSetError,
+      'db2 ibmi': moveSchemaNotSupportedError,
     });
   });
 
   it('produces a query that renames the table with schema', () => {
-    expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema' }, { tableName: 'newTable', schema: 'newSchema' }), {
-      default: 'ALTER TABLE [oldSchema].[oldTable] RENAME TO [newSchema].[newTable];',
-      mssql: 'EXEC sp_rename [oldSchema].[oldTable], [newSchema].[newTable];',
-      sqlite: 'ALTER TABLE `oldSchema.oldTable` RENAME TO `newSchema.newTable`;',
-      'db2 ibmi': 'RENAME TABLE "oldSchema"."oldTable" TO "newSchema"."newTable";',
+    expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema' }, { tableName: 'newTable', schema: 'newSchema' }, { changeSchema: true }), {
+      default: 'ALTER TABLE [oldSchema].[oldTable] RENAME TO [newSchema].[newTable]',
+      sqlite: 'ALTER TABLE `oldSchema.oldTable` RENAME TO `newSchema.newTable`',
+      'db2 ibmi': moveSchemaNotSupportedError,
+      'mssql postgres': moveSchemaWithRenameNotSupportedError,
     });
   });
 
   it('produces a query that renames the table with default schema', () => {
     expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: dialect.getDefaultSchema() }, { tableName: 'newTable', schema: dialect.getDefaultSchema() }), {
-      default: 'ALTER TABLE [oldTable] RENAME TO [newTable];',
-      mssql: 'EXEC sp_rename [oldTable], [newTable];',
-      'db2 ibmi': 'RENAME TABLE "oldTable" TO "newTable";',
+      default: 'ALTER TABLE [oldTable] RENAME TO [newTable]',
+      mssql: `EXEC sp_rename '[oldTable]', N'newTable'`,
+      'db2 ibmi': 'RENAME TABLE "oldTable" TO "newTable"',
     });
   });
 
@@ -46,10 +57,11 @@ describe('QueryGenerator#renameTableQuery', () => {
     const queryGeneratorSchema = sequelizeSchema.queryGenerator;
 
     expectsql(() => queryGeneratorSchema.renameTableQuery('oldTable', 'newTable'), {
-      default: 'ALTER TABLE [mySchema].[oldTable] RENAME TO [mySchema].[newTable];',
-      mssql: 'EXEC sp_rename [mySchema].[oldTable], [mySchema].[newTable];',
-      sqlite: 'ALTER TABLE `mySchema.oldTable` RENAME TO `mySchema.newTable`;',
-      'db2 ibmi': 'RENAME TABLE "mySchema"."oldTable" TO "mySchema"."newTable";',
+      default: 'ALTER TABLE [mySchema].[oldTable] RENAME TO [mySchema].[newTable]',
+      mssql: `EXEC sp_rename '[mySchema].[oldTable]', N'newTable'`,
+      sqlite: 'ALTER TABLE `mySchema.oldTable` RENAME TO `mySchema.newTable`',
+      postgres: `ALTER TABLE "mySchema"."oldTable" RENAME TO "newTable"`,
+      'db2 ibmi': 'RENAME TABLE "mySchema"."oldTable" TO "newTable"',
     });
   });
 
@@ -59,8 +71,8 @@ describe('QueryGenerator#renameTableQuery', () => {
       return;
     }
 
-    expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema', delimiter: 'custom' }, { tableName: 'newTable', schema: 'newSchema', delimiter: 'custom' }), {
-      sqlite: 'ALTER TABLE `oldSchemacustomoldTable` RENAME TO `newSchemacustomnewTable`;',
+    expectsql(() => queryGenerator.renameTableQuery({ tableName: 'oldTable', schema: 'oldSchema', delimiter: 'custom' }, { tableName: 'newTable', schema: 'newSchema', delimiter: 'custom' }, { changeSchema: true }), {
+      sqlite: 'ALTER TABLE `oldSchemacustomoldTable` RENAME TO `newSchemacustomnewTable`',
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR migrates `renameTable` and `renameTableQuery` methods to typescript.
I have included a `changeSchema` option which has to be set in order to move a table from one schema to another if this is supported by the dialect. 
