### PR TITLE
meta: ignore .nx cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules
 *.log
 /packages/*/lib
 /packages/*/types
+/.nx
 
 .pnp.*
 .yarn/*


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

When developping fixes on main, nx created its cache in a `.nx`  directory that was not ignored.