### PR TITLE
fix: correct link to data types docs

### DIFF
--- a/packages/core/src/dialects/abstract/data-types-utils.ts
+++ b/packages/core/src/dialects/abstract/data-types-utils.ts
@@ -99,5 +99,5 @@ export function getDataTypeParser(dialect: AbstractDialect, dataType: DataTypeCl
 
 export function throwUnsupportedDataType(dialect: AbstractDialect, typeName: string): never {
   throw new Error(`${dialect.name} does not support the ${typeName} data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 }

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -1678,7 +1678,7 @@ export interface AttributeOptions<M extends Model = Model> {
   /**
    * A string or a data type.
    *
-   * @see https://sequelize.org/docs/v7/other-topics/other-data-types/
+   * @see https://sequelize.org/docs/v7/models/data-types/
    */
   type: DataType;
 

--- a/packages/core/test/unit/data-types/arrays.test.ts
+++ b/packages/core/test/unit/data-types/arrays.test.ts
@@ -6,7 +6,7 @@ import { testDataTypeSql } from './_utils';
 const { dialect, queryGenerator } = sequelize;
 
 describe('DataTypes.ARRAY', () => {
-  const unsupportedError = new Error(`${dialect.name} does not support the ARRAY data type.\nSee https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+  const unsupportedError = new Error(`${dialect.name} does not support the ARRAY data type.\nSee https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
   testDataTypeSql('ARRAY(VARCHAR)', DataTypes.ARRAY(DataTypes.STRING), {
     default: unsupportedError,

--- a/packages/core/test/unit/data-types/decimal-numbers.test.ts
+++ b/packages/core/test/unit/data-types/decimal-numbers.test.ts
@@ -9,7 +9,7 @@ const dialectName = dialect.name;
 
 describe('DataTypes.REAL', () => {
   const zeroFillUnsupportedError = new Error(`${dialectName} does not support the REAL.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
   testDataTypeSql('REAL', DataTypes.REAL, {
     default: 'REAL',
@@ -53,7 +53,7 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 
 describe('DataTypes.DOUBLE', () => {
   const zeroFillUnsupportedError = new Error(`${dialectName} does not support the DOUBLE.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
   testDataTypeSql('DOUBLE', DataTypes.DOUBLE, {
     default: 'DOUBLE PRECISION',
@@ -110,7 +110,7 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 
 describe('DataTypes.FLOAT', () => {
   const zeroFillUnsupportedError = new Error(`${dialectName} does not support the FLOAT.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
   // Must be a single-precision floating point if available,
   // or a double-precision fallback if not.
@@ -189,9 +189,9 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 
 describe('DECIMAL', () => {
   const zeroFillUnsupportedError = new Error(`${dialectName} does not support the DECIMAL.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
   const unsupportedError = new Error(`${dialectName} does not support the DECIMAL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
   testDataTypeSql('DECIMAL', DataTypes.DECIMAL, {
     default: new Error(`${dialectName} does not support unconstrained DECIMAL types. Please specify the "precision" and "scale" options.`),

--- a/packages/core/test/unit/data-types/geography.test.ts
+++ b/packages/core/test/unit/data-types/geography.test.ts
@@ -7,7 +7,7 @@ const dialectName = sequelize.dialect.name;
 // TODO: extend suite to cover all data sub-types, like in geometry.test.ts
 describe('GEOGRAPHY', () => {
   testDataTypeSql('GEOGRAPHY', DataTypes.GEOGRAPHY, {
-    default: new Error(`${dialectName} does not support the GEOGRAPHY data type.\nSee https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`),
+    default: new Error(`${dialectName} does not support the GEOGRAPHY data type.\nSee https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`),
     postgres: 'GEOGRAPHY',
   });
 });

--- a/packages/core/test/unit/data-types/geometry.test.ts
+++ b/packages/core/test/unit/data-types/geometry.test.ts
@@ -5,7 +5,7 @@ import { testDataTypeSql } from './_utils';
 const dialect = sequelize.dialect;
 
 describe('GEOMETRY', () => {
-  const unsupportedError = new Error(`${dialect.name} does not support the GEOMETRY data type.\nSee https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+  const unsupportedError = new Error(`${dialect.name} does not support the GEOMETRY data type.\nSee https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
   testDataTypeSql('GEOMETRY', DataTypes.GEOMETRY, {
     default: unsupportedError,
     'postgres mysql mariadb': 'GEOMETRY',

--- a/packages/core/test/unit/data-types/integers.test.ts
+++ b/packages/core/test/unit/data-types/integers.test.ts
@@ -9,7 +9,7 @@ const dialectName = dialect.name;
 describe('DataTypes.TINYINT', () => {
   describe('toSql', () => {
     const zeroFillUnsupportedError = new Error(`${dialectName} does not support the TINYINT.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
     const cases = [
       {
@@ -144,7 +144,7 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 describe('DataTypes.SMALLINT', () => {
   describe('toSql', () => {
     const zeroFillUnsupportedError = new Error(`${dialectName} does not support the SMALLINT.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
     const cases = [
       {
@@ -274,7 +274,7 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 describe('DataTypes.MEDIUMINT', () => {
   describe('toSql', () => {
     const zeroFillUnsupportedError = new Error(`${dialectName} does not support the MEDIUMINT.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
     const cases = [
       {
@@ -398,7 +398,7 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 describe('DataTypes.INTEGER', () => {
   describe('toSql', () => {
     const zeroFillUnsupportedError = new Error(`${dialectName} does not support the INTEGER.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
     testDataTypeSql('INTEGER', DataTypes.INTEGER, {
       default: 'INTEGER',
@@ -478,9 +478,9 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 describe('DataTypes.BIGINT', () => {
   describe('toSql', () => {
     const zeroFillUnsupportedError = new Error(`${dialectName} does not support the BIGINT.ZEROFILL data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
     const unsignedUnsupportedError = new Error(`${dialectName} does not support the BIGINT.UNSIGNED data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
     testDataTypeSql('BIGINT', DataTypes.BIGINT, {
       default: 'BIGINT',

--- a/packages/core/test/unit/data-types/misc-data-types.test.ts
+++ b/packages/core/test/unit/data-types/misc-data-types.test.ts
@@ -167,7 +167,7 @@ describe('DataTypes.RANGE', () => {
 
 describe('DataTypes.JSON', () => {
   testDataTypeSql('JSON', DataTypes.JSON, {
-    default: new Error(`${dialectName} does not support the JSON data type.\nSee https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`),
+    default: new Error(`${dialectName} does not support the JSON data type.\nSee https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`),
 
     // All dialects must support DataTypes.JSON. If your dialect does not have a native JSON type, use an as-big-as-possible text type instead.
     'mariadb mysql postgres': 'JSON',
@@ -235,7 +235,7 @@ describe('DataTypes.JSON', () => {
 
 describe('DataTypes.JSONB', () => {
   testDataTypeSql('JSONB', DataTypes.JSONB, {
-    default: new Error(`${dialectName} does not support the JSONB data type.\nSee https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`),
+    default: new Error(`${dialectName} does not support the JSONB data type.\nSee https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`),
     postgres: 'JSONB',
   });
 });
@@ -243,7 +243,7 @@ describe('DataTypes.JSONB', () => {
 describe('DataTypes.HSTORE', () => {
   describe('toSql', () => {
     testDataTypeSql('HSTORE', DataTypes.HSTORE, {
-      default: new Error(`${dialectName} does not support the HSTORE data type.\nSee https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`),
+      default: new Error(`${dialectName} does not support the HSTORE data type.\nSee https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`),
       postgres: 'HSTORE',
     });
   });

--- a/packages/core/test/unit/data-types/string-types.test.ts
+++ b/packages/core/test/unit/data-types/string-types.test.ts
@@ -10,7 +10,7 @@ const dialectName = dialect.name;
 describe('DataTypes.STRING', () => {
   describe('toSql', () => {
     const binaryCollationUnsupportedError = new Error(`${dialectName} does not support the STRING.BINARY data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
     testDataTypeSql('STRING', DataTypes.STRING, {
       default: 'VARCHAR(255)',
@@ -113,7 +113,7 @@ describe('DataTypes.CITEXT', () => {
   describe('toSql', () => {
     testDataTypeSql('CITEXT', DataTypes.CITEXT, {
       default: new Error(`${dialectName} does not support the case-insensitive text (CITEXT) data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`),
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`),
       postgres: 'CITEXT',
       sqlite: 'TEXT COLLATE NOCASE',
     });
@@ -139,9 +139,9 @@ See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of s
 describe('DataTypes.CHAR', () => {
   describe('toSql', () => {
     const binaryNotSupportedError = new Error(`${dialectName} does not support the CHAR.BINARY data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
     const charNotSupportedError = new Error(`${dialectName} does not support the CHAR data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`);
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`);
 
     testDataTypeSql('CHAR', DataTypes.CHAR, {
       default: 'CHAR(255)',
@@ -178,7 +178,7 @@ describe('DataTypes.TSVECTOR', () => {
   describe('toSql', () => {
     testDataTypeSql('TSVECTOR', DataTypes.TSVECTOR, {
       default: new Error(`${dialectName} does not support the TSVECTOR data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`),
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`),
       postgres: 'TSVECTOR',
     });
   });

--- a/packages/core/test/unit/data-types/temporal-types.test.ts
+++ b/packages/core/test/unit/data-types/temporal-types.test.ts
@@ -135,7 +135,7 @@ describe('DataTypes.TIME', () => {
     testDataTypeSql('TIME(6)', DataTypes.TIME(6), {
       default: 'TIME(6)',
       db2: new Error(`db2 does not support the TIME(precision) data type.
-See https://sequelize.org/docs/v7/other-topics/other-data-types/ for a list of supported data types.`),
+See https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`),
       sqlite: 'TEXT',
     });
   });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Resolves the additional remark in https://github.com/sequelize/sequelize/issues/11039#issuecomment-1770198478
