### PR TITLE
feat: allow case insensitive model fetching

### DIFF
--- a/packages/core/src/model-manager.ts
+++ b/packages/core/src/model-manager.ts
@@ -32,7 +32,7 @@ export class ModelManager {
 
   getModel(modelName: string, options?: { caseSensitive?: boolean }): ModelStatic | undefined {
     options = defaults(options, {
-      caseSensitive: true
+      caseSensitive: true,
     });
 
     if (options.caseSensitive) {

--- a/packages/core/src/model-manager.ts
+++ b/packages/core/src/model-manager.ts
@@ -30,8 +30,16 @@ export class ModelManager {
     delete this.#sequelize.models[modelToRemove.name];
   }
 
-  getModel(modelName: string): ModelStatic | undefined {
-    return this.models.find(model => model.name === modelName);
+  getModel(modelName: string, options?: { caseSensitive?: boolean }): ModelStatic | undefined {
+    options = defaults(options, {
+      caseSensitive: true
+    });
+
+    if (options.caseSensitive) {
+      return this.models.find(model => model.name === modelName);
+    }
+
+    return this.models.find(model => model.name.toLowerCase() === modelName.toLowerCase());
   }
 
   findModel(

--- a/packages/core/src/sequelize.d.ts
+++ b/packages/core/src/sequelize.d.ts
@@ -910,15 +910,17 @@ export class Sequelize extends SequelizeTypeScript {
    * Fetch a Model which is already defined
    *
    * @param modelName The name of a model defined with Sequelize.define
+   * @param {object} options Options for searching
    */
-  model<M extends Model = Model>(modelName: string): ModelStatic<M>;
+  model<M extends Model = Model>(modelName: string, options?: { caseSensitive?: boolean }): ModelStatic<M>;
 
   /**
    * Checks whether a model with the given name is defined
    *
    * @param modelName The name of a model defined with Sequelize.define
+   * @param {object} options Options for searching
    */
-  isDefined(modelName: string): boolean;
+  isDefined(modelName: string, options?: { caseSensitive?: boolean }): boolean;
 
   /**
    * Execute a query on the DB, optionally bypassing all the Sequelize goodness.

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -527,7 +527,7 @@ export class Sequelize extends SequelizeTypeScript {
    */
   model(modelName, options) {
     options = defaults(options, {
-      caseSensitive: true
+      caseSensitive: true,
     });
 
     if (!this.isDefined(modelName, options)) {
@@ -547,7 +547,7 @@ export class Sequelize extends SequelizeTypeScript {
    */
   isDefined(modelName, options) {
     options = defaults(options, {
-      caseSensitive: true
+      caseSensitive: true,
     });
 
     if (options.caseSensitive) {

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -520,27 +520,41 @@ export class Sequelize extends SequelizeTypeScript {
    * Fetch a Model which is already defined
    *
    * @param {string} modelName The name of a model defined with Sequelize.define
+   * @param {object} options Options for searching
    *
    * @throws Will throw an error if the model is not defined (that is, if sequelize#isDefined returns false)
    * @returns {Model} Specified model
    */
-  model(modelName) {
-    if (!this.isDefined(modelName)) {
+  model(modelName, options) {
+    options = defaults(options, {
+      caseSensitive: true
+    });
+
+    if (!this.isDefined(modelName, options)) {
       throw new Error(`${modelName} has not been defined`);
     }
 
-    return this.modelManager.getModel(modelName);
+    return this.modelManager.getModel(modelName, options);
   }
 
   /**
    * Checks whether a model with the given name is defined
    *
    * @param {string} modelName The name of a model defined with Sequelize.define
+   * @param {object} options Options for searching
    *
    * @returns {boolean} Returns true if model is already defined, otherwise false
    */
-  isDefined(modelName) {
-    return this.modelManager.models.some(model => model.name === modelName);
+  isDefined(modelName, options) {
+    options = defaults(options, {
+      caseSensitive: true
+    });
+
+    if (options.caseSensitive) {
+      return this.modelManager.models.some(model => model.name === modelName);
+    }
+
+    return this.modelManager.models.some(model => model.name.toLowerCase() === modelName.toLowerCase());
   }
 
   /**

--- a/packages/core/test/integration/sequelize.test.js
+++ b/packages/core/test/integration/sequelize.test.js
@@ -210,6 +210,17 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
       expect(this.sequelize.isDefined('Project')).to.be.true;
     });
+
+    it('returns false if the dao was defined before but case does not match', function() {
+      expect(this.sequelize.isDefined('PrOjEct')).to.be.false;
+    });
+
+    it('returns true if the dao was defined before, the case does not match but search is case insensitive', function() {
+      this.sequelize.define('Project', {
+        name: DataTypes.STRING
+      });
+      expect(this.sequelize.isDefined('PrOjEct', { caseSensitive: false })).to.be.true;
+    });
   });
 
   describe('model', () => {
@@ -225,6 +236,26 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       expect(this.sequelize.model('Project')).to.equal(project);
+    });
+
+    it('throws an error if the dao being accessed does not match exactly', function() {
+      const project = this.sequelize.define('Project', {
+        name: DataTypes.STRING
+      });
+
+      expect(() => {
+        this.sequelize.model('PrOjEct');
+      }).to.throw(/PrOjEct has not been defined/i);
+
+      expect(this.sequelize.model('Project')).to.equal(project);
+    });
+
+    it('returns the dao factory defined by daoName (Case insensitive)', function() {
+      const project = this.sequelize.define('Project', {
+        name: DataTypes.STRING
+      });
+
+      expect(this.sequelize.model('PrOjEct', { caseSensitive: false })).to.equal(project);
     });
   });
 

--- a/packages/core/test/integration/sequelize.test.js
+++ b/packages/core/test/integration/sequelize.test.js
@@ -211,13 +211,13 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       expect(this.sequelize.isDefined('Project')).to.be.true;
     });
 
-    it('returns false if the dao was defined before but case does not match', function() {
+    it('returns false if the dao was defined before but case does not match', function () {
       expect(this.sequelize.isDefined('PrOjEct')).to.be.false;
     });
 
-    it('returns true if the dao was defined before, the case does not match but search is case insensitive', function() {
+    it('returns true if the dao was defined before, the case does not match but search is case insensitive', function () {
       this.sequelize.define('Project', {
-        name: DataTypes.STRING
+        name: DataTypes.STRING,
       });
       expect(this.sequelize.isDefined('PrOjEct', { caseSensitive: false })).to.be.true;
     });
@@ -238,9 +238,9 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       expect(this.sequelize.model('Project')).to.equal(project);
     });
 
-    it('throws an error if the dao being accessed does not match exactly', function() {
+    it('throws an error if the dao being accessed does not match exactly', function () {
       const project = this.sequelize.define('Project', {
-        name: DataTypes.STRING
+        name: DataTypes.STRING,
       });
 
       expect(() => {
@@ -250,9 +250,9 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       expect(this.sequelize.model('Project')).to.equal(project);
     });
 
-    it('returns the dao factory defined by daoName (Case insensitive)', function() {
+    it('returns the dao factory defined by daoName (Case insensitive)', function () {
       const project = this.sequelize.define('Project', {
-        name: DataTypes.STRING
+        name: DataTypes.STRING,
       });
 
       expect(this.sequelize.model('PrOjEct', { caseSensitive: false })).to.equal(project);


### PR DESCRIPTION
## Pull Request Checklist

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

This PR adds the option to use case insensitive search in [`sequelize.model`](https://github.com/sequelize/sequelize/blob/f3253b9f3045b0225b5a321cecffbd754e81fa48/packages/core/src/sequelize.js#L527) function.

By extension, it also adds that option to [`sequelize.isDefined`](https://github.com/sequelize/sequelize/blob/f3253b9f3045b0225b5a321cecffbd754e81fa48/packages/core/src/sequelize.js#L542) and [`modelManager.getModel`](https://github.com/sequelize/sequelize/blob/f3253b9f3045b0225b5a321cecffbd754e81fa48/packages/core/src/model-manager.ts#L33)

By default, the search is case sensitive.

**NOTE: This is the same functionality of #16705 but updated for v7**