### PR TITLE
docs: update typescript link to an existing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Please find upgrade information to major versions here:
 ### :wrench: Tools
 
 - [CLI](https://github.com/sequelize/cli)
-- [With TypeScript](https://sequelize.org/docs/v6/other-topics/typescript)
 - [Enhanced TypeScript with decorators](https://github.com/RobinBuschmann/sequelize-typescript)
 - [For GraphQL](https://github.com/mickhansen/graphql-sequelize)
 - [For CockroachDB](https://github.com/cockroachdb/sequelize-cockroachdb)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please find upgrade information to major versions here:
 ### :wrench: Tools
 
 - [CLI](https://github.com/sequelize/cli)
-- [With TypeScript](https://sequelize.org/docs/v7/other-topics/typescript)
+- [With TypeScript](https://sequelize.org/docs/v6/other-topics/typescript)
 - [Enhanced TypeScript with decorators](https://github.com/RobinBuschmann/sequelize-typescript)
 - [For GraphQL](https://github.com/mickhansen/graphql-sequelize)
 - [For CockroachDB](https://github.com/cockroachdb/sequelize-cockroachdb)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Please find upgrade information to major versions here:
 ### :wrench: Tools
 
 - [CLI](https://github.com/sequelize/cli)
-- [Enhanced TypeScript with decorators](https://github.com/RobinBuschmann/sequelize-typescript)
 - [For GraphQL](https://github.com/mickhansen/graphql-sequelize)
 - [For CockroachDB](https://github.com/cockroachdb/sequelize-cockroachdb)
 - [Awesome Sequelize](https://sequelize.org/docs/v7/other-topics/resources/)


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Fixed wrong Typescript documentation link for the Read.me file. Solves #16586 
