### PR TITLE
feat: drop support TS 4.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts-version: ["4.9", "5.0", "5.1", "5.2"]
+        ts-version: ["5.0", "5.1", "5.2", "5.3"]
     name: TS Typings (${{ matrix.ts-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sequelize/monorepo",
   "private": true,
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "publish-all": "lerna publish --conventional-commits --no-private --yes --create-release github",
     "lint": "eslint . --fix --report-unused-disable-directives",
     "lint-no-fix": "eslint . --quiet --report-unused-disable-directives",

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -21,7 +21,7 @@ import { Op } from '../../operators.js';
 import type { BindOrReplacements, Expression, Sequelize } from '../../sequelize.js';
 import { bestGuessDataTypeOfVal } from '../../sql-string.js';
 import { TableHints } from '../../table-hints.js';
-import { isDictionary, isNullish, isPlainObject, isString, rejectInvalidOptions } from '../../utils/check.js';
+import { isNullish, isPlainObject, isString, rejectInvalidOptions } from '../../utils/check.js';
 import { noOpCol } from '../../utils/deprecations.js';
 import { quoteIdentifier } from '../../utils/dialect.js';
 import { joinSQLFragments } from '../../utils/join-sql-fragments.js';
@@ -959,7 +959,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
    * @param options The options to use when escaping the value
    */
   escape(value: unknown, options: EscapeOptions = EMPTY_OBJECT): string {
-    if (isDictionary(value) && Op.col in value) {
+    if (isPlainObject(value) && Op.col in value) {
       noOpCol();
       value = new Col(value[Op.col] as string);
     }

--- a/packages/core/src/dialects/abstract/where-sql-builder.ts
+++ b/packages/core/src/dialects/abstract/where-sql-builder.ts
@@ -14,7 +14,7 @@ import type { Expression, ModelStatic, WhereOptions } from '../../index.js';
 import { Op } from '../../operators';
 import type { ParsedJsonPropertyKey } from '../../utils/attribute-syntax.js';
 import { parseAttributeSyntax, parseNestedJsonKeySyntax } from '../../utils/attribute-syntax.js';
-import { isDictionary, isPlainObject, isString } from '../../utils/check.js';
+import { isPlainObject, isString } from '../../utils/check.js';
 import { noOpCol } from '../../utils/deprecations.js';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../utils/object.js';
 import type { Nullish } from '../../utils/types.js';
@@ -636,7 +636,7 @@ export class WhereSqlBuilder {
   }
 
   #formatOpAnyAll(value: unknown, type: NormalizedDataType | undefined): string {
-    if (!isDictionary(value)) {
+    if (!isPlainObject(value)) {
       return '';
     }
 
@@ -652,7 +652,7 @@ export class WhereSqlBuilder {
   }
 
   #formatOpValues(value: unknown, type: NormalizedDataType | undefined): string {
-    if (isDictionary(value) && Op.values in value) {
+    if (isPlainObject(value) && Op.values in value) {
       const options = { type };
 
       const operand: unknown[] = Array.isArray(value[Op.values])

--- a/packages/core/src/utils/check.ts
+++ b/packages/core/src/utils/check.ts
@@ -71,17 +71,6 @@ export function isPlainObject(value: unknown): value is object {
 }
 
 /**
- * This function is the same as {@link isPlainObject}, but types the result as a Record / Dictionary.
- * This function won't be necessary starting with TypeScript 4.9, thanks to improvements to the TS object type,
- * but we have to keep it until we drop support for TS < 4.9.
- *
- * @param value
- */
-export function isDictionary(value: unknown): value is Record<PropertyKey, unknown> {
-  return isPlainObject(value);
-}
-
-/**
  * Returns whether `value` is using the nested syntax for attributes.
  *
  * @param value The attribute reference to check.


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here --> https://github.com/sequelize/website/pull/681
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

In line with our support policy this PR drops testing on TS 4.9. A workaround for isPlainObject typing is removed since it was fixed in TS 4.9. We also update husky on the side.