### PR TITLE
feat: add support for `sql` tag & functions in `sequelize.query`

### DIFF
--- a/packages/core/src/sequelize.d.ts
+++ b/packages/core/src/sequelize.d.ts
@@ -4,7 +4,7 @@ import type { AbstractConnectionManager } from './dialects/abstract/connection-m
 import type { AbstractDataType, DataType, DataTypeClassOrInstance } from './dialects/abstract/data-types.js';
 import type { AbstractQueryInterface } from './dialects/abstract/query-interface';
 import type { ColumnsDescription, RawConstraintDescription } from './dialects/abstract/query-interface.types';
-import type { DynamicSqlExpression } from './expression-builders/base-sql-expression.js';
+import type { BaseSqlExpression, DynamicSqlExpression } from './expression-builders/base-sql-expression.js';
 import type { cast } from './expression-builders/cast.js';
 import type { col } from './expression-builders/col.js';
 import type { Fn, fn } from './expression-builders/fn.js';
@@ -931,20 +931,20 @@ export class Sequelize extends SequelizeTypeScript {
    * @param options Query options
    */
   /* eslint-disable max-len -- these signatures are more readable if they are all aligned */
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.UPDATE>): Promise<[undefined, number]>;
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.BULKUPDATE>): Promise<number>;
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.INSERT>): Promise<[number, number]>;
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.UPSERT>): Promise<number>;
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.DELETE>): Promise<void>;
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.DESCRIBE>): Promise<ColumnsDescription>;
-  query(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SHOWCONSTRAINTS>): Promise<RawConstraintDescription[]>;
-  query<M extends Model>(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithModel<M> & { plain: true }): Promise<M | null>;
-  query<M extends Model>(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithModel<M>): Promise<M[]>;
-  query<T extends object>(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SELECT> & { plain: true }): Promise<T | null>;
-  query<T extends object>(sql: string | { query: string, values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SELECT>): Promise<T[]>;
-  query(sql: string | { query: string, values: unknown[] }, options: (QueryOptions | QueryOptionsWithType<QueryTypes.RAW>) & { plain: true }): Promise<{ [key: string]: unknown } | null>;
-  query(sql: string | { query: string, values: unknown[] }, options?: QueryOptions | QueryOptionsWithType<QueryTypes.RAW>): Promise<[unknown[], unknown]>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.UPDATE>): Promise<[undefined, number]>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.BULKUPDATE>): Promise<number>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.INSERT>): Promise<[number, number]>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.UPSERT>): Promise<number>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.DELETE>): Promise<void>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.DESCRIBE>): Promise<ColumnsDescription>;
+  query(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.SHOWCONSTRAINTS>): Promise<RawConstraintDescription[]>;
+  query<M extends Model>(sql: string | BaseSqlExpression, options: QueryOptionsWithModel<M> & { plain: true }): Promise<M | null>;
+  query<M extends Model>(sql: string | BaseSqlExpression, options: QueryOptionsWithModel<M>): Promise<M[]>;
+  query<T extends object>(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.SELECT> & { plain: true }): Promise<T | null>;
+  query<T extends object>(sql: string | BaseSqlExpression, options: QueryOptionsWithType<QueryTypes.SELECT>): Promise<T[]>;
+  query(sql: string | BaseSqlExpression, options: (QueryOptions | QueryOptionsWithType<QueryTypes.RAW>) & { plain: true }): Promise<{ [key: string]: unknown } | null>;
+  query(sql: string | BaseSqlExpression, options?: QueryOptions | QueryOptionsWithType<QueryTypes.RAW>): Promise<[unknown[], unknown]>;
 
   /**
    * Works like {@link Sequelize#query}, but does not inline replacements. Only bind parameters are supported.
@@ -952,20 +952,20 @@ export class Sequelize extends SequelizeTypeScript {
    * @param sql The SQL to execute
    * @param options The options for the query. See {@link QueryRawOptions} for details.
    */
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.UPDATE>): Promise<[undefined, number]>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.BULKUPDATE>): Promise<number>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.INSERT>): Promise<[number, number]>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.UPSERT>): Promise<number>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.DELETE>): Promise<void>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.DESCRIBE>): Promise<ColumnsDescription>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.SHOWCONSTRAINTS>): Promise<RawConstraintDescription[]>;
-  queryRaw<M extends Model>(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithModel<M> & { plain: true }): Promise<M | null>;
-  queryRaw<M extends Model>(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithModel<M>): Promise<M[]>;
-  queryRaw<T extends object>(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.SELECT> & { plain: true }): Promise<T | null>;
-  queryRaw<T extends object>(sql: string | { query: string, values: unknown[] }, options: QueryRawOptionsWithType<QueryTypes.SELECT>): Promise<T[]>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options: (QueryRawOptions | QueryRawOptionsWithType<QueryTypes.RAW>) & { plain: true }): Promise<{ [key: string]: unknown } | null>;
-  queryRaw(sql: string | { query: string, values: unknown[] }, options?: QueryRawOptions | QueryRawOptionsWithType<QueryTypes.RAW>): Promise<[unknown[], unknown]>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.UPDATE>): Promise<[undefined, number]>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.BULKUPDATE>): Promise<number>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.INSERT>): Promise<[number, number]>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.UPSERT>): Promise<number>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.DELETE>): Promise<void>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.DESCRIBE>): Promise<ColumnsDescription>;
+  queryRaw(sql: string, options: QueryRawOptionsWithType<QueryTypes.SHOWCONSTRAINTS>): Promise<RawConstraintDescription[]>;
+  queryRaw<M extends Model>(sql: string, options: QueryRawOptionsWithModel<M> & { plain: true }): Promise<M | null>;
+  queryRaw<M extends Model>(sql: string, options: QueryRawOptionsWithModel<M>): Promise<M[]>;
+  queryRaw<T extends object>(sql: string, options: QueryRawOptionsWithType<QueryTypes.SELECT> & { plain: true }): Promise<T | null>;
+  queryRaw<T extends object>(sql: string, options: QueryRawOptionsWithType<QueryTypes.SELECT>): Promise<T[]>;
+  queryRaw(sql: string, options: (QueryRawOptions | QueryRawOptionsWithType<QueryTypes.RAW>) & { plain: true }): Promise<{ [key: string]: unknown } | null>;
+  queryRaw(sql: string, options?: QueryRawOptions | QueryRawOptionsWithType<QueryTypes.RAW>): Promise<[unknown[], unknown]>;
   /* eslint-enable max-len */
 
   /**

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -4,6 +4,7 @@ import retry from 'retry-as-promised';
 import { normalizeDataType } from './dialects/abstract/data-types-utils';
 import { AssociationPath } from './expression-builders/association-path';
 import { Attribute } from './expression-builders/attribute';
+import { BaseSqlExpression } from './expression-builders/base-sql-expression.js';
 import { Identifier } from './expression-builders/identifier';
 import { JsonPath } from './expression-builders/json-path';
 import { Value } from './expression-builders/value';
@@ -589,6 +590,10 @@ export class Sequelize extends SequelizeTypeScript {
    */
   async query(sql, options) {
     options = { ...this.options.query, ...options };
+
+    if (sql instanceof BaseSqlExpression) {
+      sql = this.queryGenerator.formatSqlExpression(sql, options);
+    }
 
     if (typeof sql === 'object') {
       throw new TypeError('"sql" cannot be an object. Pass a string instead, and pass bind and replacement parameters through the "options" parameter');

--- a/packages/core/test/unit/query-interface/bulk-delete.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-delete.test.ts
@@ -30,7 +30,7 @@ describe('QueryInterface#bulkDelete', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: `DELETE FROM [Users] WHERE [firstName] = ':id'`,
       mssql: `DELETE FROM [Users] WHERE [firstName] = N':id'; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
     });

--- a/packages/core/test/unit/query-interface/bulk-update.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-update.test.ts
@@ -36,7 +36,7 @@ describe('QueryInterface#bulkUpdate', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: `UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [firstName] = $sequelize_2`,
       db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "firstName" = $sequelize_2);`,
     });
@@ -83,7 +83,7 @@ describe('QueryInterface#bulkUpdate', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [firstName] = $one',
       db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "firstName" = $one);`,
     });
@@ -113,7 +113,7 @@ describe('QueryInterface#bulkUpdate', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [firstName] = $1',
       db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "firstName" = $1);`,
     });

