### PR TITLE
fix: remove unsupported options for snowflake

### DIFF
--- a/packages/core/src/dialects/snowflake/query-generator-typescript.ts
+++ b/packages/core/src/dialects/snowflake/query-generator-typescript.ts
@@ -16,7 +16,7 @@ import type {
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 
-const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['charset', 'collate']);
+const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>([]);
 const LIST_DATABASES_QUERY_SUPPORTED_OPTIONS = new Set<keyof ListDatabasesQueryOptions>([]);
 const SHOW_CONSTRAINTS_QUERY_SUPPORTED_OPTIONS = new Set<keyof ShowConstraintsQueryOptions>(['constraintName', 'constraintType']);
 
@@ -41,8 +41,6 @@ export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
     return joinSQLFragments([
       `CREATE DATABASE IF NOT EXISTS ${this.quoteIdentifier(database)}`,
-      options?.charset && `DEFAULT CHARACTER SET ${this.escape(options.charset)}`,
-      options?.collate && `DEFAULT COLLATE ${this.escape(options.collate)}`,
     ]);
   }
 

--- a/packages/core/src/dialects/snowflake/query-generator-typescript.ts
+++ b/packages/core/src/dialects/snowflake/query-generator-typescript.ts
@@ -16,6 +16,7 @@ import type {
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 
+const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>([]);
 const LIST_DATABASES_QUERY_SUPPORTED_OPTIONS = new Set<keyof ListDatabasesQueryOptions>([]);
 const SHOW_CONSTRAINTS_QUERY_SUPPORTED_OPTIONS = new Set<keyof ShowConstraintsQueryOptions>(['constraintName', 'constraintType']);
 
@@ -33,7 +34,7 @@ export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
         'createDatabaseQuery',
         this.dialect.name,
         CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
-        new Set<keyof CreateDatabaseQueryOptions>([]),
+        CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }

--- a/packages/core/src/dialects/snowflake/query-generator-typescript.ts
+++ b/packages/core/src/dialects/snowflake/query-generator-typescript.ts
@@ -16,7 +16,6 @@ import type {
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 
-const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>([]);
 const LIST_DATABASES_QUERY_SUPPORTED_OPTIONS = new Set<keyof ListDatabasesQueryOptions>([]);
 const SHOW_CONSTRAINTS_QUERY_SUPPORTED_OPTIONS = new Set<keyof ShowConstraintsQueryOptions>(['constraintName', 'constraintType']);
 
@@ -34,7 +33,7 @@ export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
         'createDatabaseQuery',
         this.dialect.name,
         CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS,
+        new Set<keyof CreateDatabaseQueryOptions>([]),
         options,
       );
     }

--- a/packages/core/src/dialects/snowflake/query-generator.js
+++ b/packages/core/src/dialects/snowflake/query-generator.js
@@ -29,7 +29,7 @@ const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
-const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['collate', 'charset', 'rowFormat', 'comment', 'uniqueKeys']);
+const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['comment', 'uniqueKeys']);
 
 export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
   constructor(options) {
@@ -134,9 +134,6 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
       table,
       `(${attributesClause})`,
       options.comment && typeof options.comment === 'string' && `COMMENT ${this.escape(options.comment)}`,
-      options.charset && `DEFAULT CHARSET=${options.charset}`,
-      options.collate && `COLLATE ${options.collate}`,
-      options.rowFormat && `ROW_FORMAT=${options.rowFormat}`,
       ';',
     ]);
   }

--- a/packages/core/test/unit/query-generator/create-database-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-database-query.test.ts
@@ -22,7 +22,7 @@ describe('QueryGenerator#createDatabaseQuery', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', { collate: 'en_US.UTF-8' }), {
       default: notSupportedError,
       postgres: `CREATE DATABASE "myDatabase" LC_COLLATE = 'en_US.UTF-8'`,
-      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT COLLATE 'en_US.UTF-8'`,
+      snowflake: buildInvalidOptionReceivedError('createDatabaseQuery', dialectName, ['collate']),
       mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase' ) CREATE DATABASE [myDatabase] COLLATE N'en_US.UTF-8'`,
     });
   });
