### PR TITLE
fix: fix `NOT` operator sometimes producing incorrect queries

### DIFF
--- a/packages/core/src/dialects/abstract/where-sql-builder.ts
+++ b/packages/core/src/dialects/abstract/where-sql-builder.ts
@@ -879,10 +879,6 @@ function wrapWithNot(sql: string): string {
     return '';
   }
 
-  if (sql.startsWith('(') && sql.endsWith(')')) {
-    return `NOT ${sql}`;
-  }
-
   return `NOT (${sql})`;
 }
 

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -2696,6 +2696,23 @@ Caused by: "undefined" cannot be escaped`),
         default: 'NOT ([intAttr1] = 1 AND [intAttr2] = 2)',
       });
 
+      testSql({
+        [Op.not]: {
+          [Op.or]: {
+            [Op.and]: {
+              intAttr1: 1,
+              intAttr2: 2,
+            },
+            [Op.or]: {
+              intAttr1: 1,
+              intAttr2: 2,
+            },
+          },
+        },
+      }, {
+        default: 'NOT ((`intAttr1` = 1 AND `intAttr2` = 2) OR (`intAttr1` = 1 OR `intAttr2` = 2))',
+      });
+
       // Op.not, Op.and, Op.or can reside on the same object as attributes
       testSql({
         intAttr1: 1,

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -2710,7 +2710,7 @@ Caused by: "undefined" cannot be escaped`),
           },
         },
       }, {
-        default: 'NOT ((`intAttr1` = 1 AND `intAttr2` = 2) OR (`intAttr1` = 1 OR `intAttr2` = 2))',
+        default: 'NOT (([intAttr1] = 1 AND [intAttr2] = 2) OR ([intAttr1] = 1 OR [intAttr2] = 2))',
       });
 
       // Op.not, Op.and, Op.or can reside on the same object as attributes


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Fixes #16437 
