### PR TITLE
fix: correctly cascade delete with `hooks: true`

### DIFF
--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -680,7 +680,7 @@ export class AbstractQueryInterfaceTypeScript {
   async delete(
     instance: Model | null,
     tableName: TableName,
-    identifier: WhereOptions<any>,
+    identifier: WhereOptions,
     options?: QiDeleteOptions,
   ): Promise<object> {
     const cascades: string[] = [];

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -703,6 +703,7 @@ export class AbstractQueryInterfaceTypeScript {
       for (let i = 0; i < length; i++) {
         association = model.associations[keys[i]];
         if (['HasMany', 'HasOne'].includes(association.associationType)
+          && association.options?.foreignKey
           && association.options.foreignKey.onDelete === 'CASCADE'
           && association.options.hooks) {
           cascades.push(association.accessors.get);

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -694,7 +694,7 @@ export class AbstractQueryInterfaceTypeScript {
       for (let i = 0; i < length; i++) {
         association = model.associations[keys[i]];
         if (['HasMany', 'HasOne'].includes(association.associationType) &&
-          association.options.foreignKey.onDelete?.toLowerCase() === 'cascade' &&
+          association.options.foreignKey.onDelete === 'CASCADE' &&
           association.options.hooks) {
           cascades.push(association.accessors.get);
         }

--- a/packages/core/src/dialects/abstract/query-interface.d.ts
+++ b/packages/core/src/dialects/abstract/query-interface.d.ts
@@ -389,16 +389,6 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   ): Promise<object>;
 
   /**
-   * Deletes a row
-   */
-  delete(
-    instance: Model | null,
-    tableName: TableName,
-    identifier: WhereOptions<any>,
-    options?: QiDeleteOptions,
-  ): Promise<object>;
-
-  /**
    * Deletes multiple rows at once
    */
   bulkDelete(

--- a/packages/core/src/dialects/abstract/query-interface.js
+++ b/packages/core/src/dialects/abstract/query-interface.js
@@ -563,53 +563,6 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
     return await this.sequelize.queryRaw(query, options);
   }
 
-  async delete(instance, tableName, identifier, options) {
-    const cascades = [];
-
-    const sql = this.queryGenerator.deleteQuery(tableName, identifier, {}, instance.constructor);
-
-    options = { ...options };
-
-    // unlike bind, replacements are handled by QueryGenerator, not QueryRaw
-    delete options.replacements;
-
-    // Check for a restrict field
-    if (Boolean(instance.constructor) && Boolean(instance.constructor.associations)) {
-      const keys = Object.keys(instance.constructor.associations);
-      const length = keys.length;
-      let association;
-
-      for (let i = 0; i < length; i++) {
-        association = instance.constructor.associations[keys[i]];
-        if (association.options && association.options.onDelete
-          && association.options.onDelete.toLowerCase() === 'cascade'
-          && association.options.hooks === true) {
-          cascades.push(association.accessors.get);
-        }
-      }
-    }
-
-    for (const cascade of cascades) {
-      let instances = await instance[cascade](options);
-      // Check for hasOne relationship with non-existing associate ("has zero")
-      if (!instances) {
-        continue;
-      }
-
-      if (!Array.isArray(instances)) {
-        instances = [instances];
-      }
-
-      for (const _instance of instances) {
-        await _instance.destroy(options);
-      }
-    }
-
-    options.instance = instance;
-
-    return await this.sequelize.queryRaw(sql, options);
-  }
-
   /**
    * Delete multiple records from a table
    *

--- a/packages/core/test/integration/associations/cascade.test.ts
+++ b/packages/core/test/integration/associations/cascade.test.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import type { Model } from '@sequelize/core';
+import { DataTypes } from '@sequelize/core';
+import { getTestDialectTeaser, sequelize } from '../support';
+
+describe(getTestDialectTeaser('Cascade Destroy'), async () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should delete associations manually, if explicit set', async () => {
+    const onDestroySpy = sinon.spy();
+
+    const Child = sequelize.define<{ id: number } & Model>('Child', {
+      parentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+    }, {
+      timestamps: false, hooks: {
+        afterDestroy: () => {
+          onDestroySpy();
+        },
+      },
+    });
+
+    const Parent = sequelize.define<{ id: number } & Model>('Parent', {}, { timestamps: false });
+
+    Parent.hasMany(Child, {
+      foreignKey: {
+        name: 'parentId',
+        onDelete: 'CASCADE',
+      },
+      inverse: 'parent',
+      hooks: true,
+    });
+
+    await sequelize.sync({ force: true });
+
+    const parent = await Parent.create({});
+    await Child.bulkCreate([{ parentId: parent.id }, { parentId: parent.id }]);
+
+    await parent.destroy();
+
+    const childCount = await Child.count();
+    expect(childCount).to.eq(0);
+
+    expect(onDestroySpy.callCount).to.eq(2);
+  });
+
+  it('should not delete associations manually, if hooks is false', async () => {
+    const onDestroySpy = sinon.spy();
+
+    const Child = sequelize.define<{ id: number } & Model>('Child', {
+      parentId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+    }, {
+      timestamps: false, hooks: {
+        afterDestroy: () => {
+          onDestroySpy();
+        },
+      },
+    });
+
+    const Parent = sequelize.define<{ id: number } & Model>('Parent', {}, { timestamps: false });
+
+    Parent.hasMany(Child, {
+      foreignKey: {
+        name: 'parentId',
+        onDelete: 'CASCADE',
+      },
+      inverse: 'parent',
+    });
+
+    await sequelize.sync({ force: true });
+
+    const parent = await Parent.create({});
+    await Child.bulkCreate([{ parentId: parent.id }, { parentId: parent.id }]);
+
+    await parent.destroy();
+
+    const childCount = await Child.count();
+    expect(childCount).to.eq(0);
+
+    expect(onDestroySpy.callCount).to.eq(0);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

This is my first PR to this repository, i hope i did everything right, if not, let me know! 😊 

As mentioned in the linked issue, i mentioned that the cascade `delete` with `hooks: true` doesn't work in v7. I fixed this in this PR:

- Added the `delete` method to the **query-interface-typescript.ts**
  - use correct typings
  - move check on `onDelete` from `association.options` to `association.options.foreignKey`
- Remove the `delete` method from the **query-interface.js**

closes #16745 

## Todos

- [ ] From my understanding the `onDelete` is interpreted as `CASCADE` if user's don't set it directly and the foreign key is not nullable. I think it would make sense to cascade delete them as well, but i didn't find the place in code where this default is set. Within the `delete` method the `association.options.foreignKey` doesn't contain the default value, so atm it only works if the user explicit sets `onDelete: 'CASCADE'` (think it was the same in v6)
