### PR TITLE
fix(oracle): add missing default and not null condition to addColumn

### DIFF
--- a/src/dialects/oracle/query-generator.js
+++ b/src/dialects/oracle/query-generator.js
@@ -854,11 +854,20 @@ export class OracleQueryGenerator extends AbstractQueryGenerator {
 
     let template;
 
+    template = attribute.type.toSql ? attribute.type.toSql() : '';
+    if (attribute.type instanceof DataTypes.JSON) {
+      template += ` CHECK (${this.quoteIdentifier(options.attributeName)} IS JSON)`;
+      return template;
+    }
+    if (Utils.defaultValueSchemable(attribute.defaultValue)) {
+      template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+    }
+    if (attribute.allowNull === false) {
+      template += ' NOT NULL';
+    }
     if (attribute.type instanceof DataTypes.ENUM) {
       if (attribute.type.values && !attribute.values) attribute.values = attribute.type.values;
-
       // enums are a special case
-      template = attribute.type.toSql();
       template +=
         ` CHECK (${this.quoteIdentifier(options.attributeName)} IN(${ 
           _.map(attribute.values, value => {
@@ -867,13 +876,7 @@ export class OracleQueryGenerator extends AbstractQueryGenerator {
         }))`;
       return template;
     } 
-    if (attribute.type instanceof DataTypes.JSON) {
-      template = attribute.type.toSql();
-      template += ` CHECK (${this.quoteIdentifier(options.attributeName)} IS JSON)`;
-      return template;
-    } 
     if (attribute.type instanceof DataTypes.BOOLEAN) {
-      template = attribute.type.toSql();
       template +=
         ` CHECK (${this.quoteIdentifier(options.attributeName)} IN('1', '0'))`;
       return template;

--- a/test/unit/sql/add-column.test.js
+++ b/test/unit/sql/add-column.test.js
@@ -69,6 +69,26 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     }
 
+    it('DEFAULT VALUE FOR BOOLEAN', () => {
+      return expectsql(sql.addColumnQuery(User.getTableName(), 'bool_col', current.normalizeAttribute({
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true
+      })), {
+        oracle: 'ALTER TABLE "Users" ADD "bool_col" CHAR(1) DEFAULT 1 NOT NULL CHECK ("bool_col" IN(\'1\', \'0\'))'
+      });
+    });
+
+    it('DEFAULT VALUE FOR ENUM', () => {
+      return expectsql(sql.addColumnQuery(User.getTableName(), 'enum_col', current.normalizeAttribute({
+        type: DataTypes.ENUM('happy', 'sad'),
+        allowNull: false,
+        defaultValue: 'happy'
+      })), {
+        oracle: 'ALTER TABLE "Users" ADD "enum_col" VARCHAR2(512) DEFAULT \'happy\' NOT NULL CHECK ("enum_col" IN(\'happy\', \'sad\'))'
+      });
+    });
+
     it('defaults the schema to the one set in the Sequelize options', () => {
       return expectsql(customSql.addColumnQuery(User.getTableName(), 'level_id', customSequelize.normalizeAttribute({
         type: DataTypes.FLOAT,

--- a/test/unit/sql/add-column.test.js
+++ b/test/unit/sql/add-column.test.js
@@ -69,27 +69,39 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     }
 
-    if (['oracle'].includes(current.dialect.name)) {
-      it('DEFAULT VALUE FOR BOOLEAN', () => {
-        return expectsql(sql.addColumnQuery(User.getTableName(), 'bool_col', current.normalizeAttribute({
-          type: DataTypes.BOOLEAN,
-          allowNull: false,
-          defaultValue: true
-        })), {
-          oracle: 'ALTER TABLE "Users" ADD "bool_col" CHAR(1) DEFAULT 1 NOT NULL CHECK ("bool_col" IN(\'1\', \'0\'))'
-        });
+    it('DEFAULT VALUE FOR BOOLEAN', () => {
+      return expectsql(sql.addColumnQuery(User.getTableName(), 'bool_col', current.normalizeAttribute({
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true
+      })), {
+        oracle: 'ALTER TABLE "Users" ADD "bool_col" CHAR(1) DEFAULT 1 NOT NULL CHECK ("bool_col" IN(\'1\', \'0\'))',
+        mysql: 'ALTER TABLE `Users` ADD `bool_col` TINYINT(1) NOT NULL DEFAULT true;',
+        mariadb: 'ALTER TABLE `Users` ADD `bool_col` TINYINT(1) NOT NULL DEFAULT true;',
+        mssql: 'ALTER TABLE [Users] ADD [bool_col] BIT NOT NULL DEFAULT 1;',
+        postgres: 'ALTER TABLE "public"."Users" ADD COLUMN "bool_col" BOOLEAN NOT NULL DEFAULT true;',
+        db2: 'ALTER TABLE "Users" ADD "bool_col" BOOLEAN NOT NULL DEFAULT true;',
+        snowflake: 'ALTER TABLE "Users" ADD "bool_col" BOOLEAN NOT NULL DEFAULT true;',
+        sqlite: 'ALTER TABLE `Users` ADD `bool_col` TINYINT(1) NOT NULL DEFAULT 1;'
       });
+    });
 
-      it('DEFAULT VALUE FOR ENUM', () => {
-        return expectsql(sql.addColumnQuery(User.getTableName(), 'enum_col', current.normalizeAttribute({
-          type: DataTypes.ENUM('happy', 'sad'),
-          allowNull: false,
-          defaultValue: 'happy'
-        })), {
-          oracle: 'ALTER TABLE "Users" ADD "enum_col" VARCHAR2(512) DEFAULT \'happy\' NOT NULL CHECK ("enum_col" IN(\'happy\', \'sad\'))'
-        });
+    it('DEFAULT VALUE FOR ENUM', () => {
+      return expectsql(sql.addColumnQuery(User.getTableName(), 'enum_col', current.normalizeAttribute({
+        type: DataTypes.ENUM('happy', 'sad'),
+        allowNull: false,
+        defaultValue: 'happy'
+      })), {
+        oracle: 'ALTER TABLE "Users" ADD "enum_col" VARCHAR2(512) DEFAULT \'happy\' NOT NULL CHECK ("enum_col" IN(\'happy\', \'sad\'))',
+        mysql: 'ALTER TABLE `Users` ADD `enum_col` ENUM(\'happy\', \'sad\') NOT NULL DEFAULT \'happy\';',
+        mariadb: 'ALTER TABLE `Users` ADD `enum_col` ENUM(\'happy\', \'sad\') NOT NULL DEFAULT \'happy\';',
+        mssql: 'ALTER TABLE [Users] ADD [enum_col] VARCHAR(255) CHECK ([enum_col] IN(N\'happy\', N\'sad\'));',
+        postgres: 'DO \'BEGIN CREATE TYPE "public"."enum_Users_enum_col" AS ENUM(\'\'happy\'\', \'\'sad\'\'); EXCEPTION WHEN duplicate_object THEN null; END\';ALTER TABLE "public"."Users" ADD COLUMN "enum_col" "public"."enum_Users_enum_col" NOT NULL DEFAULT \'happy\';',
+        db2: 'ALTER TABLE "Users" ADD "enum_col" VARCHAR(255) CHECK ("enum_col" IN(\'happy\', \'sad\')) NOT NULL DEFAULT \'happy\';',
+        snowflake: 'ALTER TABLE "Users" ADD "enum_col" ENUM NOT NULL DEFAULT \'happy\';',
+        sqlite: 'ALTER TABLE `Users` ADD `enum_col` TEXT NOT NULL DEFAULT \'happy\';'
       });
-    }
+    });
 
     it('defaults the schema to the one set in the Sequelize options', () => {
       return expectsql(customSql.addColumnQuery(User.getTableName(), 'level_id', customSequelize.normalizeAttribute({

--- a/test/unit/sql/add-column.test.js
+++ b/test/unit/sql/add-column.test.js
@@ -69,25 +69,27 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     }
 
-    it('DEFAULT VALUE FOR BOOLEAN', () => {
-      return expectsql(sql.addColumnQuery(User.getTableName(), 'bool_col', current.normalizeAttribute({
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-        defaultValue: true
-      })), {
-        oracle: 'ALTER TABLE "Users" ADD "bool_col" CHAR(1) DEFAULT 1 NOT NULL CHECK ("bool_col" IN(\'1\', \'0\'))'
+    if (['oracle'].includes(current.dialect.name)) {
+      it('DEFAULT VALUE FOR BOOLEAN', () => {
+        return expectsql(sql.addColumnQuery(User.getTableName(), 'bool_col', current.normalizeAttribute({
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: true
+        })), {
+          oracle: 'ALTER TABLE "Users" ADD "bool_col" CHAR(1) DEFAULT 1 NOT NULL CHECK ("bool_col" IN(\'1\', \'0\'))'
+        });
       });
-    });
 
-    it('DEFAULT VALUE FOR ENUM', () => {
-      return expectsql(sql.addColumnQuery(User.getTableName(), 'enum_col', current.normalizeAttribute({
-        type: DataTypes.ENUM('happy', 'sad'),
-        allowNull: false,
-        defaultValue: 'happy'
-      })), {
-        oracle: 'ALTER TABLE "Users" ADD "enum_col" VARCHAR2(512) DEFAULT \'happy\' NOT NULL CHECK ("enum_col" IN(\'happy\', \'sad\'))'
+      it('DEFAULT VALUE FOR ENUM', () => {
+        return expectsql(sql.addColumnQuery(User.getTableName(), 'enum_col', current.normalizeAttribute({
+          type: DataTypes.ENUM('happy', 'sad'),
+          allowNull: false,
+          defaultValue: 'happy'
+        })), {
+          oracle: 'ALTER TABLE "Users" ADD "enum_col" VARCHAR2(512) DEFAULT \'happy\' NOT NULL CHECK ("enum_col" IN(\'happy\', \'sad\'))'
+        });
       });
-    });
+    }
 
     it('defaults the schema to the one set in the Sequelize options', () => {
       return expectsql(customSql.addColumnQuery(User.getTableName(), 'level_id', customSequelize.normalizeAttribute({


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
<!-- Please provide a description of the change here. -->
This PR is to allow default values and not null condition for `BOOLEAN` and `ENUM`.
While adding columns, the options `defaultValue` and `allowNull` have no impact.

Example:
```
queryInterface.addColumn('menu_uploads', 'displayable', {
      type: Sequelize.DataTypes.BOOLEAN(),
      defaultValue: true,
      allowNull: false
});
```
SQL expected: `ALTER TABLE "menu_uploads" ADD "displayable" CHAR(1) DEFAULT 1 NOT NULL CHECK ("displayable" IN('1',  '0'))`