### PR TITLE
fix(types): incorrect type for default in findOrCreate and findOrBuild

### DIFF
--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -1054,7 +1054,7 @@ export interface FindOrCreateOptions<TAttributes = any, TCreationAttributes = TA
   /**
    * Default values to use if building a new instance
    */
-  defaults?: TCreationAttributes;
+  defaults?: Partial<TCreationAttributes>;
 }
 
 /**
@@ -1065,7 +1065,7 @@ export interface FindOrBuildOptions<TAttributes = any, TCreationAttributes = TAt
   /**
    * Default values to use if building a new instance
    */
-  defaults?: TCreationAttributes;
+  defaults?: Partial<TCreationAttributes>;
 }
 
 /**

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2593,10 +2593,10 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     this: ModelStatic<M>,
     options: Omit<
       FindOrCreateOptions<Attributes<M>, CreationAttributes<M>>,
-      "raw"
+      'raw'
     > & { raw: true }
   ): Promise<[entity: R, created: false] | [entity: M, created: true]>;
-  
+
   static findOrCreate<M extends Model>(
     this: ModelStatic<M>,
     options: FindOrCreateOptions<Attributes<M>, CreationAttributes<M>>

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2589,6 +2589,14 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * If a transaction is passed, a savepoint will be created instead,
    * and any unique constraint violation will be handled internally.
    */
