### PR TITLE
Dependency postgres-array is added

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,6 +64,7 @@
     "type-fest": "^3.0.0",
     "uuid": "^9.0.0",
     "validator": "^13.7.0",
+    "postgres-array":"^3.0.2",
     "wkx": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In sequelize@7-alpha dont included "postgres-array" and this error ocurred:

SequelizeDatabaseError: this[#arrayParserLib].parse is not a function

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
