### PR TITLE
feat(oracle): add support for lock

### DIFF
--- a/src/dialects/oracle/index.js
+++ b/src/dialects/oracle/index.js
@@ -28,8 +28,10 @@ OracleDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   'VALUES ()': true,
   'LIMIT ON UPDATE': true,
   IGNORE: ' IGNORE',
-  lock: false,
-  forShare: ' IN SHARE MODE',
+  lock: true,
+  lockOuterJoinFailure: true,
+  forShare: 'FOR UPDATE',
+  skipLocked: true,
   index: {
     collate: false,
     length: false,


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
The issue is raised [here](https://github.com/sequelize/sequelize/issues/16606)
- Enabled skipLocked, forShare, lockOuterJoinFailure, lock properties for Oracle dialect. 
-  Oracle does not have shared locks on individual table rows, `FOR UPDATE` is what i found closest to 
 ` forShare` dialect support .
- `FOR UPDATE` cant be used in sql's along with these :
  -  ORDER BY 
  -  FETCH NEXT 1 ROWS ( creates a inline view, ...)

It results in error
`ORA-02014: cannot select FOR UPDATE from view with DISTINCT, GROUP BY, etc. `

We can instead generate a subquery like this to avoid error , but it's not equivalent and is not correct all the time and might cause issues. 
`SELECT "id", "username", "awesome", "createdAt", "updatedAt" FROM "users"  "user" WHERE  rowid in (select rowid from "users" "user" where "user"."username" = 'jan'  ORDER BY "user"."id" OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) FOR UPDATE;`

instead of

`SELECT "id", "username", "awesome", "createdAt", "updatedAt" FROM "users"  "user" WHERE "user"."username" = 'jan'  ORDER BY "user"."id" OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY FOR UPDATE;`


Modified tests to use different model API's just to simulate the locking functionality .
-- `findOrCreate` is replaced with `findAll` and `create` 
-- `findByPK` instead of `findByOne`
## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
