### PR TITLE
fix(oracle): clean constraints

### DIFF
--- a/src/dialects/oracle/query-generator.js
+++ b/src/dialects/oracle/query-generator.js
@@ -393,10 +393,16 @@ export class OracleQueryGenerator extends AbstractQueryGenerator {
   addConstraintQuery(tableName, options) {
     options = options || {};
 
+    // 'ON UPDATE XXX' clause is not supported by Oracle
+    options.onUpdate = null;
+
     const constraintSnippet = this.getConstraintSnippet(tableName, options);
 
+    // 'ON DELETE NO ACTION' is the default option in Oracle, but it is not supported if defined
+    const cleanedConstraintSnippet = constraintSnippet.replace('ON DELETE NO ACTION', '');
+
     tableName = this.quoteTable(tableName);
-    return `ALTER TABLE ${tableName} ADD ${constraintSnippet};`;
+    return `ALTER TABLE ${tableName} ADD ${cleanedConstraintSnippet};`;
   }
 
   addColumnQuery(table, key, dataType) {

--- a/src/dialects/oracle/query-generator.js
+++ b/src/dialects/oracle/query-generator.js
@@ -393,8 +393,10 @@ export class OracleQueryGenerator extends AbstractQueryGenerator {
   addConstraintQuery(tableName, options) {
     options = options || {};
 
-    // 'ON UPDATE XXX' clause is not supported by Oracle
-    options.onUpdate = null;
+    if (options.onUpdate) {
+      // Oracle does not support ON UPDATE, remove it.
+      delete options.onUpdate;
+    }
 
     const constraintSnippet = this.getConstraintSnippet(tableName, options);
 

--- a/src/dialects/oracle/query-generator.js
+++ b/src/dialects/oracle/query-generator.js
@@ -398,13 +398,15 @@ export class OracleQueryGenerator extends AbstractQueryGenerator {
       delete options.onUpdate;
     }
 
+    if (options.onDelete && options.onDelete.toUpperCase() === 'NO ACTION') {
+      // 'ON DELETE NO ACTION' is the default option in Oracle, but it is not supported if defined
+      delete options.onDelete;
+    }
+
     const constraintSnippet = this.getConstraintSnippet(tableName, options);
 
-    // 'ON DELETE NO ACTION' is the default option in Oracle, but it is not supported if defined
-    const cleanedConstraintSnippet = constraintSnippet.replace(' ON DELETE NO ACTION', '');
-
     tableName = this.quoteTable(tableName);
-    return `ALTER TABLE ${tableName} ADD ${cleanedConstraintSnippet};`;
+    return `ALTER TABLE ${tableName} ADD ${constraintSnippet};`;
   }
 
   addColumnQuery(table, key, dataType) {

--- a/src/dialects/oracle/query-generator.js
+++ b/src/dialects/oracle/query-generator.js
@@ -401,7 +401,7 @@ export class OracleQueryGenerator extends AbstractQueryGenerator {
     const constraintSnippet = this.getConstraintSnippet(tableName, options);
 
     // 'ON DELETE NO ACTION' is the default option in Oracle, but it is not supported if defined
-    const cleanedConstraintSnippet = constraintSnippet.replace('ON DELETE NO ACTION', '');
+    const cleanedConstraintSnippet = constraintSnippet.replace(' ON DELETE NO ACTION', '');
 
     tableName = this.quoteTable(tableName);
     return `ALTER TABLE ${tableName} ADD ${cleanedConstraintSnippet};`;

--- a/test/unit/sql/add-constraint.test.js
+++ b/test/unit/sql/add-constraint.test.js
@@ -156,8 +156,7 @@ if (current.dialect.supports.constraints.addConstraint) {
           });
         });
 
-        // The Oracle dialect doesn't support onUpdate cascade
-        (current.dialect.name !== 'oracle' ? it : it.skip)('supports composite keys', () => {
+        it('supports composite keys', () => {
           expectsql(
             sql.addConstraintQuery('myTable', {
               type: 'foreign key',
@@ -171,13 +170,14 @@ if (current.dialect.supports.constraints.addConstraint) {
             }),
             {
               db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_anotherColumn_myOtherTable_fk" FOREIGN KEY ("myColumn", "anotherColumn") REFERENCES "myOtherTable" ("id1", "id2") ON DELETE CASCADE;',
+              oracle: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_anotherColumn_myOtherTable_fk" FOREIGN KEY ("myColumn", "anotherColumn") REFERENCES "myOtherTable" ("id1", "id2") ON DELETE CASCADE;',
               default:
                 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_anotherColumn_myOtherTable_fk] FOREIGN KEY ([myColumn], [anotherColumn]) REFERENCES [myOtherTable] ([id1], [id2]) ON UPDATE CASCADE ON DELETE CASCADE;'
             }
           );
         });
-        // The Oracle dialect doesn't support onUpdate cascade
-        (current.dialect.name !== 'oracle' ? it : it.skip)('uses onDelete, onUpdate', () => {
+
+        it('uses onDelete, onUpdate', () => {
           expectsql(sql.addConstraintQuery('myTable', {
             type: 'foreign key',
             fields: ['myColumn'],
@@ -189,6 +189,7 @@ if (current.dialect.supports.constraints.addConstraint) {
             onDelete: 'cascade'
           }), {
             db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON DELETE CASCADE;',
+            oracle: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON DELETE CASCADE;',
             default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_myOtherTable_fk] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;'
           });
         });

--- a/test/unit/sql/add-constraint.test.js
+++ b/test/unit/sql/add-constraint.test.js
@@ -194,14 +194,28 @@ if (current.dialect.supports.constraints.addConstraint) {
           });
         });
 
+        it('uses onDelete: \'no action\'', () => {
+          expectsql(sql.addConstraintQuery('myTable', {
+            type: 'foreign key',
+            fields: ['myColumn'],
+            references: {
+              table: 'myOtherTable',
+              field: 'id'
+            },
+            onUpdate: 'cascade',
+            onDelete: 'no action'
+          }), {
+            oracle: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id");',
+            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_myOtherTable_fk] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]) ON UPDATE CASCADE ON DELETE NO ACTION;'
+          });
+        });
+
         it('errors if references object is not passed', () => {
           expect(sql.addConstraintQuery.bind(sql, 'myTable', {
             type: 'foreign key',
             fields: ['myColumn']
           })).to.throw('references object with table and field must be specified');
         });
-
-
       });
 
       describe('validation', () => {


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

Oracle doesn't support "ON UPDATE" actions in constraints and it throws an error if defined. It also doesn't support "ON DELETE NO ACTION".

The PR modifies `addConstraintQuery` method to avoid errors.
