### PR TITLE
fix: self referencing with through table where-clause clashes with the included models

### DIFF
--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -1881,6 +1881,10 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     topInclude.association = undefined;
 
     if (topInclude.through && Object(topInclude.through.model) === topInclude.through.model) {
+      if (topAssociation.toTarget !== undefined && topParent.model.name === topAssociation.toTarget.as) {
+        topAssociation.toTarget.as = `${topInclude.through.model.name}->${topAssociation.toTarget.as}`;
+      }
+
       query = this.selectQuery(topInclude.through.model.getTableName(), {
         attributes: [topInclude.through.model.primaryKeyField],
         include: _validateIncludedElements({


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
Fix self-reference with though table where-clause in include not working correctly because top parent name in the where-clause clashes with the included models.
Closes #16719

