### PR TITLE
meta: update typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "nx": "17.3.0",
     "source-map-support": "0.5.21",
     "ts-node": "10.9.2",
-    "typedoc": "0.25.4",
+    "typedoc": "0.25.7",
     "typedoc-plugin-carbon-ads": "1.6.0",
     "typedoc-plugin-mdn-links": "3.1.14",
     "typedoc-plugin-missing-exports": "2.2.0",

--- a/packages/core/src/errors/validation-error.ts
+++ b/packages/core/src/errors/validation-error.ts
@@ -172,11 +172,16 @@ export class ValidationErrorItem extends Error {
    *
    * @param useTypeAsNS controls whether the returned value is "namespace",
    *                    this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.Origins
-   * @param NSSeparator a separator string for concatenating the namespace, must be not be empty,
-   *                    defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
    * @throws {Error}    thrown if NSSeparator is found to be invalid.
    */
   getValidatorKey(useTypeAsNS: false): string;
+
+  /**
+   * @param useTypeAsNS controls whether the returned value is "namespace",
+   *                    this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.Origins
+   * @param NSSeparator a separator string for concatenating the namespace, must be not be empty,
+   *                    defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
+   */
   getValidatorKey(useTypeAsNS?: true, NSSeparator?: string): string;
   getValidatorKey(useTypeAsNS: boolean = true, NSSeparator: string = '.'): string {
     const useTANS = useTypeAsNS === undefined || Boolean(useTypeAsNS);

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2957,9 +2957,6 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    *
    * If called with a dot.seperated key on a JSON/JSONB attribute it will set the value nested and flag the
    * entire object as changed.
-   *
-   * @param options.raw If set to true, field and virtual setters will be ignored
-   * @param options.reset Clear all previously set data values
    */
   // TODO: 'key' accepts nested paths for JSON values (json.property)
   set<K extends keyof TModelAttributes>(key: K, value: TModelAttributes[K], options?: SetOptions): this;

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -34,10 +34,7 @@ export class Transaction {
    * Creates a new transaction instance
    *
    * @param sequelize A configured sequelize Instance
-   * @param options An object with options
-   * @param [options.type] Sets the type of the transaction. Sqlite only
-   * @param [options.isolationLevel] Sets the isolation level of the transaction.
-   * @param [options.constraintChecking] Sets the constraints to be deferred or immediately checked. PostgreSQL only
+   * @param options The transaction options.
    */
   constructor(sequelize: Sequelize, options: TransactionOptions) {
     this.sequelize = sequelize;
@@ -526,8 +523,20 @@ export interface TransactionOptions extends Logging {
    * Used to determine whether sequelize is allowed to use a read replication server.
    */
   readOnly?: boolean | undefined;
+
+  /**
+   * Sets the isolation level of the transaction.
+   */
   isolationLevel?: IsolationLevel | null | undefined;
+
+  /**
+   * Sets the type of the transaction. Sqlite only
+   */
   type?: TransactionType | undefined;
+
+  /**
+   * Sets the constraints to be deferred or immediately checked. PostgreSQL only
+   */
   constraintChecking?: ConstraintChecking | Class<ConstraintChecking> | undefined;
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,7 +2258,7 @@ __metadata:
     nx: "npm:17.3.0"
     source-map-support: "npm:0.5.21"
     ts-node: "npm:10.9.2"
-    typedoc: "npm:0.25.4"
+    typedoc: "npm:0.25.7"
     typedoc-plugin-carbon-ads: "npm:1.6.0"
     typedoc-plugin-mdn-links: "npm:3.1.14"
     typedoc-plugin-missing-exports: "npm:2.2.0"
@@ -12072,7 +12072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shiki@npm:^0.14.1":
+"shiki@npm:^0.14.7":
   version: 0.14.7
   resolution: "shiki@npm:0.14.7"
   dependencies:
@@ -13363,19 +13363,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:0.25.4":
-  version: 0.25.4
-  resolution: "typedoc@npm:0.25.4"
+"typedoc@npm:0.25.7":
+  version: 0.25.7
+  resolution: "typedoc@npm:0.25.7"
   dependencies:
     lunr: "npm:^2.3.9"
     marked: "npm:^4.3.0"
     minimatch: "npm:^9.0.3"
-    shiki: "npm:^0.14.1"
+    shiki: "npm:^0.14.7"
   peerDependencies:
     typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/2790b3f16b26a477cfc9b72f81b4f209c885c554f9c7b2557d5d85ea4c8bd6a51584af8d29eec123a26398c4986f52b0c3c7a9c32352a223c33a96bd211f288f
+  checksum: 10c0/e663be0534dd56f45f041a478ee0613a1bf96cad7208a5cfc771981c904d0f30d8dca51956486f125f8004237264acc5dd45920fa6a0a32e351e36d74279abb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replacement for #16920

Here is how each warning was fixed:

```
[warning] The signature index.Transaction.constructor has an @param with name "options.type", which was not used.
[warning] The signature index.Transaction.constructor has an @param with name "options.isolationLevel", which was not used.
[warning] The signature index.Transaction.constructor has an @param with name "options.constraintChecking", which was not used.
[warning] The signature index.Model.set has an @param with name "options.raw", which was not used.
[warning] The signature index.Model.set has an @param with name "options.reset", which was not used.

➡️ These parameters were part of the option bag, so they are not documented on the Option type instead.

---

[warning] The signature index.ValidationErrorItem.getValidatorKey has an @param with name "NSSeparator", which was not used.

➡️ This parameter was only on one overload, so I moved it to that overload
```