### PR TITLE
meta: fix codeowners & lint-staged

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sequelize/maintainers
+* @sequelize/code-reviewers

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn lint-staged
+yarn lint-staged --concurrent false

--- a/package.json
+++ b/package.json
@@ -86,9 +86,7 @@
   },
   "packageManager": "yarn@4.1.0",
   "lint-staged": {
-    "*": [
-      "eslint --fix --report-unused-disable-directives",
-      "prettier --write"
-    ]
+    "*.{js,mjs,cjs,ts,mts,cts}": "eslint --fix --report-unused-disable-directives",
+    "*": "prettier --write --ignore-unknown"
   }
 }


### PR DESCRIPTION
The lint-staged config had issues with running on every type of files

eslint:

![image](https://github.com/sequelize/sequelize/assets/1280915/ec057f17-9f35-40cd-b0a9-c9a5d074a04a)

prettier:

![image](https://github.com/sequelize/sequelize/assets/1280915/94676e4d-b1a4-42ed-9114-92b0188debfb)

This updated config only runs eslint on JS/TS files, and makes prettier ignore any file it doesn't have a parser for

I also updated the codeowner based on https://github.com/sequelize/sequelize/pull/17095#issuecomment-1953041371