### PR TITLE
meta: make renovate only open a PR if the CI check failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - v7
+      - renovate/**
   pull_request:
   merge_group:
 
@@ -246,7 +247,7 @@ jobs:
         test-postgres,
         test-oldest-latest
       ]
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/v7'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     ":semanticCommitScopeDisabled"
   ],
   "automergeStrategy": "squash",
+  "automergeType": "branch",
   "semanticCommitType": "meta",
   "ignorePaths": ["dev/**/oldest/docker-compose.yml"],
   "platformAutomerge": true,


### PR DESCRIPTION
The goal of this PR is to make renovate use `automergeType: branch`, which only opens a PR if the CI failed on the `renovate/x` branch, and is otherwise merged immediately.

This should massively reduce the spam caused by renovate