### PR TITLE
meta: add unit test for ARRAY(UUID)

### DIFF
--- a/packages/core/test/unit/data-types/arrays.test.ts
+++ b/packages/core/test/unit/data-types/arrays.test.ts
@@ -83,6 +83,11 @@ describe('DataTypes.ARRAY', () => {
     postgres: 'CITEXT[]',
   });
 
+  testDataTypeSql('ARRAY(UUID)', DataTypes.ARRAY(DataTypes.UUID), {
+    default: unsupportedError,
+    postgres: 'UUID[]',
+  });
+
   it('raises an error if no values are defined', () => {
     expect(() => {
       sequelize.define('omnomnom', {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Support for this was likely added in the big DataTypes PR, but it was not tested before. This was requested in https://github.com/sequelize/sequelize/issues/10321
The docs just mention that `DataTypes.Something` can be used so no need to update those; https://sequelize.org/docs/v7/models/data-types/#arrays