### PR TITLE
fix(types): Add definition of returning in SaveOptions as it was missing.

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1308,7 +1308,7 @@ export interface SaveOptions<TAttributes = any> extends Logging, Transactionable
   /**
    * Return the affected rows (only for postgres)
    */
-  returning?: boolean | (keyof TAttributes)[];
+  returning?: boolean | Array<keyof TAttributes>;
 }
 
 /**

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1304,6 +1304,11 @@ export interface SaveOptions<TAttributes = any> extends Logging, Transactionable
    * @default false
    */
   omitNull?: boolean;
+
+  /**
+   * Return the affected rows (only for postgres)
+   */
+  returning?: boolean | (keyof TAttributes)[];
 }
 
 /**


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] ~~Have you added new tests to prevent regressions?~~
- [ ] ~~If a documentation update is necessary, have you opened a PR to [the documentation repository]~~(https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] ~~Did you update the typescript typings accordingly (if applicable)?~~
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

In the type definition file, the return of SaveOptions was omitted. 

https://github.com/sequelize/sequelize/blob/cb8ea88c9aa37b14c908fd34dff1afc603de2ea7/src/model.d.ts#L1284-L1307

They are present in the actual code.

https://github.com/sequelize/sequelize/blob/cb8ea88c9aa37b14c908fd34dff1afc603de2ea7/src/model.js#L4016-L4022

This pull request adds the missing `returning`.

There was no problem with the v7 codes.

## Todos

