### PR TITLE
docs: provide custom operators documentation link

### DIFF
--- a/packages/core/src/expression-builders/where.ts
+++ b/packages/core/src/expression-builders/where.ts
@@ -60,9 +60,8 @@ export class Where<Operator extends keyof WhereOperators = typeof Op.eq> extends
       this.where = PojoWhere.create(args[0], args[1]);
     } else {
       if (typeof args[1] === 'string') {
-        // TODO: link to actual page
         throw new TypeError(`where(left, operator, right) does not accept a string as the operator. Use one of the operators available in the Op object.
-If you wish to use custom operators not provided by Sequelize, you can use the "sql" template literal tag. Refer to the documentation on custom operators on https://sequelize.org/ for more details.`);
+If you wish to use custom operators not provided by Sequelize, you can use the "sql" template literal tag. Refer to the documentation on custom operators on https://sequelize.org/docs/v7/querying/operators/#custom-operators for more details.`);
       }
 
       // normalize where(col, op, val)


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Updated TypeError error message in regards to the documentation link for Custom Operators. 

Before this change the error message was providing the home page of the Sequelize documentation https://sequelize.org/ instead of the actual Custom Operators documentation link https://sequelize.org/docs/v7/querying/operators/#custom-operators.

Solves #16595.