@@ -54,18 +54,17 @@ describe('QueryGenerator#createDatabaseQuery', () => {
   it('supports the charset option', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', { charset: 'utf8mb4' }), {
       default: notSupportedError,
-      'mssql postgres': buildInvalidOptionReceivedError('createDatabaseQuery', dialectName, ['charset']),
-      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT CHARACTER SET 'utf8mb4'`,
+      'mssql postgres snowflake': buildInvalidOptionReceivedError('createDatabaseQuery', dialectName, ['charset']),
     });
   });
 
   it('supports combining all options', () => {
     const optionSupport = {
-      collate: ['postgres', 'snowflake', 'mssql'],
+      collate: ['postgres', 'mssql'],
       encoding: ['postgres'],
       ctype: ['postgres'],
       template: ['postgres'],
-      charset: ['snowflake'],
+      charset: [''],
     };
 
     const config = removeUndefined({
@@ -79,7 +78,7 @@ describe('QueryGenerator#createDatabaseQuery', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', config), {
       default: notSupportedError,
       postgres: `CREATE DATABASE "myDatabase" ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'zh_TW.UTF-8' TEMPLATE = 'template0'`,
-      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT CHARACTER SET 'utf8mb4' DEFAULT COLLATE 'en_US.UTF-8'`,
+      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase"`,
       mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase') CREATE DATABASE [myDatabase] COLLATE N'en_US.UTF-8'`,
     });
   });

--- a/packages/core/test/unit/query-generator/create-database-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-database-query.test.ts
@@ -64,7 +64,6 @@ describe('QueryGenerator#createDatabaseQuery', () => {
       encoding: ['postgres'],
       ctype: ['postgres'],
       template: ['postgres'],
-      charset: [''],
     };
 
     const config = removeUndefined({
@@ -72,7 +71,6 @@ describe('QueryGenerator#createDatabaseQuery', () => {
       encoding: optionSupport.encoding.includes(dialectName) ? 'UTF8' : undefined,
       ctype: optionSupport.ctype.includes(dialectName) ? 'zh_TW.UTF-8' : undefined,
       template: optionSupport.template.includes(dialectName) ? 'template0' : undefined,
-      charset: optionSupport.charset.includes(dialectName) ? 'utf8mb4' : undefined,
     });
 
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', config), {

--- a/packages/core/test/unit/query-generator/create-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-table-query.test.ts
@@ -345,7 +345,6 @@ describe('QueryGenerator#createTableQuery', () => {
     expectsql(() => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { charset: 'utf8mb4' }), {
       default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['charset']),
       'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;',
-      snowflake: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['charset']),
     });
   });
 
@@ -353,7 +352,6 @@ describe('QueryGenerator#createTableQuery', () => {
     expectsql(() => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { collate: 'en_US.UTF-8' }), {
       default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['collate']),
       'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB COLLATE en_US.UTF-8;',
-      snowflake: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['collate']),
     });
   });
 
@@ -361,7 +359,6 @@ describe('QueryGenerator#createTableQuery', () => {
     expectsql(() => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { rowFormat: 'default' }), {
       default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['rowFormat']),
       'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB ROW_FORMAT=default;',
-      snowflake: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['rowFormat']),
     });
   });
 

--- a/packages/core/test/unit/query-generator/create-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-table-query.test.ts
@@ -345,7 +345,7 @@ describe('QueryGenerator#createTableQuery', () => {
     expectsql(() => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { charset: 'utf8mb4' }), {
       default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['charset']),
       'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;',
-      snowflake: 'CREATE TABLE IF NOT EXISTS "myTable" ("myColumn" DATE) DEFAULT CHARSET=utf8mb4;',
+      snowflake: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['charset']),
     });
   });
 
@@ -353,7 +353,7 @@ describe('QueryGenerator#createTableQuery', () => {
     expectsql(() => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { collate: 'en_US.UTF-8' }), {
       default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['collate']),
       'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB COLLATE en_US.UTF-8;',
-      snowflake: 'CREATE TABLE IF NOT EXISTS "myTable" ("myColumn" DATE) COLLATE en_US.UTF-8;',
+      snowflake: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['collate']),
     });
   });
 
@@ -361,7 +361,7 @@ describe('QueryGenerator#createTableQuery', () => {
     expectsql(() => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { rowFormat: 'default' }), {
       default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['rowFormat']),
       'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB ROW_FORMAT=default;',
-      snowflake: 'CREATE TABLE IF NOT EXISTS "myTable" ("myColumn" DATE) ROW_FORMAT=default;',
+      snowflake: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['rowFormat']),
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Snowflake does not explicitly support collation in the same way as some other databases.

Like it shows in [create table syntax](https://docs.snowflake.com/en/sql-reference/sql/create-table#syntax)
And in [collation specification](https://docs.snowflake.com/en/sql-reference/collation#label-collation-specification)

This fix removes the unsupported options for Snowflake