### PR TITLE
fix: sort keys by depth in groupJoinData

### DIFF
--- a/src/dialects/abstract/query.js
+++ b/src/dialects/abstract/query.js
@@ -550,7 +550,7 @@ class AbstractQuery {
 
       // Keys are the same for all rows, so only need to compute them on the first row
       if (rowsI === 0) {
-        keys = Object.keys(row);
+        keys = _.sortBy(Object.keys(row), item => [item.split('.').length]);
         keyLength = keys.length;
       }
 

--- a/test/unit/dialects/abstract/query.test.js
+++ b/test/unit/dialects/abstract/query.test.js
@@ -16,6 +16,9 @@ describe('[ABSTRACT]', () => {
         id: {
           primaryKey: true,
           type: current.Sequelize.STRING(1)
+        },
+        name: {
+          type: current.Sequelize.TEXT
         }
       });
 
@@ -64,6 +67,7 @@ describe('[ABSTRACT]', () => {
           'players.created': new Date('2017-03-06T15:47:30.000Z'),
           'players.lastModified': new Date('2017-03-06T15:47:30.000Z'),
           'agents.uuid': agentOneUuid,
+          name: 'vansh',
           'agents.id': 'p',
           'agents.name': 'One'
         },
@@ -73,6 +77,7 @@ describe('[ABSTRACT]', () => {
           'players.created': new Date('2017-03-06T15:47:30.000Z'),
           'players.lastModified': new Date('2017-08-22T11:16:44.000Z'),
           'agents.uuid': agentTwoUuid,
+          name: 'joe',
           'agents.id': 'z',
           'agents.name': 'Two'
         }
@@ -83,6 +88,7 @@ describe('[ABSTRACT]', () => {
       expect(result.length).to.be.equal(1);
 
       expect(result[0]).to.have.property('id').and.be.equal('a');
+      expect(result[0]).to.have.property('name').and.be.ok;
       expect(result[0].agents).to.be.deep.equal([
         {
           id: 'p',


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