--- a/packages/core/test/unit/query-interface/decrement.test.ts
+++ b/packages/core/test/unit/query-interface/decrement.test.ts
@@ -38,7 +38,7 @@ describe('QueryInterface#decrement', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: `UPDATE [Users] SET [age]=[age]- ':age',[name]=':name' WHERE [firstName] = ':firstName'`,
       postgres: `UPDATE "Users" SET "age"="age"- ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
       mssql: `UPDATE [Users] SET [age]=[age]- N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [firstName] = N':firstName'`,

--- a/packages/core/test/unit/query-interface/delete.test.ts
+++ b/packages/core/test/unit/query-interface/delete.test.ts
@@ -32,7 +32,7 @@ describe('QueryInterface#delete', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: `DELETE FROM [Users] WHERE [firstName] = ':id'`,
       mssql: `DELETE FROM [Users] WHERE [firstName] = N':id'; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
     });

--- a/packages/core/test/unit/query-interface/drop-table.test.ts
+++ b/packages/core/test/unit/query-interface/drop-table.test.ts
@@ -17,7 +17,7 @@ describe('QueryInterface#dropTable', () => {
 
       expect(stub.callCount).to.eq(1);
       const firstCall = stub.getCall(0);
-      expectsql(firstCall.args[0] as string, {
+      expectsql(firstCall.args[0], {
         default: 'DROP TABLE IF EXISTS [myTable] CASCADE',
       });
     } else {

--- a/packages/core/test/unit/query-interface/increment.test.ts
+++ b/packages/core/test/unit/query-interface/increment.test.ts
@@ -38,7 +38,7 @@ describe('QueryInterface#increment', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: `UPDATE [Users] SET [age]=[age]+ ':age',[name]=':name' WHERE [firstName] = ':firstName'`,
       postgres: `UPDATE "Users" SET "age"="age"+ ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
       mssql: `UPDATE [Users] SET [age]=[age]+ N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [firstName] = N':firstName'`,

--- a/packages/core/test/unit/query-interface/insert.test.ts
+++ b/packages/core/test/unit/query-interface/insert.test.ts
@@ -27,7 +27,7 @@ describe('QueryInterface#insert', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       postgres: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1) RETURNING ":data";`,
       default: 'INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1);',
       mssql: `INSERT INTO [Users] ([firstName]) OUTPUT INSERTED.[:data] VALUES ($sequelize_1);`,
@@ -65,7 +65,7 @@ describe('QueryInterface#insert', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'INSERT INTO [Users] ([firstName],[lastName]) VALUES ($firstName,$sequelize_1);',
       db2: `SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName","lastName") VALUES ($firstName,$sequelize_1));`,
       ibmi: `SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName","lastName") VALUES ($firstName,$sequelize_1))`,
@@ -89,7 +89,7 @@ describe('QueryInterface#insert', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'INSERT INTO [Users] ([firstName],[lastName]) VALUES ($1,$sequelize_1);',
       db2: `SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName","lastName") VALUES ($1,$sequelize_1));`,
       ibmi: `SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName","lastName") VALUES ($1,$sequelize_1))`,

--- a/packages/core/test/unit/query-interface/raw-select.test.ts
+++ b/packages/core/test/unit/query-interface/raw-select.test.ts
@@ -29,7 +29,7 @@ describe('QueryInterface#rawSelect', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: `SELECT [id] FROM [Users] AS [User] WHERE [User].[username] = 'some :data';`,
       mssql: `SELECT [id] FROM [Users] AS [User] WHERE [User].[username] = N'some :data';`,
     });

--- a/packages/core/test/unit/query-interface/select.test.ts
+++ b/packages/core/test/unit/query-interface/select.test.ts
@@ -29,7 +29,7 @@ describe('QueryInterface#select', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: `SELECT [id] FROM [Users] AS [User] WHERE [User].[username] = 'some :data';`,
       mssql: `SELECT [id] FROM [Users] AS [User] WHERE [User].[username] = N'some :data';`,
     });

--- a/packages/core/test/unit/query-interface/update.test.ts
+++ b/packages/core/test/unit/query-interface/update.test.ts
@@ -34,7 +34,7 @@ describe('QueryInterface#update', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [firstName] = $sequelize_2',
       postgres: 'UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "firstName" = $sequelize_2 RETURNING ":data"',
       mssql: 'UPDATE [Users] SET [firstName]=$sequelize_1 OUTPUT INSERTED.[:data] WHERE [firstName] = $sequelize_2',
@@ -83,7 +83,7 @@ describe('QueryInterface#update', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [id] = $id',
       db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "id" = $id);`,
     });
@@ -111,7 +111,7 @@ describe('QueryInterface#update', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [id] = $1',
       db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "id" = $1);`,
     });

--- a/packages/core/test/unit/query-interface/upsert.test.ts
+++ b/packages/core/test/unit/query-interface/upsert.test.ts
@@ -34,7 +34,7 @@ describe('QueryInterface#upsert', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1) ON CONFLICT ([id]) DO UPDATE SET [firstName]=EXCLUDED.[firstName];',
       mariadb: 'INSERT INTO `Users` (`firstName`) VALUES ($sequelize_1) ON DUPLICATE KEY UPDATE `firstName`=$sequelize_1;',
       mysql: 'INSERT INTO `Users` (`firstName`) VALUES ($sequelize_1) ON DUPLICATE KEY UPDATE `firstName`=$sequelize_1;',
@@ -112,7 +112,7 @@ describe('QueryInterface#upsert', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'INSERT INTO [Users] ([firstName],[lastName]) VALUES ($firstName,$sequelize_1) ON CONFLICT ([id]) DO NOTHING;',
       mysql: 'INSERT INTO `Users` (`firstName`,`lastName`) VALUES ($firstName,$sequelize_1) ON DUPLICATE KEY UPDATE `id`=`id`;',
       mariadb: 'INSERT INTO `Users` (`firstName`,`lastName`) VALUES ($firstName,$sequelize_1) ON DUPLICATE KEY UPDATE `id`=`id`;',
@@ -169,7 +169,7 @@ describe('QueryInterface#upsert', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'INSERT INTO [Users] ([firstName],[lastName]) VALUES ($1,$sequelize_1) ON CONFLICT ([id]) DO NOTHING;',
       mysql: 'INSERT INTO `Users` (`firstName`,`lastName`) VALUES ($1,$sequelize_1) ON DUPLICATE KEY UPDATE `id`=`id`;',
       mariadb: 'INSERT INTO `Users` (`firstName`,`lastName`) VALUES ($1,$sequelize_1) ON DUPLICATE KEY UPDATE `id`=`id`;',
@@ -226,7 +226,7 @@ describe('QueryInterface#upsert', () => {
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
-    expectsql(firstCall.args[0] as string, {
+    expectsql(firstCall.args[0], {
       default: 'INSERT INTO `Users` (`firstName`,`counter`) VALUES ($sequelize_1,`counter` + 1) ON DUPLICATE KEY UPDATE `counter`=`counter` + 1;',
       postgres: 'INSERT INTO "Users" ("firstName","counter") VALUES ($sequelize_1,`counter` + 1) ON CONFLICT ("id") DO UPDATE SET "counter"=EXCLUDED."counter";',
       mssql: `

--- a/packages/core/test/unit/sequelize.test.ts
+++ b/packages/core/test/unit/sequelize.test.ts
@@ -1,19 +1,37 @@
 import { expect } from 'chai';
-import { Sequelize } from '@sequelize/core';
-import { createSequelizeInstance } from '../support';
+import sinon from 'sinon';
+import { Sequelize, sql } from '@sequelize/core';
+import { createSequelizeInstance, sequelize } from '../support';
 
 describe('Sequelize', () => {
   describe('constructor', () => {
     it('should correctly set the host and the port', () => {
-      const sequelize = createSequelizeInstance({ host: '127.0.0.1', port: 1234 });
-      expect(sequelize.config.port).to.equal(1234);
-      expect(sequelize.config.host).to.equal('127.0.0.1');
+      const localSequelize = createSequelizeInstance({ host: '127.0.0.1', port: 1234 });
+      expect(localSequelize.config.port).to.equal(1234);
+      expect(localSequelize.config.host).to.equal('127.0.0.1');
     });
   });
 
   describe('version', () => {
     it('should be a string', () => {
       expect(typeof Sequelize.version).to.eq('string');
+    });
+  });
+
+  describe('query', () => {
+    it('supports sql expressions', async () => {
+      // mock sequelize.queryRaw using sinon
+      sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
+
+      await sequelize.query(sql`SELECT * FROM "users" WHERE id = ${1} AND id2 = :id2`, {
+        replacements: {
+          id2: 2,
+        },
+      });
+
+      expect(sequelize.queryRaw).to.have.been.calledWith(
+        'SELECT * FROM "users" WHERE id = 1 AND id2 = 2',
+      );
     });
   });
 });

--- a/packages/core/test/unit/sequelize.test.ts
+++ b/packages/core/test/unit/sequelize.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import type { SinonStub } from 'sinon';
 import sinon from 'sinon';
 import { Sequelize, sql } from '@sequelize/core';
 import { createSequelizeInstance, sequelize } from '../support';
@@ -19,9 +20,19 @@ describe('Sequelize', () => {
   });
 
   describe('query', () => {
+    let stubs: Array<SinonStub<any>> = [];
+
+    afterEach(() => {
+      for (const stub of stubs) {
+        stub.restore();
+      }
+
+      stubs = [];
+    });
+
     it('supports sql expressions', async () => {
       // mock sequelize.queryRaw using sinon
-      sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
+      stubs.push(sinon.stub(sequelize, 'queryRaw').resolves([[], 0]));
 
       await sequelize.query(sql`SELECT * FROM "users" WHERE id = ${1} AND id2 = :id2`, {
         replacements: {


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] ~~If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?~~
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

This PR adds support for using the `sql` tag in `sequelize.query`, like was already described in our documentation: https://sequelize.org/docs/v7/querying/raw-queries/#sequelizequery

Closes https://github.com/sequelize/website/issues/634