+  static findOrCreate<M extends Model, R = Attributes<M>>(
+    this: ModelStatic<M>,
+    options: Omit<
+      FindOrCreateOptions<Attributes<M>, CreationAttributes<M>>,
+      "raw"
+    > & { raw: true }
+  ): Promise<[entity: R, created: false] | [entity: M, created: true]>;
+  
   static findOrCreate<M extends Model>(
     this: ModelStatic<M>,
     options: FindOrCreateOptions<Attributes<M>, CreationAttributes<M>>

--- a/packages/core/test/types/find-or-build.ts
+++ b/packages/core/test/types/find-or-build.ts
@@ -1,0 +1,36 @@
+import { expectTypeOf } from "expect-type";
+import { User } from "./models/user";
+
+User.findOrBuild({
+  where: { firstName: "Jonh" },
+  // `defaults` shouldn't require all fields
+  defaults: {
+    lastName: "Smith",
+  },
+});
+
+User.findOrBuild({
+  // These attributes do not exist
+  // @ts-expect-error -- this should error, if this doesn't error, findOrBuild has a bug!
+  where: { blah: "blah2" },
+  defaults: {
+    firstName: "Jonh",
+  },
+});
+
+User.findOrBuild({
+  where: {
+    firstName: "Jonh",
+  },
+  defaults: {
+    // These attributes do not exist
+    // @ts-expect-error -- this should error, if this doesn't error, findOrBuild has a bug!
+    blah: "Jonh 2",
+  },
+});
+
+(async () => {
+  expectTypeOf(
+    await User.findOrBuild({ where: { firstName: "John" } })
+  ).toEqualTypeOf<[User, boolean]>();
+})();

--- a/packages/core/test/types/find-or-build.ts
+++ b/packages/core/test/types/find-or-build.ts
@@ -1,36 +1,36 @@
-import { expectTypeOf } from "expect-type";
-import { User } from "./models/user";
+import { expectTypeOf } from 'expect-type';
+import { User } from './models/user';
 
 User.findOrBuild({
-  where: { firstName: "Jonh" },
+  where: { firstName: 'Jonh' },
   // `defaults` shouldn't require all fields
   defaults: {
-    lastName: "Smith",
+    lastName: 'Smith',
   },
 });
 
 User.findOrBuild({
   // These attributes do not exist
   // @ts-expect-error -- this should error, if this doesn't error, findOrBuild has a bug!
-  where: { blah: "blah2" },
+  where: { blah: 'blah2' },
   defaults: {
-    firstName: "Jonh",
+    firstName: 'Jonh',
   },
 });
 
 User.findOrBuild({
   where: {
-    firstName: "Jonh",
+    firstName: 'Jonh',
   },
   defaults: {
     // These attributes do not exist
     // @ts-expect-error -- this should error, if this doesn't error, findOrBuild has a bug!
-    blah: "Jonh 2",
+    blah: 'Jonh 2',
   },
 });
 
 (async () => {
   expectTypeOf(
-    await User.findOrBuild({ where: { firstName: "John" } })
+    await User.findOrBuild({ where: { firstName: 'John' } }),
   ).toEqualTypeOf<[User, boolean]>();
 })();

--- a/packages/core/test/types/find-or-create.ts
+++ b/packages/core/test/types/find-or-create.ts
@@ -1,46 +1,46 @@
-import { expectTypeOf } from "expect-type";
-import type { Attributes } from "@sequelize/core";
-import { User } from "./models/user";
+import { expectTypeOf } from 'expect-type';
+import type { Attributes } from '@sequelize/core';
+import { User } from './models/user';
 
 User.findOrCreate({
-  where: { firstName: "Jonh" },
+  where: { firstName: 'Jonh' },
   // `defaults` shouldn't require all fields
   defaults: {
-    lastName: "Smith",
+    lastName: 'Smith',
   },
 });
 
 User.findOrCreate({
   // These attributes do not exist
   // @ts-expect-error -- this should error, if this doesn't error, findOrCreate has a bug!
-  where: { blah: "blah2" },
+  where: { blah: 'blah2' },
   defaults: {
-    firstName: "Jonh",
+    firstName: 'Jonh',
   },
 });
 
 User.findOrCreate({
   where: {
-    firstName: "Jonh",
+    firstName: 'Jonh',
   },
   defaults: {
     // These attributes do not exist
     // @ts-expect-error -- this should error, if this doesn't error, findOrCreate has a bug!
-    blah: "Jonh 2",
+    blah: 'Jonh 2',
   },
 });
 
 (async () => {
   expectTypeOf(
-    await User.findOrCreate({ where: { firstName: "John" } })
+    await User.findOrCreate({ where: { firstName: 'John' } }),
   ).toEqualTypeOf<[User, boolean]>();
 
   // raw
 
   User.findOrCreate({
     raw: true,
-    where: { firstName: "John" },
-  }).then((res) => {
+    where: { firstName: 'John' },
+  }).then(res => {
     if (res[1]) {
       // if created
       expectTypeOf(res).toEqualTypeOf<[User, true]>();
@@ -52,14 +52,14 @@ User.findOrCreate({
   expectTypeOf(
     await User.findOrCreate({
       raw: false,
-      where: { firstName: "John" },
-    })
+      where: { firstName: 'John' },
+    }),
   ).toEqualTypeOf<[User, boolean]>();
 
   expectTypeOf(
     await User.findOrCreate({
       raw: undefined,
-      where: { firstName: "John" },
-    })
+      where: { firstName: 'John' },
+    }),
   ).toEqualTypeOf<[User, boolean]>();
 })();

--- a/packages/core/test/types/find-or-create.ts
+++ b/packages/core/test/types/find-or-create.ts
@@ -1,0 +1,65 @@
+import { expectTypeOf } from "expect-type";
+import type { Attributes } from "@sequelize/core";
+import { User } from "./models/user";
+
+User.findOrCreate({
+  where: { firstName: "Jonh" },
+  // `defaults` shouldn't require all fields
+  defaults: {
+    lastName: "Smith",
+  },
+});
+
+User.findOrCreate({
+  // These attributes do not exist
+  // @ts-expect-error -- this should error, if this doesn't error, findOrCreate has a bug!
+  where: { blah: "blah2" },
+  defaults: {
+    firstName: "Jonh",
+  },
+});
+
+User.findOrCreate({
+  where: {
+    firstName: "Jonh",
+  },
+  defaults: {
+    // These attributes do not exist
+    // @ts-expect-error -- this should error, if this doesn't error, findOrCreate has a bug!
+    blah: "Jonh 2",
+  },
+});
+
+(async () => {
+  expectTypeOf(
+    await User.findOrCreate({ where: { firstName: "John" } })
+  ).toEqualTypeOf<[User, boolean]>();
+
+  // raw
+
+  User.findOrCreate({
+    raw: true,
+    where: { firstName: "John" },
+  }).then((res) => {
+    if (res[1]) {
+      // if created
+      expectTypeOf(res).toEqualTypeOf<[User, true]>();
+    } else {
+      expectTypeOf(res).toEqualTypeOf<[Attributes<User>, false]>();
+    }
+  });
+
+  expectTypeOf(
+    await User.findOrCreate({
+      raw: false,
+      where: { firstName: "John" },
+    })
+  ).toEqualTypeOf<[User, boolean]>();
+
+  expectTypeOf(
+    await User.findOrCreate({
+      raw: undefined,
+      where: { firstName: "John" },
+    })
+  ).toEqualTypeOf<[User, boolean]>();
+})();


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Closes [#16947](https://github.com/sequelize/sequelize/issues/16947)
Fixed incorrect types for `default` in `Model.findOrCreate` and `Model.findOrBuild`

## Todos

N/a
