### PR TITLE
fix(db2): change SSL related keyword and value in connection-manager.ts

### DIFF
--- a/packages/core/src/dialects/db2/connection-manager.ts
+++ b/packages/core/src/dialects/db2/connection-manager.ts
@@ -54,7 +54,7 @@ export class Db2ConnectionManager extends AbstractConnectionManager<Db2Connectio
       UID: config.username,
       // @ts-expect-error -- Bad typings
       PWD: config.password,
-      ...(config.ssl ? { SECURITY: config.ssl } : undefined),
+      ...(config.ssl ? { Security: 'SSL' } : undefined),
       // TODO: pass this property through dialectOptions
       // @ts-expect-error -- DB2 specific option that should not be at the top level
       ...(config.sslcertificate ? { SSLServerCertificate: config.ssl } : undefined),


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Fixes issue #16583
See ['ibm_db' API Documentation](https://github.com/ibmdb/node-ibm_db/blob/master/APIDocumentation.md), search for `Secure Database Connection using SSL/TSL`:

```bash
connStr = "DATABASE=database;HOSTNAME=hostname;PORT=port;Security=SSL;SSLServerCertificate=<cert.arm_file_path>;PROTOCOL=TCPIP;UID=username;PWD=passwd;";
```

The SSL related keyword should be `Security` (not `SECURITY`) with a value of `SSL` (string, not boolean).

## Todos

- [ ] Clarify if I should do any more of the "Pull Request Checklist" TODOs for this change.
