### PR TITLE
feat: migrate schema queries to typescript

### DIFF
--- a/packages/core/src/dialects/abstract/index.ts
+++ b/packages/core/src/dialects/abstract/index.ts
@@ -245,6 +245,10 @@ export type DialectSupports = {
     ifNotExists: boolean,
     replace: boolean,
   },
+  dropSchema: {
+    cascade: boolean,
+    ifExists: boolean,
+  },
 };
 
 type TypeParser = (...params: any[]) => unknown;
@@ -397,6 +401,10 @@ export abstract class AbstractDialect {
       comment: false,
       ifNotExists: false,
       replace: false,
+    },
+    dropSchema: {
+      cascade: false,
+      ifExists: false,
     },
   };
 

--- a/packages/core/src/dialects/abstract/index.ts
+++ b/packages/core/src/dialects/abstract/index.ts
@@ -237,6 +237,14 @@ export type DialectSupports = {
     changeSchema: boolean,
     changeSchemaAndTable: boolean,
   },
+  createSchema: {
+    authorization: boolean,
+    charset: boolean,
+    collate: boolean,
+    comment: boolean,
+    ifNotExists: boolean,
+    replace: boolean,
+  },
 };
 
 type TypeParser = (...params: any[]) => unknown;
@@ -381,6 +389,14 @@ export abstract class AbstractDialect {
     renameTable: {
       changeSchema: true,
       changeSchemaAndTable: true,
+    },
+    createSchema: {
+      authorization: false,
+      charset: false,
+      collate: false,
+      comment: false,
+      ifNotExists: false,
+      replace: false,
     },
   };
 

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -37,6 +37,7 @@ import type {
   AddLimitOffsetOptions,
   CreateDatabaseQueryOptions,
   CreateSchemaQueryOptions,
+  DropSchemaQueryOptions,
   DropTableQueryOptions,
   GetConstraintSnippetQueryOptions,
   ListDatabasesQueryOptions,
@@ -64,6 +65,7 @@ export interface RemoveIndexQueryOptions {
 
 export const CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['charset', 'collate', 'ctype', 'encoding', 'template']);
 export const CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof CreateSchemaQueryOptions>(['authorization', 'charset', 'collate', 'comment', 'ifNotExists', 'replace']);
+export const DROP_SCHEMA_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof DropSchemaQueryOptions>(['cascade', 'ifExists']);
 export const DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof DropTableQueryOptions>(['cascade']);
 export const LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ListDatabasesQueryOptions>(['skip']);
 export const LIST_TABLES_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ListTablesQueryOptions>(['schema']);
@@ -237,6 +239,38 @@ export class AbstractQueryGeneratorTypeScript {
       options?.charset ? `DEFAULT CHARACTER SET ${this.escape(options.charset)}` : '',
       options?.collate ? `DEFAULT COLLATE ${this.escape(options.collate)}` : '',
       options?.comment ? `COMMENT ${this.escape(options.comment)}` : '',
+    ]);
+  }
+
+  dropSchemaQuery(schemaName: string, options?: DropSchemaQueryOptions): string {
+    if (!this.dialect.supports.schemas) {
+      throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
+    }
+
+    if (options) {
+      const DROP_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set<keyof DropSchemaQueryOptions>();
+      if (this.dialect.supports.dropSchema.cascade) {
+        DROP_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('cascade');
+      }
+
+      if (this.dialect.supports.dropSchema.ifExists) {
+        DROP_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('ifExists');
+      }
+
+      rejectInvalidOptions(
+        'dropSchemaQuery',
+        this.dialect.name,
+        DROP_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
+        DROP_SCHEMA_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
+    return joinSQLFragments([
+      'DROP SCHEMA',
+      options?.ifExists ? 'IF EXISTS' : '',
+      this.quoteIdentifier(schemaName),
+      options?.cascade ? 'CASCADE' : '',
     ]);
   }
 

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -36,6 +36,7 @@ import type {
   AddConstraintQueryOptions,
   AddLimitOffsetOptions,
   CreateDatabaseQueryOptions,
+  CreateSchemaQueryOptions,
   DropTableQueryOptions,
   GetConstraintSnippetQueryOptions,
   ListDatabasesQueryOptions,
@@ -62,6 +63,7 @@ export interface RemoveIndexQueryOptions {
 }
 
 export const CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['charset', 'collate', 'ctype', 'encoding', 'template']);
+export const CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof CreateSchemaQueryOptions>(['authorization', 'charset', 'collate', 'comment', 'ifNotExists', 'replace']);
 export const DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof DropTableQueryOptions>(['cascade']);
 export const LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ListDatabasesQueryOptions>(['skip']);
 export const LIST_TABLES_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ListTablesQueryOptions>(['schema']);
@@ -181,6 +183,61 @@ export class AbstractQueryGeneratorTypeScript {
     }
 
     throw new Error(`Databases are not supported in ${this.dialect.name}.`);
+  }
+
+  createSchemaQuery(schemaName: string, options?: CreateSchemaQueryOptions): string {
+    if (!this.dialect.supports.schemas) {
+      throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
+    }
+
+    if (options) {
+      const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateSchemaQueryOptions>();
+      if (this.dialect.supports.createSchema.authorization) {
+        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('authorization');
+      }
+
+      if (this.dialect.supports.createSchema.charset) {
+        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('charset');
+      }
+
+      if (this.dialect.supports.createSchema.collate) {
+        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('collate');
+      }
+
+      if (this.dialect.supports.createSchema.comment) {
+        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('comment');
+      }
+
+      if (this.dialect.supports.createSchema.ifNotExists) {
+        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('ifNotExists');
+      }
+
+      if (this.dialect.supports.createSchema.replace) {
+        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS.add('replace');
+      }
+
+      rejectInvalidOptions(
+        'createSchemaQuery',
+        this.dialect.name,
+        CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
+        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
+    return joinSQLFragments([
+      'CREATE',
+      options?.replace ? 'OR REPLACE' : '',
+      'SCHEMA',
+      options?.ifNotExists ? 'IF NOT EXISTS' : '',
+      this.quoteIdentifier(schemaName),
+      options?.authorization
+        ? `AUTHORIZATION ${options.authorization instanceof Literal ? this.formatLiteral(options.authorization) : this.quoteIdentifier(options.authorization)}`
+        : '',
+      options?.charset ? `DEFAULT CHARACTER SET ${this.escape(options.charset)}` : '',
+      options?.collate ? `DEFAULT COLLATE ${this.escape(options.collate)}` : '',
+      options?.comment ? `COMMENT ${this.escape(options.comment)}` : '',
+    ]);
   }
 
   listSchemasQuery(_options?: ListSchemasQueryOptions): string {

--- a/packages/core/src/dialects/abstract/query-generator.d.ts
+++ b/packages/core/src/dialects/abstract/query-generator.d.ts
@@ -14,7 +14,7 @@ import type { Nullish } from '../../utils/types.js';
 import type { DataType } from './data-types.js';
 import type { QueryGeneratorOptions, TableNameOrModel } from './query-generator-typescript.js';
 import { AbstractQueryGeneratorTypeScript } from './query-generator-typescript.js';
-import type { AttributeToSqlOptions, QueryWithBindParams } from './query-generator.types.js';
+import type { AttributeToSqlOptions } from './query-generator.types.js';
 import type { TableName } from './query-interface.js';
 import type { ColumnsDescription } from './query-interface.types.js';
 import type { WhereOptions } from './where-sql-builder-types.js';
@@ -142,8 +142,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     columns: { [columnName: string]: string },
     options?: CreateTableQueryOptions
   ): string;
-
-  dropSchemaQuery(schemaName: string): string | QueryWithBindParams;
 
   /**
    * Creates a function that can be used to collect bind parameters.

--- a/packages/core/src/dialects/abstract/query-generator.d.ts
+++ b/packages/core/src/dialects/abstract/query-generator.d.ts
@@ -59,12 +59,6 @@ type ArithmeticQueryOptions = ParameterOptions & {
   returning?: boolean | Array<string | Literal | Col>,
 };
 
-// keep CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
-export interface CreateSchemaQueryOptions {
-  collate?: string;
-  charset?: string;
-}
-
 // keep CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
 export interface CreateTableQueryOptions {
   collate?: string;
@@ -149,7 +143,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     options?: CreateTableQueryOptions
   ): string;
 
-  createSchemaQuery(schemaName: string, options?: CreateSchemaQueryOptions): string;
   dropSchemaQuery(schemaName: string): string | QueryWithBindParams;
 
   /**

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -37,7 +37,6 @@ const { Op } = require('../../operators');
 const sequelizeError = require('../../errors');
 const { _validateIncludedElements } = require('../../model-internals');
 
-export const CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS = new Set(['collate', 'charset']);
 export const CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set(['collate', 'charset', 'engine', 'rowFormat', 'comment', 'initialAutoIncrement', 'uniqueKeys']);
 export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
 
@@ -47,14 +46,6 @@ export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
  * @private
  */
 export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
-  createSchemaQuery() {
-    if (this.dialect.supports.schemas) {
-      throw new Error(`${this.dialect.name} declares supporting schema but createSchemaQuery is not implemented.`);
-    }
-
-    throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
-  }
-
   dropSchemaQuery() {
     if (this.dialect.supports.schemas) {
       throw new Error(`${this.dialect.name} declares supporting schema but dropSchemaQuery is not implemented.`);

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -46,14 +46,6 @@ export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
  * @private
  */
 export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
-  dropSchemaQuery() {
-    if (this.dialect.supports.schemas) {
-      throw new Error(`${this.dialect.name} declares supporting schema but dropSchemaQuery is not implemented.`);
-    }
-
-    throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
-  }
-
   /**
    * Returns an insert into command
    *

--- a/packages/core/src/dialects/abstract/query-generator.types.ts
+++ b/packages/core/src/dialects/abstract/query-generator.types.ts
@@ -28,6 +28,16 @@ export interface ListDatabasesQueryOptions {
   skip?: string[];
 }
 
+// keep CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
+export interface CreateSchemaQueryOptions {
+  authorization?: string | Literal;
+  charset?: string;
+  collate?: string;
+  comment?: string;
+  ifNotExists?: boolean;
+  replace?: boolean;
+}
+
 export interface ListSchemasQueryOptions {
   /** List of schemas to exclude from output */
   skip?: string[];

--- a/packages/core/src/dialects/abstract/query-generator.types.ts
+++ b/packages/core/src/dialects/abstract/query-generator.types.ts
@@ -38,6 +38,12 @@ export interface CreateSchemaQueryOptions {
   replace?: boolean;
 }
 
+// keep DROP_SCHEMA_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
+export interface DropSchemaQueryOptions {
+  cascade?: boolean;
+  ifExists?: boolean;
+}
+
 export interface ListSchemasQueryOptions {
   /** List of schemas to exclude from output */
   skip?: string[];

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -15,7 +15,6 @@ import {
 import type { Connection } from './connection-manager.js';
 import type { AbstractQueryGenerator } from './query-generator';
 import type { TableNameOrModel } from './query-generator-typescript.js';
-import type { QueryWithBindParams } from './query-generator.types';
 import { AbstractQueryInterfaceInternal } from './query-interface-internal.js';
 import type { TableNameWithSchema } from './query-interface.js';
 import type {
@@ -27,6 +26,7 @@ import type {
   DatabaseDescription,
   DeferConstraintsOptions,
   DescribeTableOptions,
+  DropSchemaOptions,
   FetchDatabaseVersionOptions,
   ListDatabasesOptions,
   QiDropAllTablesOptions,
@@ -139,20 +139,9 @@ export class AbstractQueryInterfaceTypeScript {
    * @param schema Name of the schema
    * @param options
    */
-  async dropSchema(schema: string, options?: QueryRawOptions): Promise<void> {
-    const dropSchemaQuery: string | QueryWithBindParams = this.queryGenerator.dropSchemaQuery(schema);
-
-    let sql: string;
-    let queryRawOptions: undefined | QueryRawOptions;
-    if (typeof dropSchemaQuery === 'string') {
-      sql = dropSchemaQuery;
-      queryRawOptions = options;
-    } else {
-      sql = dropSchemaQuery.query;
-      queryRawOptions = { ...options, bind: dropSchemaQuery.bind };
-    }
-
-    await this.sequelize.queryRaw(sql, queryRawOptions);
+  async dropSchema(schema: string, options?: DropSchemaOptions): Promise<void> {
+    const sql = this.queryGenerator.dropSchemaQuery(schema, options);
+    await this.sequelize.queryRaw(sql, options);
   }
 
   /**

--- a/packages/core/src/dialects/abstract/query-interface.d.ts
+++ b/packages/core/src/dialects/abstract/query-interface.d.ts
@@ -19,7 +19,7 @@ import type { RemoveIndexQueryOptions, TableNameOrModel } from './query-generato
 import type { AbstractQueryGenerator, AddColumnQueryOptions } from './query-generator.js';
 import type { AddLimitOffsetOptions } from './query-generator.types.js';
 import { AbstractQueryInterfaceTypeScript } from './query-interface-typescript';
-import type { ColumnsDescription, QiDropAllSchemasOptions } from './query-interface.types.js';
+import type { ColumnsDescription } from './query-interface.types.js';
 import type { WhereOptions } from './where-sql-builder-types.js';
 
 interface Replaceable {
@@ -245,11 +245,6 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
    * Returns the current sequelize instance.
    */
   sequelize: Sequelize;
-
-  /**
-   * Drops all tables
-   */
-  dropAllSchemas(options?: QiDropAllSchemasOptions): Promise<void>;
 
   /**
    * Creates a table with specified attributes.

--- a/packages/core/src/dialects/abstract/query-interface.js
+++ b/packages/core/src/dialects/abstract/query-interface.js
@@ -22,26 +22,6 @@ const { QueryTypes } = require('../../query-types');
  */
 export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   /**
-    * Drop all schemas
-    *
-    * @param {object} [options] Query options
-    *
-    * @returns {Promise}
-    */
-
-  async dropAllSchemas(options) {
-    options = options || {};
-
-    if (!this.sequelize.dialect.supports.schemas) {
-      return this.sequelize.drop(options);
-    }
-
-    const schemas = await this.listSchemas(options);
-
-    return Promise.all(schemas.map(schemaName => this.dropSchema(schemaName, options)));
-  }
-
-  /**
    * Create a table with given set of attributes
    *
    * ```js

--- a/packages/core/src/dialects/abstract/query-interface.types.ts
+++ b/packages/core/src/dialects/abstract/query-interface.types.ts
@@ -4,6 +4,7 @@ import type {
   AddConstraintQueryOptions,
   CreateDatabaseQueryOptions,
   CreateSchemaQueryOptions,
+  DropSchemaQueryOptions,
   DropTableQueryOptions,
   ListDatabasesQueryOptions,
   ListSchemasQueryOptions,
@@ -76,6 +77,9 @@ export interface ListDatabasesOptions extends ListDatabasesQueryOptions, QueryRa
 
 /** Options accepted by {@link AbstractQueryInterface#createSchema} */
 export interface CreateSchemaOptions extends CreateSchemaQueryOptions, QueryRawOptions { }
+
+/** Options accepted by {@link AbstractQueryInterface#dropSchema} */
+export interface DropSchemaOptions extends DropSchemaQueryOptions, QueryRawOptions { }
 
 /** Options accepted by {@link AbstractQueryInterface#listSchemas} */
 export interface QiListSchemasOptions extends ListSchemasQueryOptions, QueryRawOptions { }

--- a/packages/core/src/dialects/abstract/query-interface.types.ts
+++ b/packages/core/src/dialects/abstract/query-interface.types.ts
@@ -1,9 +1,9 @@
 import type { Deferrable } from '../../deferrable';
 import type { QueryRawOptions } from '../../sequelize';
-import type { CreateSchemaQueryOptions } from './query-generator';
 import type {
   AddConstraintQueryOptions,
   CreateDatabaseQueryOptions,
+  CreateSchemaQueryOptions,
   DropTableQueryOptions,
   ListDatabasesQueryOptions,
   ListSchemasQueryOptions,

--- a/packages/core/src/dialects/abstract/query-interface.types.ts
+++ b/packages/core/src/dialects/abstract/query-interface.types.ts
@@ -85,7 +85,7 @@ export interface DropSchemaOptions extends DropSchemaQueryOptions, QueryRawOptio
 export interface QiListSchemasOptions extends ListSchemasQueryOptions, QueryRawOptions { }
 
 /** Options accepted by {@link AbstractQueryInterface#dropAllSchemas} */
-export interface QiDropAllSchemasOptions extends QueryRawOptions {
+export interface QiDropAllSchemasOptions extends DropSchemaOptions, QueryRawOptions {
   /**
    * List of schemas to skip dropping (i.e., list of schemas to keep)
    */

--- a/packages/core/src/dialects/abstract/query-interface.types.ts
+++ b/packages/core/src/dialects/abstract/query-interface.types.ts
@@ -111,7 +111,7 @@ export interface DescribeTableOptions extends QueryRawOptions {
 export interface QiDropTableOptions extends DropTableQueryOptions, QueryRawOptions { }
 
 /** Options accepted by {@link AbstractQueryInterface#dropAllTables} */
-export interface QiDropAllTablesOptions extends QiDropTableOptions {
+export interface QiDropAllTablesOptions extends ListTablesQueryOptions, QiDropTableOptions {
   skip?: string[];
 }
 

--- a/packages/core/src/dialects/db2/index.ts
+++ b/packages/core/src/dialects/db2/index.ts
@@ -41,6 +41,9 @@ export class Db2Dialect extends AbstractDialect {
       changeSchema: false,
       changeSchemaAndTable: false,
     },
+    createSchema: {
+      authorization: true,
+    },
   });
 
   readonly defaultVersion = '1.0.0';

--- a/packages/core/src/dialects/db2/query-generator-typescript.ts
+++ b/packages/core/src/dialects/db2/query-generator-typescript.ts
@@ -3,12 +3,14 @@ import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
 import {
+  DROP_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
   REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
   RENAME_TABLE_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import type {
   AddLimitOffsetOptions,
+  DropSchemaQueryOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   RenameTableQueryOptions,
@@ -16,6 +18,7 @@ import type {
 } from '../abstract/query-generator.types';
 import type { ConstraintType } from '../abstract/query-interface.types';
 
+const DROP_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set<keyof DropSchemaQueryOptions>();
 const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
 const RENAME_TABLE_QUERY_SUPPORTED_OPTIONS = new Set<keyof RenameTableQueryOptions>();
 
@@ -25,6 +28,20 @@ const RENAME_TABLE_QUERY_SUPPORTED_OPTIONS = new Set<keyof RenameTableQueryOptio
 export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
   protected _getTechnicalSchemaNames() {
     return ['ERRORSCHEMA', 'NULLID', 'SQLJ'];
+  }
+
+  dropSchemaQuery(schemaName: string, options?: DropSchemaQueryOptions): string {
+    if (options) {
+      rejectInvalidOptions(
+        'dropSchemaQuery',
+        this.dialect.name,
+        DROP_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
+        DROP_SCHEMA_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
+    return `DROP SCHEMA ${this.quoteIdentifier(schemaName)} RESTRICT`;
   }
 
   listSchemasQuery(options?: ListSchemasQueryOptions) {

--- a/packages/core/src/dialects/db2/query-generator.js
+++ b/packages/core/src/dialects/db2/query-generator.js
@@ -5,11 +5,7 @@ import { removeNullishValuesFromHash } from '../../utils/format';
 import { removeTrailingSemicolon } from '../../utils/string';
 import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
-import {
-  ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator';
+import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS, CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 import { Db2QueryGeneratorTypeScript } from './query-generator-typescript';
 
 import defaults from 'lodash/defaults';
@@ -26,7 +22,6 @@ const DataTypes = require('../../data-types');
 const randomBytes = require('node:crypto').randomBytes;
 const { Op } = require('../../operators');
 
-const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
 
@@ -43,20 +38,6 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     this.whereSqlBuilder.setOperatorKeyword(Op.notRegexp, 'NOT REGEXP_LIKE');
 
     this.autoGenValue = 1;
-  }
-
-  createSchemaQuery(schema, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createSchemaQuery',
-        this.dialect.name,
-        CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    return `CREATE SCHEMA ${this.quoteIdentifier(schema)};`;
   }
 
   _errorTableCount = 0;

--- a/packages/core/src/dialects/db2/query-generator.js
+++ b/packages/core/src/dialects/db2/query-generator.js
@@ -40,27 +40,6 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     this.autoGenValue = 1;
   }
 
-  _errorTableCount = 0;
-
-  dropSchemaQuery(schema) {
-    // DROP SCHEMA Can't drop schema if it is not empty.
-    // DROP SCHEMA Can't drop objects belonging to the schema
-    // So, call the admin procedure to drop schema.
-    const query = `CALL SYSPROC.ADMIN_DROP_SCHEMA(${this.escape(schema.trim())}, NULL, $sequelize_errorSchema, $sequelize_errorTable)`;
-
-    if (this._errorTableCount >= Number.MAX_SAFE_INTEGER) {
-      this._errorTableCount = 0;
-    }
-
-    return {
-      query,
-      bind: {
-        sequelize_errorSchema: { ParamType: 'INOUT', Data: 'ERRORSCHEMA' },
-        sequelize_errorTable: { ParamType: 'INOUT', Data: `ERRORTABLE${this._errorTableCount++}` },
-      },
-    };
-  }
-
   createTableQuery(tableName, attributes, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/db2/query-interface-typescript.ts
+++ b/packages/core/src/dialects/db2/query-interface-typescript.ts
@@ -1,0 +1,43 @@
+import { QueryTypes } from '../../query-types';
+import { AbstractQueryInterface } from '../abstract/query-interface';
+import type { QiDropAllSchemasOptions } from '../abstract/query-interface.types';
+
+export class Db2QueryInterfaceTypeScript extends AbstractQueryInterface {
+  async dropAllSchemas(options?: QiDropAllSchemasOptions): Promise<void> {
+    const skip = options?.skip || [];
+    const allSchemas = await this.listSchemas(options);
+    const schemaNames = allSchemas.filter(schemaName => !skip.includes(schemaName));
+
+    // if the dialect does not support "cascade", then drop all tables and routines first in a loop to avoid deadlocks and timeouts
+    if (options?.cascade === undefined) {
+      for (const schema of schemaNames) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.dropAllTables({ ...options, schema });
+
+        // In Db2 the routines are scoped to the schema, so we need to drop them separately for each schema
+        // eslint-disable-next-line no-await-in-loop
+        const routines = await this.sequelize.queryRaw<{ ROUTINENAME: string, ROUTINETYPE: 'F' | 'M' | 'P' }>(`SELECT ROUTINENAME, ROUTINETYPE FROM SYSCAT.ROUTINES WHERE ROUTINESCHEMA = ${this.queryGenerator.escape(schema)}`, {
+          ...options,
+          type: QueryTypes.SELECT,
+        });
+        for (const routine of routines) {
+          const type = routine.ROUTINETYPE === 'F'
+          ? 'FUNCTION'
+          : routine.ROUTINETYPE === 'P'
+          ? 'PROCEDURE'
+          : routine.ROUTINETYPE === 'M'
+          ? 'METHOD'
+          : '';
+          // eslint-disable-next-line no-await-in-loop
+          await this.sequelize.queryRaw(`DROP ${type} ${this.quoteIdentifier(schema)}.${this.quoteIdentifier(routine.ROUTINENAME)}`, options);
+        }
+      }
+    }
+
+    // Drop all the schemas in a loop to avoid deadlocks and timeouts
+    for (const schema of schemaNames) {
+      // eslint-disable-next-line no-await-in-loop
+      await this.dropSchema(schema, options);
+    }
+  }
+}

--- a/packages/core/src/dialects/db2/query-interface.d.ts
+++ b/packages/core/src/dialects/db2/query-interface.d.ts
@@ -1,8 +1,8 @@
 import type { Sequelize } from '../../sequelize.js';
-import { AbstractQueryInterface } from '../abstract/query-interface.js';
 import type { Db2QueryGenerator } from './query-generator.js';
+import { Db2QueryInterfaceTypeScript } from './query-interface-typescript.js';
 
-export class Db2QueryInterface extends AbstractQueryInterface {
+export class Db2QueryInterface extends Db2QueryInterfaceTypeScript {
   queryGenerator: Db2QueryGenerator;
 
   constructor(sequelize: Sequelize, queryGenerator: Db2QueryGenerator);

--- a/packages/core/src/dialects/db2/query-interface.js
+++ b/packages/core/src/dialects/db2/query-interface.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import { AggregateError, BaseError, DatabaseError } from '../../errors';
 import { isWhereEmpty } from '../../utils/query-builder-utils';
 import { assertNoReservedBind } from '../../utils/sql';
+import { Db2QueryInterfaceTypeScript } from './query-interface-typescript';
 
 import clone from 'lodash/clone';
 import intersection from 'lodash/intersection';
@@ -10,13 +10,12 @@ import isPlainObject from 'lodash/isPlainObject';
 import mapValues from 'lodash/mapValues';
 
 const { Op } = require('../../operators');
-const { AbstractQueryInterface } = require('../abstract/query-interface');
 const { QueryTypes } = require('../../query-types');
 
 /**
  * The interface that Sequelize uses to talk with Db2 database
  */
-export class Db2QueryInterface extends AbstractQueryInterface {
+export class Db2QueryInterface extends Db2QueryInterfaceTypeScript {
   async upsert(tableName, insertValues, updateValues, where, options) {
     if (options.bind) {
       assertNoReservedBind(options.bind);
@@ -75,61 +74,6 @@ export class Db2QueryInterface extends AbstractQueryInterface {
     const result = await this.sequelize.queryRaw(sql, options);
 
     return [result, undefined];
-  }
-
-  async dropSchema(schema, options) {
-    const outParams = new Map();
-
-    // DROP SCHEMA works in a weird way in DB2:
-    // Its query uses ADMIN_DROP_SCHEMA, which stores the error message in a table
-    // specified by two IN-OUT parameters.
-    // If the returned values for these parameters is not null, then an error occurred.
-    const response = await super.dropSchema(schema, {
-      ...options,
-      // TODO: db2 supports out parameters. We don't have a proper API for it yet
-      //   for now, this temporary API will have to do.
-      _unsafe_db2Outparams: outParams,
-    });
-
-    const errorTable = outParams.get('sequelize_errorTable');
-    if (errorTable != null) {
-      const errorSchema = outParams.get('sequelize_errorSchema');
-
-      const errorData = await this.sequelize.queryRaw(`SELECT * FROM "${errorSchema}"."${errorTable}"`, {
-        type: QueryTypes.SELECT,
-      });
-
-      // replicate the data ibm_db adds on an error object
-      const error = new Error(errorData[0].DIAGTEXT);
-      error.sqlcode = errorData[0].SQLCODE;
-      error.sql = errorData[0].STATEMENT;
-      error.state = errorData[0].SQLSTATE;
-
-      const wrappedError = new DatabaseError(error);
-
-      try {
-        await this.dropTable({
-          tableName: errorTable,
-          schema: errorSchema,
-        });
-      } catch (dropError) {
-        throw new AggregateError([
-          wrappedError,
-          new BaseError(`An error occurred while cleaning up table ${errorSchema}.${errorTable}`, { cause: dropError }),
-        ]);
-      }
-
-      // -204 is "name is undefined" (schema does not exist)
-      // 'queryInterface.dropSchema' is supposed to be DROP SCHEMA IF EXISTS
-      // so we can ignore this error
-      if (error.sqlcode === -204 && error.state === '42704') {
-        return response;
-      }
-
-      throw wrappedError;
-    }
-
-    return response;
   }
 
   // TODO: drop "schema" options from the option bag, it must be passed through tableName instead.

--- a/packages/core/src/dialects/db2/query.js
+++ b/packages/core/src/dialects/db2/query.js
@@ -229,10 +229,9 @@ export class Db2Query extends AbstractQuery {
    * @param {Array} data - The result of the query execution.
    * @param {Integer} rowCount - The number of affected rows.
    * @param {Array} metadata - Metadata of the returned result set.
-   * @param {object} conn - The connection object.
    * @private
    */
-  formatResults(data, rowCount, metadata, conn) {
+  formatResults(data, rowCount, metadata) {
     let result = this.instance;
     if (this.isInsertQuery(data, metadata)) {
       this.handleInsertQuery(data, metadata);
@@ -269,12 +268,6 @@ export class Db2Query extends AbstractQuery {
       result = this.handleSelectQuery(data);
     } else if (this.isUpsertQuery()) {
       result = data;
-    } else if (this.isDropSchemaQuery()) {
-      result = data[0];
-      if (conn) {
-        const query = 'DROP TABLE ERRORSCHEMA.ERRORTABLE';
-        conn.querySync(query);
-      }
     } else if (this.isCallQuery()) {
       result = data;
     } else if (this.isBulkUpdateQuery()) {
@@ -386,16 +379,6 @@ export class Db2Query extends AbstractQuery {
     }
 
     return new sequelizeErrors.DatabaseError(err);
-  }
-
-  isDropSchemaQuery() {
-    let result = false;
-
-    if (this.sql.startsWith('CALL SYSPROC.ADMIN_DROP_SCHEMA')) {
-      result = true;
-    }
-
-    return result;
   }
 
   isShowOrDescribeQuery() {

--- a/packages/core/src/dialects/db2/query.js
+++ b/packages/core/src/dialects/db2/query.js
@@ -180,7 +180,7 @@ export class Db2Query extends AbstractQuery {
         data.unshift(outparams);
       }
 
-      return this.formatResults(data, datalen, metadata, connection);
+      return this.formatResults(data, datalen, metadata);
     }
 
     return this.formatResults(data, affectedRows);

--- a/packages/core/src/dialects/ibmi/index.ts
+++ b/packages/core/src/dialects/ibmi/index.ts
@@ -38,6 +38,9 @@ export class IBMiDialect extends AbstractDialect {
         changeSchema: false,
         changeSchemaAndTable: false,
       },
+      createSchema: {
+        authorization: true,
+      },
     },
   );
 

--- a/packages/core/src/dialects/ibmi/index.ts
+++ b/packages/core/src/dialects/ibmi/index.ts
@@ -41,6 +41,10 @@ export class IBMiDialect extends AbstractDialect {
       createSchema: {
         authorization: true,
       },
+      dropSchema: {
+        cascade: true,
+        ifExists: true,
+      },
     },
   );
 

--- a/packages/core/src/dialects/ibmi/query-generator.js
+++ b/packages/core/src/dialects/ibmi/query-generator.js
@@ -6,11 +6,7 @@ import { rejectInvalidOptions } from '../../utils/check';
 import { nameIndex, removeTrailingSemicolon } from '../../utils/string';
 import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
-import {
-  ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator';
+import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS, CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 
 import each from 'lodash/each';
 import isPlainObject from 'lodash/isPlainObject';
@@ -21,26 +17,10 @@ const DataTypes = require('../../data-types');
 
 const typeWithoutDefault = new Set(['BLOB']);
 
-const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
-  // Schema queries
-  createSchemaQuery(schema, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createSchemaQuery',
-        this.dialect.name,
-        CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    return `CREATE SCHEMA "${schema}"`;
-  }
-
   dropSchemaQuery(schema) {
     return `BEGIN IF EXISTS (SELECT * FROM SYSIBM.SQLSCHEMAS WHERE TABLE_SCHEM = ${schema ? `'${schema}'` : 'CURRENT SCHEMA'}) THEN SET TRANSACTION ISOLATION LEVEL NO COMMIT; DROP SCHEMA "${schema ? `${schema}` : 'CURRENT SCHEMA'}"; COMMIT; END IF; END`;
   }

--- a/packages/core/src/dialects/ibmi/query-generator.js
+++ b/packages/core/src/dialects/ibmi/query-generator.js
@@ -21,10 +21,6 @@ const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
-  dropSchemaQuery(schema) {
-    return `BEGIN IF EXISTS (SELECT * FROM SYSIBM.SQLSCHEMAS WHERE TABLE_SCHEM = ${schema ? `'${schema}'` : 'CURRENT SCHEMA'}) THEN SET TRANSACTION ISOLATION LEVEL NO COMMIT; DROP SCHEMA "${schema ? `${schema}` : 'CURRENT SCHEMA'}"; COMMIT; END IF; END`;
-  }
-
   // Table queries
   createTableQuery(tableName, attributes, options) {
     if (options) {

--- a/packages/core/src/dialects/mariadb/index.ts
+++ b/packages/core/src/dialects/mariadb/index.ts
@@ -64,7 +64,7 @@ export class MariaDbDialect extends AbstractDialect {
       createSchema: {
         charset: true,
         collate: true,
-        // TODO: uncomment when MariaDB 10.5 is oldest supported version
+        // TODO [>=2024-06-19]: uncomment when MariaDB 10.5 is oldest supported version
         // comment: true,
         ifNotExists: true,
         replace: true,

--- a/packages/core/src/dialects/mariadb/index.ts
+++ b/packages/core/src/dialects/mariadb/index.ts
@@ -68,6 +68,9 @@ export class MariaDbDialect extends AbstractDialect {
         ifNotExists: true,
         replace: true,
       },
+      dropSchema: {
+        ifExists: true,
+      },
     },
   );
 

--- a/packages/core/src/dialects/mariadb/index.ts
+++ b/packages/core/src/dialects/mariadb/index.ts
@@ -64,7 +64,8 @@ export class MariaDbDialect extends AbstractDialect {
       createSchema: {
         charset: true,
         collate: true,
-        comment: true,
+        // TODO: uncomment when MariaDB 10.5 is oldest supported version
+        // comment: true,
         ifNotExists: true,
         replace: true,
       },

--- a/packages/core/src/dialects/mariadb/index.ts
+++ b/packages/core/src/dialects/mariadb/index.ts
@@ -61,6 +61,13 @@ export class MariaDbDialect extends AbstractDialect {
       removeColumn: {
         ifExists: true,
       },
+      createSchema: {
+        charset: true,
+        collate: true,
+        comment: true,
+        ifNotExists: true,
+        replace: true,
+      },
     },
   );
 

--- a/packages/core/src/dialects/mariadb/query-generator.js
+++ b/packages/core/src/dialects/mariadb/query-generator.js
@@ -13,16 +13,6 @@ const { MariaDbQueryGeneratorTypeScript } = require('./query-generator-typescrip
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
-  createSchemaQuery(schemaName, options) {
-    return joinSQLFragments([
-      'CREATE SCHEMA IF NOT EXISTS',
-      this.quoteIdentifier(schemaName),
-      options?.charset && `DEFAULT CHARACTER SET ${this.escape(options.charset)}`,
-      options?.collate && `DEFAULT COLLATE ${this.escape(options.collate)}`,
-      ';',
-    ]);
-  }
-
   dropSchemaQuery(schemaName) {
     return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schemaName)};`;
   }

--- a/packages/core/src/dialects/mariadb/query-generator.js
+++ b/packages/core/src/dialects/mariadb/query-generator.js
@@ -13,10 +13,6 @@ const { MariaDbQueryGeneratorTypeScript } = require('./query-generator-typescrip
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
-  dropSchemaQuery(schemaName) {
-    return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schemaName)};`;
-  }
-
   createTableQuery(tableName, attributes, options) {
     options = {
       engine: 'InnoDB',

--- a/packages/core/src/dialects/mssql/index.ts
+++ b/packages/core/src/dialects/mssql/index.ts
@@ -56,6 +56,9 @@ export class MssqlDialect extends AbstractDialect {
     renameTable: {
       changeSchemaAndTable: false,
     },
+    createSchema: {
+      authorization: true,
+    },
   });
 
   readonly connectionManager: MsSqlConnectionManager;

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -5,11 +5,7 @@ import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { generateIndexName } from '../../utils/string';
 import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
-import {
-  ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator';
+import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS, CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 
 import each from 'lodash/each';
 import forOwn from 'lodash/forOwn';
@@ -26,34 +22,10 @@ function throwMethodUndefined(methodName) {
   throw new Error(`The method "${methodName}" is not defined! Please add it to your sql dialect.`);
 }
 
-const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
-  createSchemaQuery(schema, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createSchemaQuery',
-        this.dialect.name,
-        CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    return [
-      'IF NOT EXISTS (SELECT schema_name',
-      'FROM information_schema.schemata',
-      'WHERE schema_name =', this.escape(schema), ')',
-      'BEGIN',
-      'EXEC sp_executesql N\'CREATE SCHEMA',
-      this.quoteIdentifier(schema),
-      ';\'',
-      'END;',
-    ].join(' ');
-  }
-
   dropSchemaQuery(schema) {
     // Mimics Postgres CASCADE, will drop objects belonging to the schema
     const quotedSchema = this.escape(schema);

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -26,42 +26,6 @@ const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
-  dropSchemaQuery(schema) {
-    // Mimics Postgres CASCADE, will drop objects belonging to the schema
-    const quotedSchema = this.escape(schema);
-
-    return [
-      'IF EXISTS (SELECT schema_name',
-      'FROM information_schema.schemata',
-      'WHERE schema_name =', quotedSchema, ')',
-      'BEGIN',
-      'DECLARE @id INT, @ms_sql NVARCHAR(2000);',
-      'DECLARE @cascade TABLE (',
-      'id INT NOT NULL IDENTITY PRIMARY KEY,',
-      'ms_sql NVARCHAR(2000) NOT NULL );',
-      'INSERT INTO @cascade ( ms_sql )',
-      'SELECT CASE WHEN o.type IN (\'F\',\'PK\')',
-      'THEN N\'ALTER TABLE [\'+ s.name + N\'].[\' + p.name + N\'] DROP CONSTRAINT [\' + o.name + N\']\'',
-      'ELSE N\'DROP TABLE [\'+ s.name + N\'].[\' + o.name + N\']\' END',
-      'FROM sys.objects o',
-      'JOIN sys.schemas s on o.schema_id = s.schema_id',
-      'LEFT OUTER JOIN sys.objects p on o.parent_object_id = p.object_id',
-      'WHERE o.type IN (\'F\', \'PK\', \'U\') AND s.name = ', quotedSchema,
-      'ORDER BY o.type ASC;',
-      'SELECT TOP 1 @id = id, @ms_sql = ms_sql FROM @cascade ORDER BY id;',
-      'WHILE @id IS NOT NULL',
-      'BEGIN',
-      'BEGIN TRY EXEC sp_executesql @ms_sql; END TRY',
-      'BEGIN CATCH BREAK; THROW; END CATCH;',
-      'DELETE FROM @cascade WHERE id = @id;',
-      'SELECT @id = NULL, @ms_sql = NULL;',
-      'SELECT TOP 1 @id = id, @ms_sql = ms_sql FROM @cascade ORDER BY id;',
-      'END',
-      'EXEC sp_executesql N\'DROP SCHEMA', this.quoteIdentifier(schema), ';\'',
-      'END;',
-    ].join(' ');
-  }
-
   createTableQuery(tableName, attributes, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/mysql/index.ts
+++ b/packages/core/src/dialects/mysql/index.ts
@@ -62,6 +62,11 @@ export class MysqlDialect extends AbstractDialect {
       maxExecutionTimeHint: {
         select: true,
       },
+      createSchema: {
+        charset: true,
+        collate: true,
+        ifNotExists: true,
+      },
     },
   );
 

--- a/packages/core/src/dialects/mysql/index.ts
+++ b/packages/core/src/dialects/mysql/index.ts
@@ -67,6 +67,9 @@ export class MysqlDialect extends AbstractDialect {
         collate: true,
         ifNotExists: true,
       },
+      dropSchema: {
+        ifExists: true,
+      },
     },
   );
 

--- a/packages/core/src/dialects/mysql/query-generator.js
+++ b/packages/core/src/dialects/mysql/query-generator.js
@@ -17,10 +17,6 @@ const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
-  dropSchemaQuery(schemaName) {
-    return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schemaName)};`;
-  }
-
   createTableQuery(tableName, attributes, options) {
     options = {
       engine: 'InnoDB',

--- a/packages/core/src/dialects/mysql/query-generator.js
+++ b/packages/core/src/dialects/mysql/query-generator.js
@@ -17,16 +17,6 @@ const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
-  createSchemaQuery(schemaName, options) {
-    return joinSQLFragments([
-      'CREATE SCHEMA IF NOT EXISTS',
-      this.quoteIdentifier(schemaName),
-      options?.charset && `DEFAULT CHARACTER SET ${this.escape(options.charset)}`,
-      options?.collate && `DEFAULT COLLATE ${this.escape(options.collate)}`,
-      ';',
-    ]);
-  }
-
   dropSchemaQuery(schemaName) {
     return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schemaName)};`;
   }

--- a/packages/core/src/dialects/postgres/index.ts
+++ b/packages/core/src/dialects/postgres/index.ts
@@ -89,6 +89,10 @@ export class PostgresDialect extends AbstractDialect {
       authorization: true,
       ifNotExists: true,
     },
+    dropSchema: {
+      cascade: true,
+      ifExists: true,
+    },
   });
 
   readonly connectionManager: PostgresConnectionManager;

--- a/packages/core/src/dialects/postgres/index.ts
+++ b/packages/core/src/dialects/postgres/index.ts
@@ -85,6 +85,10 @@ export class PostgresDialect extends AbstractDialect {
     renameTable: {
       changeSchemaAndTable: false,
     },
+    createSchema: {
+      authorization: true,
+      ifNotExists: true,
+    },
   });
 
   readonly connectionManager: PostgresConnectionManager;

--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -6,10 +6,7 @@ import { generateIndexName } from '../../utils/string';
 import { ENUM } from './data-types';
 import { quoteIdentifier } from '../../utils/dialect';
 import { rejectInvalidOptions } from '../../utils/check';
-import {
-  CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator';
+import { CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 
 import each from 'lodash/each';
 import isEmpty from 'lodash/isEmpty';
@@ -28,26 +25,11 @@ const { PostgresQueryGeneratorTypeScript } = require('./query-generator-typescri
  */
 const POSTGRES_RESERVED_WORDS = 'all,analyse,analyze,and,any,array,as,asc,asymmetric,authorization,binary,both,case,cast,check,collate,collation,column,concurrently,constraint,create,cross,current_catalog,current_date,current_role,current_schema,current_time,current_timestamp,current_user,default,deferrable,desc,distinct,do,else,end,except,false,fetch,for,foreign,freeze,from,full,grant,group,having,ilike,in,initially,inner,intersect,into,is,isnull,join,lateral,leading,left,like,limit,localtime,localtimestamp,natural,not,notnull,null,offset,on,only,or,order,outer,overlaps,placing,primary,references,returning,right,select,session_user,similar,some,symmetric,table,tablesample,then,to,trailing,true,union,unique,user,using,variadic,verbose,when,where,window,with'.split(',');
 
-const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['comment', 'uniqueKeys']);
 
 export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   setSearchPath(searchPath) {
     return `SET search_path to ${searchPath};`;
-  }
-
-  createSchemaQuery(schema, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createSchemaQuery',
-        this.dialect.name,
-        CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    return `CREATE SCHEMA IF NOT EXISTS ${this.quoteIdentifier(schema)};`;
   }
 
   dropSchemaQuery(schema) {

--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -32,10 +32,6 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     return `SET search_path to ${searchPath};`;
   }
 
-  dropSchemaQuery(schema) {
-    return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schema)} CASCADE;`;
-  }
-
   createTableQuery(tableName, attributes, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/snowflake/index.ts
+++ b/packages/core/src/dialects/snowflake/index.ts
@@ -44,6 +44,11 @@ export class SnowflakeDialect extends AbstractDialect {
     dropTable: {
       cascade: true,
     },
+    createSchema: {
+      comment: true,
+      ifNotExists: true,
+      replace: true,
+    },
   });
 
   readonly dataTypesDocumentationUrl = 'https://docs.snowflake.com/en/sql-reference/data-types.html';

--- a/packages/core/src/dialects/snowflake/index.ts
+++ b/packages/core/src/dialects/snowflake/index.ts
@@ -49,6 +49,10 @@ export class SnowflakeDialect extends AbstractDialect {
       ifNotExists: true,
       replace: true,
     },
+    dropSchema: {
+      cascade: true,
+      ifExists: true,
+    },
   });
 
   readonly dataTypesDocumentationUrl = 'https://docs.snowflake.com/en/sql-reference/data-types.html';

--- a/packages/core/src/dialects/snowflake/query-generator.js
+++ b/packages/core/src/dialects/snowflake/query-generator.js
@@ -5,11 +5,7 @@ import { EMPTY_OBJECT } from '../../utils/object.js';
 import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { quoteIdentifier } from '../../utils/dialect.js';
 import { rejectInvalidOptions } from '../../utils/check';
-import {
-  ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator';
+import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS, CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 
 import each from 'lodash/each';
 import isPlainObject from 'lodash/isPlainObject';
@@ -28,7 +24,6 @@ const SNOWFLAKE_RESERVED_WORDS = 'account,all,alter,and,any,as,between,by,case,c
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
-const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['comment', 'uniqueKeys']);
 
 export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
@@ -37,20 +32,6 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
 
     this.whereSqlBuilder.setOperatorKeyword(Op.regexp, 'REGEXP');
     this.whereSqlBuilder.setOperatorKeyword(Op.notRegexp, 'NOT REGEXP');
-  }
-
-  createSchemaQuery(schema, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createSchemaQuery',
-        this.dialect.name,
-        CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    return `CREATE SCHEMA IF NOT EXISTS ${this.quoteIdentifier(schema)};`;
   }
 
   dropSchemaQuery(schema) {

--- a/packages/core/src/dialects/snowflake/query-generator.js
+++ b/packages/core/src/dialects/snowflake/query-generator.js
@@ -34,10 +34,6 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
     this.whereSqlBuilder.setOperatorKeyword(Op.notRegexp, 'NOT REGEXP');
   }
 
-  dropSchemaQuery(schema) {
-    return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schema)} CASCADE;`;
-  }
-
   createTableQuery(tableName, attributes, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/sqlite/query-generator-typescript.ts
+++ b/packages/core/src/dialects/sqlite/query-generator-typescript.ts
@@ -23,10 +23,6 @@ const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptio
  * Temporary class to ease the TypeScript migration
  */
 export class SqliteQueryGeneratorTypeScript extends AbstractQueryGenerator {
-  createSchemaQuery(): string {
-    throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
-  }
-
   dropSchemaQuery(): string {
     throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
   }

--- a/packages/core/src/dialects/sqlite/query-generator-typescript.ts
+++ b/packages/core/src/dialects/sqlite/query-generator-typescript.ts
@@ -23,10 +23,6 @@ const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptio
  * Temporary class to ease the TypeScript migration
  */
 export class SqliteQueryGeneratorTypeScript extends AbstractQueryGenerator {
-  dropSchemaQuery(): string {
-    throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
-  }
-
   describeTableQuery(tableName: TableNameOrModel) {
     return `PRAGMA TABLE_INFO(${this.quoteTable(tableName)})`;
   }

--- a/packages/core/test/integration/associations/belongs-to-many.test.js
+++ b/packages/core/test/integration/associations/belongs-to-many.test.js
@@ -200,11 +200,10 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         expect(project.UserProject).to.be.ok;
         expect(project.status).not.to.exist;
         expect(project.UserProject.status).to.equal('active');
+        await this.sequelize.queryInterface.dropAllTables({ schema: 'acme' });
         await this.sequelize.dropSchema('acme');
         const schemas = await this.sequelize.queryInterface.listSchemas();
-        if (['postgres', 'mssql', 'mariadb', 'ibmi'].includes(dialect)) {
-          expect(schemas).to.not.have.property('acme');
-        }
+        expect(schemas).to.not.include('acme');
       });
     }
 

--- a/packages/core/test/integration/associations/belongs-to-many.test.js
+++ b/packages/core/test/integration/associations/belongs-to-many.test.js
@@ -181,9 +181,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         AcmeUser.belongsToMany(AcmeProject, { through: AcmeProjectUsers });
         AcmeProject.belongsToMany(AcmeUser, { through: AcmeProjectUsers });
 
-        await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.createSchema('acme');
-
         await Promise.all([
           AcmeUser.sync({ force: true }),
           AcmeProject.sync({ force: true }),

--- a/packages/core/test/integration/associations/belongs-to.test.js
+++ b/packages/core/test/integration/associations/belongs-to.test.js
@@ -128,11 +128,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         await task.setUserXYZ(user0);
         const user = await task.getUserXYZ();
         expect(user).to.be.ok;
+        await this.sequelize.queryInterface.dropAllTables({ schema: 'archive' });
         await this.sequelize.dropSchema('archive');
         const schemas = await this.sequelize.queryInterface.listSchemas();
-        if (['postgres', 'mssql', 'mariadb'].includes(dialect)) {
-          expect(schemas).to.not.have.property('archive');
-        }
+        expect(schemas).to.not.include('archive');
       });
 
       it('supports schemas when defining custom foreign key attribute #9029', async function () {

--- a/packages/core/test/integration/associations/belongs-to.test.js
+++ b/packages/core/test/integration/associations/belongs-to.test.js
@@ -115,7 +115,6 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
         Task.belongsTo(User);
 
-        await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.createSchema('archive');
         await User.sync({ force: true });
         await Task.sync({ force: true });
@@ -152,7 +151,6 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
         Task.belongsTo(User, { foreignKey: 'user_id' });
 
-        await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.createSchema('archive');
         await User.sync({ force: true });
         await Task.sync({ force: true });
@@ -161,8 +159,6 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         await task.setUserXYZ(user0);
         const user = await task.getUserXYZ();
         expect(user).to.be.ok;
-
-        await this.sequelize.dropSchema('archive');
       });
     }
   });

--- a/packages/core/test/integration/associations/has-many.test.js
+++ b/packages/core/test/integration/associations/has-many.test.js
@@ -456,11 +456,10 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           expect(users[1].tasks[1].subtasks.length).to.equal(2);
           expect(users[1].tasks[1].subtasks[0].title).to.equal('b');
           expect(users[1].tasks[1].subtasks[1].title).to.equal('a');
+          await this.sequelize.queryInterface.dropAllTables({ schema: 'work' });
           await this.sequelize.dropSchema('work');
           const schemas = await this.sequelize.queryInterface.listSchemas();
-          if (['postgres', 'mssql'].includes(dialect) || schemas === 'mariadb') {
-            expect(schemas).to.be.empty;
-          }
+          expect(schemas).to.not.include('work');
         });
       });
     }

--- a/packages/core/test/integration/associations/has-many.test.js
+++ b/packages/core/test/integration/associations/has-many.test.js
@@ -352,7 +352,6 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           User.Tasks = User.hasMany(Task, { as: 'tasks' });
           Task.SubTasks = Task.hasMany(SubTask, { as: 'subtasks' });
 
-          await Support.dropTestSchemas(this.sequelize);
           await this.sequelize.createSchema('work');
           await User.sync({ force: true });
           await Task.sync({ force: true });

--- a/packages/core/test/integration/associations/has-one.test.js
+++ b/packages/core/test/integration/associations/has-one.test.js
@@ -112,11 +112,10 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
         expect(associatedUser).not.to.be.null;
         expect(associatedUser.id).to.equal(user.id);
         expect(associatedUser.id).not.to.equal(fakeUser.id);
+        await this.sequelize.queryInterface.dropAllTables({ schema: 'admin' });
         await this.sequelize.dropSchema('admin');
         const schemas = await this.sequelize.queryInterface.listSchemas();
-        if (['postgres', 'mssql', 'mariadb'].includes(dialect)) {
-          expect(schemas).to.not.have.property('admin');
-        }
+        expect(schemas).to.not.include('admin');
       });
     }
   });

--- a/packages/core/test/integration/associations/has-one.test.js
+++ b/packages/core/test/integration/associations/has-one.test.js
@@ -95,7 +95,6 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
         Group.hasOne(User);
 
-        await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.createSchema('admin');
         await Group.sync({ force: true });
         await User.sync({ force: true });

--- a/packages/core/test/integration/dialects/postgres/query-interface.test.js
+++ b/packages/core/test/integration/dialects/postgres/query-interface.test.js
@@ -17,40 +17,6 @@ if (dialect.startsWith('postgres')) {
       this.queryInterface = this.sequelize.queryInterface;
     });
 
-    describe('createSchema', () => {
-      beforeEach(async function () {
-        // make sure we don't have a pre-existing schema called testSchema.
-        await this.queryInterface.dropSchema('testschema').catch(() => {});
-      });
-
-      it('creates a schema', async function () {
-        await this.queryInterface.createSchema('testschema');
-
-        const res = await this.sequelize.query(`
-            SELECT schema_name
-            FROM information_schema.schemata
-            WHERE schema_name = 'testschema';
-          `, { type: this.sequelize.QueryTypes.SELECT });
-
-        expect(res, 'query results').to.not.be.empty;
-        expect(res[0].schema_name).to.equal('testschema');
-      });
-
-      it('works even when schema exists', async function () {
-        await this.queryInterface.createSchema('testschema');
-        await this.queryInterface.createSchema('testschema');
-
-        const res = await this.sequelize.query(`
-            SELECT schema_name
-            FROM information_schema.schemata
-            WHERE schema_name = 'testschema';
-          `, { type: this.sequelize.QueryTypes.SELECT });
-
-        expect(res, 'query results').to.not.be.empty;
-        expect(res[0].schema_name).to.equal('testschema');
-      });
-    });
-
     describe('fetchDatabaseVersion', () => {
       it('reports version', async function () {
         const res = await this.queryInterface.fetchDatabaseVersion();

--- a/packages/core/test/integration/include/schema.test.js
+++ b/packages/core/test/integration/include/schema.test.js
@@ -21,10 +21,6 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
   }
 
   describe('findAll', () => {
-    afterEach(async function () {
-      await this.sequelize.dropSchema('account');
-    });
-
     beforeEach(async function () {
       this.fixtureA = async function () {
         await this.sequelize.dropSchema('account');
@@ -1244,7 +1240,6 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
         foreignKey: 'UserId',
       });
 
-      await this.sequelize.dropSchema('hero');
       await this.sequelize.createSchema('hero');
       await this.sequelize.sync({ force: true });
 
@@ -1257,8 +1252,6 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           as: 'Resume',
         }],
       });
-
-      await this.sequelize.dropSchema('hero');
     });
   });
 });

--- a/packages/core/test/integration/include/separate.test.js
+++ b/packages/core/test/integration/include/separate.test.js
@@ -8,7 +8,6 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
-const dialect = Support.getTestDialect();
 
 if (current.dialect.supports.groupedLimit) {
   describe(Support.getTestDialectTeaser('Include'), () => {
@@ -481,11 +480,10 @@ if (current.dialect.supports.groupedLimit) {
         expect(result[1].tasks.length).to.equal(2);
         expect(result[1].tasks[0].title).to.equal('a');
         expect(result[1].tasks[1].title).to.equal('c');
+        await this.sequelize.queryInterface.dropAllTables({ schema: 'archive' });
         await this.sequelize.dropSchema('archive');
         const schemas = await this.sequelize.queryInterface.listSchemas();
-        if (['postgres', 'mssql', 'mariadb'].includes(dialect)) {
-          expect(schemas).to.not.have.property('archive');
-        }
+        expect(schemas).to.not.include('archive');
       });
 
       it('should work with required non-separate parent and required child', async function () {

--- a/packages/core/test/integration/include/separate.test.js
+++ b/packages/core/test/integration/include/separate.test.js
@@ -438,7 +438,6 @@ if (current.dialect.supports.groupedLimit) {
 
         User.Tasks = User.hasMany(Task, { as: 'tasks' });
 
-        await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.createSchema('archive');
         await this.sequelize.sync({ force: true });
 

--- a/packages/core/test/integration/model.test.js
+++ b/packages/core/test/integration/model.test.js
@@ -901,15 +901,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         this.UserSpecialSync = await this.UserSpecial.schema('special').sync({ force: true });
       });
 
-      afterEach(async function () {
-        try {
-          await this.sequelize.dropSchema('schema_test');
-        } finally {
-          await this.sequelize.dropSchema('special');
-          await this.sequelize.dropSchema('prefix');
-        }
-      });
-
       it('should be able to drop with schemas', async function () {
         await this.UserSpecial.drop();
       });
@@ -988,7 +979,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         UserPub.hasMany(ItemPub, { foreignKeyConstraints: true });
 
-        await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.queryInterface.createSchema('prefix');
 
         let test = false;

--- a/packages/core/test/integration/model/bulk-create.test.js
+++ b/packages/core/test/integration/model/bulk-create.test.js
@@ -418,7 +418,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           tableName: 'Dummy',
         });
 
-        await Support.dropTestSchemas(this.customSequelize);
         await this.customSequelize.createSchema('space1');
         await Dummy.sync({ force: true });
 

--- a/packages/core/test/integration/model/schema.test.js
+++ b/packages/core/test/integration/model/schema.test.js
@@ -55,10 +55,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]);
       });
 
-      afterEach('drop schemas', async () => {
-        await current.dropSchema(SCHEMA_TWO);
-      });
-
       describe('Add data via model.create, retrieve via model.findOne', () => {
         it('should be able to sync model without schema option', function () {
           expect(this.RestaurantOne.table.schema).to.eq(current.dialect.getDefaultSchema());
@@ -186,13 +182,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         await Promise.all([
           this.RestaurantOne.sync({ force: true }),
           this.RestaurantTwo.sync({ force: true }),
-        ]);
-      });
-
-      afterEach('drop schemas', async () => {
-        await Promise.all([
-          current.dropSchema(SCHEMA_ONE),
-          current.dropSchema(SCHEMA_TWO),
         ]);
       });
 

--- a/packages/core/test/integration/model/searchPath.test.js
+++ b/packages/core/test/integration/model/searchPath.test.js
@@ -73,13 +73,6 @@ describe('SearchPath in Model Methods', () => {
     await Restaurant.sync({ force: true, searchPath: SEARCH_PATH_TWO });
   });
 
-  afterEach('drop schemas', async () => {
-    const { sequelize } = vars;
-
-    await sequelize.dropSchema('schema_one');
-    await sequelize.dropSchema('schema_two');
-  });
-
   describe('enum case', () => {
     it('able to refresh enum when searchPath is used', async function () {
       await this.Location.sync({ force: true });

--- a/packages/core/test/integration/model/sync.test.js
+++ b/packages/core/test/integration/model/sync.test.js
@@ -604,7 +604,6 @@ describe(getTestDialectTeaser('Model.sync & Sequelize#sync'), () => {
         .queryInterface
         .showConstraints(BelongsToUser, { constraintType: 'FOREIGN KEY' });
       expect(results).to.have.length(1);
-      await sequelize.dropSchema(schema);
     });
 
     it('should not recreate a foreign key if it already exists when { alter: true } is used with a custom schema (reference attribute is a Model)', async () => {

--- a/packages/core/test/integration/query-interface.test.js
+++ b/packages/core/test/integration/query-interface.test.js
@@ -18,10 +18,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     this.queryInterface = this.sequelize.queryInterface;
   });
 
-  afterEach(async function () {
-    await Support.dropTestSchemas(this.sequelize);
-  });
-
   if (dialect.supports.schemas) {
     describe('dropAllSchema', () => {
       it('should drop all schema', async function () {
@@ -36,7 +32,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         }
 
         expect(newSchemaNames).to.have.length(schemaNames.length + 1);
-        await this.queryInterface.dropSchema('newSchema');
       });
     });
   }

--- a/packages/core/test/integration/query-interface/changeColumn.test.js
+++ b/packages/core/test/integration/query-interface/changeColumn.test.js
@@ -12,7 +12,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   beforeEach(async function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.queryInterface;
-    await Support.dropTestSchemas(this.sequelize);
   });
 
   describe('changeColumn', () => {

--- a/packages/core/test/integration/query-interface/createTable.test.js
+++ b/packages/core/test/integration/query-interface/createTable.test.js
@@ -14,10 +14,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     this.queryInterface = this.sequelize.queryInterface;
   });
 
-  afterEach(async function () {
-    await Support.dropTestSchemas(this.sequelize);
-  });
-
   describe('createTable', () => {
     it('should create a auto increment primary key', async function () {
       await this.queryInterface.createTable('TableWithPK', {

--- a/packages/core/test/integration/query-interface/describeTable.test.js
+++ b/packages/core/test/integration/query-interface/describeTable.test.js
@@ -14,10 +14,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     this.queryInterface = this.sequelize.queryInterface;
   });
 
-  afterEach(async function () {
-    await Support.dropTestSchemas(this.sequelize);
-  });
-
   describe('describeTable', () => {
     if (Support.sequelize.dialect.supports.schemas) {
       it('reads the metadata of the table with schema', async function () {
@@ -36,8 +32,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         expect(metadata0.username2).not.to.be.undefined;
         const metadata = await this.queryInterface.describeTable('my_tables');
         expect(metadata.username1).not.to.be.undefined;
-
-        await this.sequelize.dropSchema('test_meta');
       });
     }
 

--- a/packages/core/test/integration/query-interface/dropEnum.test.js
+++ b/packages/core/test/integration/query-interface/dropEnum.test.js
@@ -14,10 +14,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     this.queryInterface = this.sequelize.queryInterface;
   });
 
-  afterEach(async function () {
-    await Support.dropTestSchemas(this.sequelize);
-  });
-
   describe('dropEnum', () => {
     beforeEach(async function () {
       await this.queryInterface.createTable('menus',  {

--- a/packages/core/test/integration/query-interface/schemas.test.ts
+++ b/packages/core/test/integration/query-interface/schemas.test.ts
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import type {
-  CreateSchemaQueryOptions,
-} from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator';
+import type { CreateSchemaQueryOptions } from '@sequelize/core';
+import { DataTypes, sql } from '@sequelize/core';
 import { sequelize } from '../support';
 
 const { dialect } = sequelize;
@@ -31,6 +30,68 @@ describe('QueryInterface#{create,drop,list}Schema', () => {
     const postCreationSchemas = await queryInterface.listSchemas();
     expect(postCreationSchemas).to.include(testSchema, 'createSchema did not create testSchema');
   });
+
+  if (dialect.supports.createSchema.authorization) {
+    it('creates a schema with an authorization', async () => {
+      if (dialect.name === 'mssql') {
+        // MSSQL requires a user to be created before creating a schema with an authorization
+        await sequelize.query('CREATE LOGIN [myUser] WITH PASSWORD = \'Password12!\'');
+        await sequelize.query('CREATE USER [myUser] FOR LOGIN [myUser]');
+        await queryInterface.createSchema(testSchema, { authorization: 'myUser' });
+      } else {
+        await queryInterface.createSchema(testSchema, { authorization: sql`CURRENT_USER` });
+      }
+
+      const postCreationSchemas = await queryInterface.listSchemas();
+      expect(postCreationSchemas).to.include(testSchema, 'createSchema did not create testSchema');
+
+      if (dialect.name === 'mssql') {
+        await queryInterface.dropSchema(testSchema);
+        await sequelize.query('DROP USER [myUser]');
+        await sequelize.query('DROP LOGIN [myUser]');
+      }
+    });
+  }
+
+  if (dialect.supports.createSchema.charset) {
+    it('creates a schema with a charset', async () => {
+      await queryInterface.createSchema(testSchema, { charset: 'utf8mb4' });
+      const postCreationSchemas = await queryInterface.listSchemas();
+      expect(postCreationSchemas).to.include(testSchema, 'createSchema did not create testSchema');
+    });
+  }
+
+  if (dialect.supports.createSchema.collate) {
+    it('creates a schema with a collate', async () => {
+      await queryInterface.createSchema(testSchema, { collate: 'latin2_general_ci' });
+      const postCreationSchemas = await queryInterface.listSchemas();
+      expect(postCreationSchemas).to.include(testSchema, 'createSchema did not create testSchema');
+    });
+  }
+
+  if (dialect.supports.createSchema.comment) {
+    it('creates a schema with a comment', async () => {
+      await queryInterface.createSchema(testSchema, { comment: 'myComment' });
+      const postCreationSchemas = await queryInterface.listSchemas();
+      expect(postCreationSchemas).to.include(testSchema, 'createSchema did not create testSchema');
+    });
+  }
+
+  if (dialect.supports.createSchema.ifNotExists) {
+    it('does not throw if the schema already exists', async () => {
+      await queryInterface.createSchema(testSchema);
+      await queryInterface.createSchema(testSchema, { ifNotExists: true });
+    });
+  }
+
+  if (dialect.supports.createSchema.replace) {
+    it('replaces a schema if it already exists', async () => {
+      await queryInterface.createSchema(testSchema);
+      await queryInterface.createTable({ tableName: 'testTable', schema: testSchema }, { id: { type: DataTypes.INTEGER, primaryKey: true } });
+      await queryInterface.createSchema(testSchema, { replace: true });
+      expect(await queryInterface.listTables()).to.be.empty;
+    });
+  }
 
   it(`passes options through to the queryInterface's queryGenerator`, async () => {
     const options: CreateSchemaQueryOptions = {

--- a/packages/core/test/integration/schema.test.js
+++ b/packages/core/test/integration/schema.test.js
@@ -17,10 +17,6 @@ describe(Support.getTestDialectTeaser('Schema'), () => {
     await this.sequelize.createSchema('testschema');
   });
 
-  afterEach(async function () {
-    await this.sequelize.dropSchema('testschema');
-  });
-
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       aNumber: { type: DataTypes.INTEGER },

--- a/packages/core/test/integration/support.ts
+++ b/packages/core/test/integration/support.ts
@@ -271,32 +271,7 @@ export async function dropTestSchemas(customSequelize: Sequelize = sequelize) {
     return;
   }
 
-  const qi = customSequelize.queryInterface;
-  const schemas = await qi.listSchemas({ skip: [customSequelize.config.database] });
-  const tablesPromise = [];
-  const schemasPromise = [];
-  if (customSequelize.dialect.supports.dropSchema.cascade) {
-    for (const schemaName of schemas) {
-      schemasPromise.push(qi.dropSchema(schemaName, { cascade: true }));
-    }
-  } else if (getTestDialect() === 'db2') {
-    // https://github.com/sequelize/sequelize/pull/14453#issuecomment-1155581572
-    // DB2 can sometimes deadlock / timeout when deleting more than one schema at the same time.
-    for (const schemaName of schemas) {
-      // eslint-disable-next-line no-await-in-loop
-      await qi.dropAllTables({ schema: schemaName });
-      // eslint-disable-next-line no-await-in-loop
-      await qi.dropSchema(schemaName);
-    }
-  } else {
-    for (const schemaName of schemas) {
-      tablesPromise.push(qi.dropAllTables({ schema: schemaName }));
-      schemasPromise.push(qi.dropSchema(schemaName));
-    }
-  }
-
-  await Promise.all(tablesPromise);
-  await Promise.all(schemasPromise);
+  await customSequelize.queryInterface.dropAllSchemas({ skip: [customSequelize.config.database] });
 }
 
 export * from '../support';

--- a/packages/core/test/unit/query-generator/create-schema-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-schema-query.test.ts
@@ -1,3 +1,4 @@
+import { sql } from '@sequelize/core';
 import { buildInvalidOptionReceivedError } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
 import { expectsql, getTestDialect, sequelize } from '../../support';
 
@@ -9,35 +10,82 @@ describe('QueryGenerator#createSchemaQuery', () => {
   const queryGenerator = sequelize.queryGenerator;
 
   it('produces a CREATE SCHEMA query in supported dialects', () => {
-    expectsql(() => queryGenerator.createSchemaQuery('myDatabase'), {
-      default: 'CREATE SCHEMA IF NOT EXISTS [myDatabase];',
-      db2: 'CREATE SCHEMA "myDatabase";',
-      ibmi: 'CREATE SCHEMA "myDatabase"',
-      mssql: `IF NOT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = N'myDatabase') BEGIN EXEC sp_executesql N'CREATE SCHEMA [myDatabase] ;' END;`,
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema'), {
+      default: 'CREATE SCHEMA [mySchema]',
+      sqlite: notSupportedError,
+    });
+  });
+
+  it('supports the authorization option', () => {
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', { authorization: 'myUser' }), {
+      default: 'CREATE SCHEMA [mySchema] AUTHORIZATION [myUser]',
+      sqlite: notSupportedError,
+      'mariadb mysql snowflake': buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization']),
+    });
+  });
+
+  it('supports the authorization option with a literal', () => {
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', { authorization: sql`CURRENT USER` }), {
+      default: 'CREATE SCHEMA [mySchema] AUTHORIZATION CURRENT USER',
+      sqlite: notSupportedError,
+      'mariadb mysql snowflake': buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization']),
+    });
+  });
+
+  it('supports the charset option', () => {
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', { charset: 'utf8mb4' }), {
+      default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['charset']),
+      'mysql mariadb': `CREATE SCHEMA \`mySchema\` DEFAULT CHARACTER SET 'utf8mb4'`,
       sqlite: notSupportedError,
     });
   });
 
   it('supports the collate option', () => {
-    expectsql(() => queryGenerator.createSchemaQuery('myDatabase', { collate: 'en_US.UTF-8' }), {
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', { collate: 'en_US.UTF-8' }), {
       default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['collate']),
-      'mysql mariadb': `CREATE SCHEMA IF NOT EXISTS \`myDatabase\` DEFAULT COLLATE 'en_US.UTF-8';`,
+      'mysql mariadb': `CREATE SCHEMA \`mySchema\` DEFAULT COLLATE 'en_US.UTF-8'`,
       sqlite: notSupportedError,
     });
   });
 
-  it('supports the charset option', () => {
-    expectsql(() => queryGenerator.createSchemaQuery('myDatabase', { charset: 'utf8mb4' }), {
-      default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['charset']),
-      'mysql mariadb': `CREATE SCHEMA IF NOT EXISTS \`myDatabase\` DEFAULT CHARACTER SET 'utf8mb4';`,
+  it('supports the comment option', () => {
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', { comment: 'myComment' }), {
+      default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['comment']),
+      'mariadb snowflake': `CREATE SCHEMA [mySchema] COMMENT 'myComment'`,
+      sqlite: notSupportedError,
+    });
+  });
+
+  it('supports the ifNotExists option', () => {
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', { ifNotExists: true }), {
+      default: 'CREATE SCHEMA IF NOT EXISTS [mySchema]',
+      'db2 ibmi mssql': buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['ifNotExists']),
+      sqlite: notSupportedError,
+    });
+  });
+
+  it('supports the replace option', () => {
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', { replace: true }), {
+      default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['replace']),
+      'mariadb snowflake': `CREATE OR REPLACE SCHEMA [mySchema]`,
       sqlite: notSupportedError,
     });
   });
 
   it('supports specifying all possible combinations', () => {
-    expectsql(() => queryGenerator.createSchemaQuery('myDatabase', { charset: 'utf8mb4', collate: 'en_US.UTF-8' }), {
-      default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['charset', 'collate']),
-      'mysql mariadb': `CREATE SCHEMA IF NOT EXISTS \`myDatabase\` DEFAULT CHARACTER SET 'utf8mb4' DEFAULT COLLATE 'en_US.UTF-8';`,
+    expectsql(() => queryGenerator.createSchemaQuery('mySchema', {
+      authorization: 'myUser',
+      charset: 'utf8mb4',
+      collate: 'en_US.UTF-8',
+      comment: 'myComment',
+      ifNotExists: true,
+      replace: true,
+    }), {
+      default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['charset', 'collate', 'comment', 'ifNotExists', 'replace']),
+      mariadb: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization']),
+      mysql: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization', 'comment', 'replace']),
+      postgres: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['charset', 'collate', 'comment', 'replace']),
+      snowflake: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization', 'charset', 'collate']),
       sqlite: notSupportedError,
     });
   });

--- a/packages/core/test/unit/query-generator/create-schema-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-schema-query.test.ts
@@ -51,7 +51,7 @@ describe('QueryGenerator#createSchemaQuery', () => {
   it('supports the comment option', () => {
     expectsql(() => queryGenerator.createSchemaQuery('mySchema', { comment: 'myComment' }), {
       default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['comment']),
-      'mariadb snowflake': `CREATE SCHEMA [mySchema] COMMENT 'myComment'`,
+      snowflake: `CREATE SCHEMA [mySchema] COMMENT 'myComment'`,
       sqlite: notSupportedError,
     });
   });
@@ -82,7 +82,7 @@ describe('QueryGenerator#createSchemaQuery', () => {
       replace: true,
     }), {
       default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['charset', 'collate', 'comment', 'ifNotExists', 'replace']),
-      mariadb: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization']),
+      mariadb: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization', 'comment']),
       mysql: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization', 'comment', 'replace']),
       postgres: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['charset', 'collate', 'comment', 'replace']),
       snowflake: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['authorization', 'charset', 'collate']),

--- a/packages/core/test/unit/query-generator/create-schema-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-schema-query.test.ts
@@ -51,7 +51,7 @@ describe('QueryGenerator#createSchemaQuery', () => {
   it('supports the comment option', () => {
     expectsql(() => queryGenerator.createSchemaQuery('mySchema', { comment: 'myComment' }), {
       default: buildInvalidOptionReceivedError('createSchemaQuery', dialectName, ['comment']),
-      snowflake: `CREATE SCHEMA [mySchema] COMMENT 'myComment'`,
+      snowflake: `CREATE SCHEMA "mySchema" COMMENT 'myComment'`,
       sqlite: notSupportedError,
     });
   });

--- a/packages/core/test/unit/query-generator/drop-schema-query.test.ts
+++ b/packages/core/test/unit/query-generator/drop-schema-query.test.ts
@@ -1,3 +1,4 @@
+import { buildInvalidOptionReceivedError } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
 import { expectsql, getTestDialect, sequelize } from '../../support';
 
 const dialectName = getTestDialect();
@@ -8,21 +9,34 @@ describe('QueryGenerator#dropSchemaQuery', () => {
   const queryGenerator = sequelize.queryGenerator;
 
   it('produces a DROP SCHEMA query in supported dialects', () => {
-    const testFn = () => {
-      const out = queryGenerator.dropSchemaQuery('myDatabase');
-      if (typeof out === 'string') {
-        return out;
-      }
+    expectsql(() => queryGenerator.dropSchemaQuery('mySchema'), {
+      default: 'DROP SCHEMA [mySchema]',
+      db2: 'DROP SCHEMA "mySchema" RESTRICT',
+      sqlite: notSupportedError,
+    });
+  });
 
-      return out.query;
-    };
+  it('produces a DROP SCHEMA IF EXISTS query in supported dialects', () => {
+    expectsql(() => queryGenerator.dropSchemaQuery('mySchema', { ifExists: true }), {
+      default: 'DROP SCHEMA IF EXISTS [mySchema]',
+      'db2 mssql': buildInvalidOptionReceivedError('dropSchemaQuery', dialectName, ['ifExists']),
+      sqlite: notSupportedError,
+    });
+  });
 
-    expectsql(testFn, {
-      default: 'DROP SCHEMA IF EXISTS [myDatabase];',
-      'postgres snowflake': 'DROP SCHEMA IF EXISTS "myDatabase" CASCADE;',
-      db2: 'CALL SYSPROC.ADMIN_DROP_SCHEMA(\'myDatabase\', NULL, $sequelize_errorSchema, $sequelize_errorTable)',
-      ibmi: 'BEGIN IF EXISTS (SELECT * FROM SYSIBM.SQLSCHEMAS WHERE TABLE_SCHEM = \'myDatabase\') THEN SET TRANSACTION ISOLATION LEVEL NO COMMIT; DROP SCHEMA "myDatabase"; COMMIT; END IF; END',
-      mssql: `IF EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = N'myDatabase') BEGIN DECLARE @id INT, @ms_sql NVARCHAR(2000); DECLARE @cascade TABLE (id INT NOT NULL IDENTITY PRIMARY KEY, ms_sql NVARCHAR(2000) NOT NULL); INSERT INTO @cascade (ms_sql) SELECT CASE WHEN o.type IN ('F','PK') THEN N'ALTER TABLE ['+ s.name + N'].[' + p.name + N'] DROP CONSTRAINT [' + o.name + N']' ELSE N'DROP TABLE ['+ s.name + N'].[' + o.name + N']' END FROM sys.objects o JOIN sys.schemas s on o.schema_id = s.schema_id LEFT OUTER JOIN sys.objects p on o.parent_object_id = p.object_id WHERE o.type IN ('F', 'PK', 'U') AND s.name = N'myDatabase' ORDER BY o.type ASC; SELECT TOP 1 @id = id, @ms_sql = ms_sql FROM @cascade ORDER BY id; WHILE @id IS NOT NULL BEGIN BEGIN TRY EXEC sp_executesql @ms_sql; END TRY BEGIN CATCH BREAK; THROW; END CATCH; DELETE FROM @cascade WHERE id = @id; SELECT @id = NULL, @ms_sql = NULL; SELECT TOP 1 @id = id, @ms_sql = ms_sql FROM @cascade ORDER BY id; END EXEC sp_executesql N'DROP SCHEMA [myDatabase] ;' END;`,
+  it('produces a DROP SCHEMA CASCADE query in supported dialects', () => {
+    expectsql(() => queryGenerator.dropSchemaQuery('mySchema', { cascade: true }), {
+      default: 'DROP SCHEMA [mySchema] CASCADE',
+      'db2 mariadb mssql mysql': buildInvalidOptionReceivedError('dropSchemaQuery', dialectName, ['cascade']),
+      sqlite: notSupportedError,
+    });
+  });
+
+  it('produces a DROP SCHEMA IF EXISTS CASCADE query in supported dialects', () => {
+    expectsql(() => queryGenerator.dropSchemaQuery('mySchema', { cascade: true, ifExists: true }), {
+      default: 'DROP SCHEMA IF EXISTS [mySchema] CASCADE',
+      'db2 mssql': buildInvalidOptionReceivedError('dropSchemaQuery', dialectName, ['cascade', 'ifExists']),
+      'mariadb mysql': buildInvalidOptionReceivedError('dropSchemaQuery', dialectName, ['cascade']),
       sqlite: notSupportedError,
     });
   });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR migrate the `createSchema`, `dropSchema` and `dropAllSchemas` queries to typescript.

# Breaking Changes
`dropSchema` no longer cascades by default. You will need to manually specify `cascade: true` in the options for dialects that support it otherwise drop all objects in the schema before dropping the schema. See the `dropAllSchemas` method for an example.
