### PR TITLE
meta: throw when using deprecated code

### DIFF
--- a/packages/core/test/integration/sequelize.test.js
+++ b/packages/core/test/integration/sequelize.test.js
@@ -184,6 +184,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   }
 
   describe('getDialect', () => {
+    Support.allowDeprecationsInSuite(['SEQUELIZE0031']);
     it('returns the defined dialect', function () {
       expect(this.sequelize.getDialect()).to.equal(dialect);
     });
@@ -196,6 +197,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   });
 
   describe('isDefined', () => {
+    Support.allowDeprecationsInSuite(['SEQUELIZE0029']);
     it("returns false if the dao wasn't defined before", function () {
       expect(this.sequelize.isDefined('Project')).to.be.false;
     });
@@ -209,6 +211,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   });
 
   describe('model', () => {
+    Support.allowDeprecationsInSuite(['SEQUELIZE0028']);
     it('throws an error if the dao being accessed is undefined', function () {
       expect(() => {
         this.sequelize.model('Project');

--- a/packages/core/test/support.ts
+++ b/packages/core/test/support.ts
@@ -591,3 +591,45 @@ if (typeof after !== 'undefined') {
     return fs.promises.rm(SQLITE_DATABASES_DIR, { recursive: true, force: true });
   });
 }
+
+// TODO: ignoredDeprecations should be removed in favour of EMPTY_ARRAY
+const ignoredDeprecations: readonly string[] = [
+  'SEQUELIZE0005',
+  'SEQUELIZE0006',
+  'SEQUELIZE0007',
+  'SEQUELIZE0008',
+  'SEQUELIZE0009',
+  'SEQUELIZE0011',
+  'SEQUELIZE0012',
+  'SEQUELIZE0013',
+  'SEQUELIZE0014',
+  'SEQUELIZE0015',
+  'SEQUELIZE0016',
+  'SEQUELIZE0017',
+  'SEQUELIZE0018',
+  'SEQUELIZE0019',
+  'SEQUELIZE0020',
+  'SEQUELIZE0021',
+  'SEQUELIZE0022',
+  'SEQUELIZE0023',
+  'SEQUELIZE0024',
+  'SEQUELIZE0025',
+  'SEQUELIZE0026',
+  'SEQUELIZE0027',
+];
+let allowedDeprecations: readonly string[] = ignoredDeprecations;
+export function allowDeprecationsInSuite(codes: readonly string[]) {
+  before(() => {
+    allowedDeprecations = [...codes, ...ignoredDeprecations];
+  });
+
+  after(() => {
+    allowedDeprecations = ignoredDeprecations;
+  });
+}
+
+process.on('warning', (warning: NodeJS.ErrnoException) => {
+  if (warning.name === 'DeprecationWarning' && !allowedDeprecations.includes(warning.code!)) {
+    throw warning;
+  }
+});


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

Test suites will now fail if they use code that throws a deprecation warning. A helper function is added when you want to test the deprecated code. Follow-up PRs will reduce the amount of codes mentioned in ignoredDeprecations, with the aim of completely removing it.