### PR TITLE
fix(types): inferred type references inaccessible 'unique symbol' type

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -3336,9 +3336,9 @@ export type NonAttribute<T> =
 /**
  * Dummy Symbol used as branding by {@link ForeignKey}.
  *
- * Do not export, Do not use.
+ * Do not use.
  */
-declare const ForeignKeyBrand: unique symbol;
+export declare const ForeignKeyBrand: unique symbol;
 
 /**
  * This is a Branded Type.

--- a/test/types/model.ts
+++ b/test/types/model.ts
@@ -328,3 +328,16 @@ expectTypeOf(resultDerived).toEqualTypeOf<FilmNoNameToJson>()
 
 const resultOverrideToJson = filmOverrideToJson.toJSON();
 expectTypeOf(resultOverrideToJson).toEqualTypeOf<FilmNoNameToJson>();
+
+/**
+ * Tests for export Model from function
+ * https://github.com/sequelize/sequelize/issues/15898
+ */
+export function createTestModel() {
+  class TestModel extends Model {
+    declare id: string;
+  };
+  return TestModel;
+}
+export type TStatic = ReturnType<typeof createTestModel>;
+export type TInstance = InstanceType<TStatic>;


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->
Fixes https://github.com/sequelize/sequelize/issues/15898
