### PR TITLE
feat: preserve keys order when using getters and virtual fields

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1,19 +1,7 @@
 'use strict';
 
-import {
-  Association,
-  BelongsToAssociation,
-  BelongsToManyAssociation,
-  HasManyAssociation,
-  HasOneAssociation,
-} from './associations';
-import { AssociationSecret } from './associations/helpers';
 import { AbstractDataType } from './dialects/abstract/data-types';
 import { BaseSqlExpression } from './expression-builders/base-sql-expression.js';
-import { _validateIncludedElements, combineIncludes, setTransactionFromCls, throwInvalidInclude } from './model-internals';
-import { ModelTypeScript } from './model-typescript';
-import { Op } from './operators';
-import { QueryTypes } from './query-types';
 import { intersects } from './utils/array';
 import {
   noDoubleNestedGroup,
@@ -25,9 +13,21 @@ import {
 import { toDefaultValue } from './utils/dialect';
 import { mapFinderOptions, mapOptionFieldNames, mapValueFieldNames } from './utils/format';
 import { every, find } from './utils/iterators';
-import { isModelStatic, isSameInitialModel } from './utils/model-utils';
 import { EMPTY_OBJECT, cloneDeep, defaults, flattenObjectDeep, getObjectFromMap, mergeDefaults } from './utils/object';
 import { isWhereEmpty } from './utils/query-builder-utils';
+import { ModelTypeScript } from './model-typescript';
+import { isModelStatic, isSameInitialModel } from './utils/model-utils';
+import {
+  Association,
+  BelongsToAssociation,
+  BelongsToManyAssociation,
+  HasManyAssociation,
+  HasOneAssociation,
+} from './associations';
+import { AssociationSecret } from './associations/helpers';
+import { Op } from './operators';
+import { _validateIncludedElements, combineIncludes, setTransactionFromCls, throwInvalidInclude } from './model-internals';
+import { QueryTypes } from './query-types';
 import { getComplexKeys } from './utils/where.js';
 
 import assignWith from 'lodash/assignWith';
@@ -39,11 +39,11 @@ import flattenDepth from 'lodash/flattenDepth';
 import forEach from 'lodash/forEach';
 import forIn from 'lodash/forIn';
 import get from 'lodash/get';
-import intersection from 'lodash/intersection';
-import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
 import isObject from 'lodash/isObject';
 import isPlainObject from 'lodash/isPlainObject';
+import intersection from 'lodash/intersection';
 import mapValues from 'lodash/mapValues';
 import omit from 'lodash/omit';
 import omitBy from 'lodash/omitBy';
@@ -51,8 +51,8 @@ import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 import remove from 'lodash/remove';
 import union from 'lodash/union';
-import unionBy from 'lodash/unionBy';
 import uniq from 'lodash/uniq';
+import unionBy from 'lodash/unionBy';
 import without from 'lodash/without';
 
 const assert = require('node:assert');


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

On a model that has getters and virtual fields, when serialized to JSON these fields are placed on top of the object. This PR implements sorting for the objects keys following the order they were declared on the model schema.

I have made this PR previously (#16169), but I was closed due to the PR not following some contribution guidelines. I have tried by best to make this match our guidelines and hope this get merged.

Thank you.

Happy New Year!