### PR TITLE
feat: use bind params in bulkInsertQuery

### DIFF
--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -165,7 +165,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           } else if (dialect === 'mssql') {
             expect(sql).to.include('INSERT INTO [Beers] ([style],[createdAt],[updatedAt]) ');
           } else { // mysql, sqlite
-            expect(sql).to.include('INSERT INTO `Beers` (`id`,`style`,`createdAt`,`updatedAt`) VALUES (NULL');
+            expect(sql).to.include('INSERT INTO `Beers` (`id`,`style`,`createdAt`,`updatedAt`) VALUES (');
           }
         }
       });

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -621,40 +621,73 @@ if (dialect === 'mariadb') {
       bulkInsertQuery: [
         {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }]],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: "foo';DROP TABLE myTable;" }, { name: 'bar' }]],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo\\';DROP TABLE myTable;'),('bar');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ["foo';DROP TABLE myTable;", 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', birthday: new Date(Date.UTC(2011, 2, 27, 10, 1, 55)) }, { name: 'bar', birthday: new Date(Date.UTC(2012, 2, 27, 10, 1, 55)) }]],
-          expectation: "INSERT INTO `myTable` (`name`,`birthday`) VALUES ('foo','2011-03-27 10:01:55.000'),('bar','2012-03-27 10:01:55.000');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`birthday`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', new Date('2011-03-27T10:01:55.000Z'), 'bar', new Date('2012-03-27T10:01:55.000Z')]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1 }, { name: 'bar', foo: 2 }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`) VALUES ('foo',1),('bar',2);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', 1, 'bar', 2]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',NULL,NULL);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', null, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);",
-          context: { options: { omitNull: false } }
+          context: { options: { omitNull: false } },
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);",
-          context: { options: { omitNull: true } } // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
+          context: { options: { omitNull: true } }, // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: undefined }, { name: 'bar', foo: 2, undefinedValue: undefined }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`,`undefinedValue`) VALUES ('foo',1,NULL,NULL),('bar',2,NULL,NULL);",
-          context: { options: { omitNull: true } } // Note: As above
+          context: { options: { omitNull: true } }, // Note: As above
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`,`undefinedValue`) VALUES ($1,$2,$3,$4),($5,$6,$7,$8);',
+            bind: ['foo', 1, null, null, 'bar', 2, null, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', value: true }, { name: 'bar', value: false }]],
-          expectation: "INSERT INTO `myTable` (`name`,`value`) VALUES ('foo',true),('bar',false);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`value`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', true, 'bar', false]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { ignoreDuplicates: true }],
-          expectation: "INSERT IGNORE INTO `myTable` (`name`) VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT IGNORE INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { updateOnDuplicate: ['name'] }],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON DUPLICATE KEY UPDATE `name`=VALUES(`name`);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2) ON DUPLICATE KEY UPDATE `name`=VALUES(`name`);',
+            bind: ['foo', 'bar']
+          }
         }
       ],
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -571,40 +571,73 @@ if (dialect === 'mysql') {
       bulkInsertQuery: [
         {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }]],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: "foo';DROP TABLE myTable;" }, { name: 'bar' }]],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo\\';DROP TABLE myTable;'),('bar');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ["foo';DROP TABLE myTable;", 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', birthday: new Date(Date.UTC(2011, 2, 27, 10, 1, 55)) }, { name: 'bar', birthday: new Date(Date.UTC(2012, 2, 27, 10, 1, 55)) }]],
-          expectation: "INSERT INTO `myTable` (`name`,`birthday`) VALUES ('foo','2011-03-27 10:01:55'),('bar','2012-03-27 10:01:55');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`birthday`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', new Date('2011-03-27T10:01:55Z'), 'bar', new Date('2012-03-27T10:01:55Z')]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1 }, { name: 'bar', foo: 2 }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`) VALUES ('foo',1),('bar',2);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', 1, 'bar', 2]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',NULL,NULL);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', null, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);",
-          context: { options: { omitNull: false } }
+          context: { options: { omitNull: false } },
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);",
-          context: { options: { omitNull: true } } // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
+          context: { options: { omitNull: true } }, // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: undefined }, { name: 'bar', foo: 2, undefinedValue: undefined }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`,`undefinedValue`) VALUES ('foo',1,NULL,NULL),('bar',2,NULL,NULL);",
-          context: { options: { omitNull: true } } // Note: As above
+          context: { options: { omitNull: true } }, // Note: As above
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`,`undefinedValue`) VALUES ($1,$2,$3,$4),($5,$6,$7,$8);',
+            bind: ['foo', 1, null, null, 'bar', 2, null, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', value: true }, { name: 'bar', value: false }]],
-          expectation: "INSERT INTO `myTable` (`name`,`value`) VALUES ('foo',true),('bar',false);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`value`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', true, 'bar', false]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { ignoreDuplicates: true }],
-          expectation: "INSERT IGNORE INTO `myTable` (`name`) VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT IGNORE INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { updateOnDuplicate: ['name'] }],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON DUPLICATE KEY UPDATE `name`=VALUES(`name`);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2) ON DUPLICATE KEY UPDATE `name`=VALUES(`name`);',
+            bind: ['foo', 'bar']
+          }
         }
       ],
 

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -819,101 +819,182 @@ if (dialect.startsWith('postgres')) {
       bulkInsertQuery: [
         {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\") VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name") VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { ignoreDuplicates: true }],
-          expectation: "INSERT INTO \"myTable\" (\"name\") VALUES ('foo'),('bar') ON CONFLICT DO NOTHING;"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name") VALUES ($1),($2) ON CONFLICT DO NOTHING;',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { returning: true }],
-          expectation: "INSERT INTO \"myTable\" (\"name\") VALUES ('foo'),('bar') RETURNING *;"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name") VALUES ($1),($2) RETURNING *;',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { returning: ['id', 'sentToId'] }],
-          expectation: "INSERT INTO \"myTable\" (\"name\") VALUES ('foo'),('bar') RETURNING \"id\",\"sentToId\";"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name") VALUES ($1),($2) RETURNING "id","sentToId";',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { ignoreDuplicates: true, returning: true }],
-          expectation: "INSERT INTO \"myTable\" (\"name\") VALUES ('foo'),('bar') ON CONFLICT DO NOTHING RETURNING *;"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name") VALUES ($1),($2) ON CONFLICT DO NOTHING RETURNING *;',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: "foo';DROP TABLE myTable;" }, { name: 'bar' }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\") VALUES ('foo'';DROP TABLE myTable;'),('bar');"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name") VALUES ($1),($2);',
+            bind: ["foo';DROP TABLE myTable;", 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', birthday: moment('2011-03-27 10:01:55 +0000', 'YYYY-MM-DD HH:mm:ss Z').toDate() }, { name: 'bar', birthday: moment('2012-03-27 10:01:55 +0000', 'YYYY-MM-DD HH:mm:ss Z').toDate() }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\",\"birthday\") VALUES ('foo','2011-03-27 10:01:55.000 +00:00'),('bar','2012-03-27 10:01:55.000 +00:00');"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name","birthday") VALUES ($1,$2),($3,$4);',
+            bind: ['foo', new Date('2011-03-27 10:01:55 +0000'), 'bar', new Date('2012-03-27 10:01:55 +0000')]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1 }, { name: 'bar', foo: 2 }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\",\"foo\") VALUES ('foo',1),('bar',2);"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name","foo") VALUES ($1,$2),($3,$4);',
+            bind: ['foo', 1, 'bar', 2]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\",\"nullValue\") VALUES ('foo',NULL),('bar',NULL);"
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name","nullValue") VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\",\"nullValue\") VALUES ('foo',NULL),('bar',NULL);",
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name","nullValue") VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          },
           context: { options: { omitNull: false } }
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\",\"nullValue\") VALUES ('foo',NULL),('bar',NULL);",
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name","nullValue") VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          },
           context: { options: { omitNull: true } } // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: undefined }, { name: 'bar', nullValue: undefined }]],
-          expectation: "INSERT INTO \"myTable\" (\"name\",\"nullValue\") VALUES ('foo',NULL),('bar',NULL);",
+          expectation: {
+            query: 'INSERT INTO "myTable" ("name","nullValue") VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          },
           context: { options: { omitNull: true } } // Note: As above
         }, {
           arguments: [{ schema: 'mySchema', tableName: 'myTable' }, [{ name: 'foo' }, { name: 'bar' }]],
-          expectation: "INSERT INTO \"mySchema\".\"myTable\" (\"name\") VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT INTO "mySchema"."myTable" ("name") VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: [{ schema: 'mySchema', tableName: 'myTable' }, [{ name: JSON.stringify({ info: 'Look ma a " quote' }) }, { name: JSON.stringify({ info: 'Look ma another " quote' }) }]],
-          expectation: "INSERT INTO \"mySchema\".\"myTable\" (\"name\") VALUES ('{\"info\":\"Look ma a \\\" quote\"}'),('{\"info\":\"Look ma another \\\" quote\"}');"
+          expectation: {
+            query: 'INSERT INTO "mySchema"."myTable" ("name") VALUES ($1),($2);',
+            bind: ['{"info":"Look ma a \\" quote"}', '{"info":"Look ma another \\" quote"}']
+          }
         }, {
           arguments: [{ schema: 'mySchema', tableName: 'myTable' }, [{ name: "foo';DROP TABLE mySchema.myTable;" }, { name: 'bar' }]],
-          expectation: "INSERT INTO \"mySchema\".\"myTable\" (\"name\") VALUES ('foo'';DROP TABLE mySchema.myTable;'),('bar');"
+          expectation: {
+            query: 'INSERT INTO "mySchema"."myTable" ("name") VALUES ($1),($2);',
+            bind: ["foo';DROP TABLE mySchema.myTable;", 'bar']
+          }
         }, {
           arguments: [{ schema: 'mySchema', tableName: 'myTable' }, [{ name: 'foo' }, { name: 'bar' }], { updateOnDuplicate: ['name'], upsertKeys: ['name'] }],
-          expectation: "INSERT INTO \"mySchema\".\"myTable\" (\"name\") VALUES ('foo'),('bar') ON CONFLICT (\"name\") DO UPDATE SET \"name\"=EXCLUDED.\"name\";"
+          expectation: {
+            query: 'INSERT INTO "mySchema"."myTable" ("name") VALUES ($1),($2) ON CONFLICT ("name") DO UPDATE SET "name"=EXCLUDED."name";',
+            bind: ['foo', 'bar']
+          }
         },
 
         // Variants when quoteIdentifiers is false
         {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }]],
-          expectation: "INSERT INTO myTable (name) VALUES ('foo'),('bar');",
+          expectation: {
+            query: 'INSERT INTO myTable (name) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          },
           context: { options: { quoteIdentifiers: false } }
         }, {
           arguments: ['myTable', [{ name: "foo';DROP TABLE myTable;" }, { name: 'bar' }]],
-          expectation: "INSERT INTO myTable (name) VALUES ('foo'';DROP TABLE myTable;'),('bar');",
+          expectation: {
+            query: 'INSERT INTO myTable (name) VALUES ($1),($2);',
+            bind: ["foo';DROP TABLE myTable;", 'bar']
+          },
           context: { options: { quoteIdentifiers: false } }
         }, {
           arguments: ['myTable', [{ name: 'foo', birthday: moment('2011-03-27 10:01:55 +0000', 'YYYY-MM-DD HH:mm:ss Z').toDate() }, { name: 'bar', birthday: moment('2012-03-27 10:01:55 +0000', 'YYYY-MM-DD HH:mm:ss Z').toDate() }]],
-          expectation: "INSERT INTO myTable (name,birthday) VALUES ('foo','2011-03-27 10:01:55.000 +00:00'),('bar','2012-03-27 10:01:55.000 +00:00');",
+          expectation: {
+            query: 'INSERT INTO myTable (name,birthday) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', new Date('2011-03-27 10:01:55.000 +00:00'), 'bar', new Date('2012-03-27 10:01:55.000 +00:00')]
+          },
           context: { options: { quoteIdentifiers: false } }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1 }, { name: 'bar', foo: 2 }]],
-          expectation: "INSERT INTO myTable (name,foo) VALUES ('foo',1),('bar',2);",
+          expectation: {
+            query: 'INSERT INTO myTable (name,foo) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', 1, 'bar', 2]
+          },
           context: { options: { quoteIdentifiers: false } }
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO myTable (name,nullValue) VALUES ('foo',NULL),('bar',NULL);",
+          expectation: {
+            query: 'INSERT INTO myTable (name,nullValue) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          },
           context: { options: { quoteIdentifiers: false } }
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO myTable (name,nullValue) VALUES ('foo',NULL),('bar',NULL);",
-          context: { options: { quoteIdentifiers: false, omitNull: false } }
+          expectation: {
+            query: 'INSERT INTO myTable (name,nullValue) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          },
+          context: { options: { omitNull: false, quoteIdentifiers: false } }
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: null }, { name: 'bar', nullValue: null }]],
-          expectation: "INSERT INTO myTable (name,nullValue) VALUES ('foo',NULL),('bar',NULL);",
+          expectation: {
+            query: 'INSERT INTO myTable (name,nullValue) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          },
           context: { options: { omitNull: true, quoteIdentifiers: false } } // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
         }, {
           arguments: ['myTable', [{ name: 'foo', nullValue: undefined }, { name: 'bar', nullValue: undefined }]],
-          expectation: "INSERT INTO myTable (name,nullValue) VALUES ('foo',NULL),('bar',NULL);",
+          expectation: {
+            query: 'INSERT INTO myTable (name,nullValue) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', null, 'bar', null]
+          },
           context: { options: { omitNull: true, quoteIdentifiers: false } } // Note: As above
         }, {
           arguments: [{ schema: 'mySchema', tableName: 'myTable' }, [{ name: 'foo' }, { name: 'bar' }]],
-          expectation: "INSERT INTO mySchema.myTable (name) VALUES ('foo'),('bar');",
+          expectation: {
+            query: 'INSERT INTO mySchema.myTable (name) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          },
           context: { options: { quoteIdentifiers: false } }
         }, {
           arguments: [{ schema: 'mySchema', tableName: 'myTable' }, [{ name: JSON.stringify({ info: 'Look ma a " quote' }) }, { name: JSON.stringify({ info: 'Look ma another " quote' }) }]],
-          expectation: "INSERT INTO mySchema.myTable (name) VALUES ('{\"info\":\"Look ma a \\\" quote\"}'),('{\"info\":\"Look ma another \\\" quote\"}');",
+          expectation: {
+            query: 'INSERT INTO mySchema.myTable (name) VALUES ($1),($2);',
+            bind: ['{"info":"Look ma a \\" quote"}', '{"info":"Look ma another \\" quote"}']
+          },
           context: { options: { quoteIdentifiers: false } }
         }, {
           arguments: [{ schema: 'mySchema', tableName: 'myTable' }, [{ name: "foo';DROP TABLE mySchema.myTable;" }, { name: 'bar' }]],
-          expectation: "INSERT INTO mySchema.myTable (name) VALUES ('foo'';DROP TABLE mySchema.myTable;'),('bar');",
+          expectation: {
+            query: 'INSERT INTO mySchema.myTable (name) VALUES ($1),($2);',
+            bind: ["foo';DROP TABLE mySchema.myTable;", 'bar']
+          },
           context: { options: { quoteIdentifiers: false } }
         }
       ],

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -466,46 +466,85 @@ if (dialect === 'sqlite') {
       bulkInsertQuery: [
         {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }]],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: "'bar'" }, { name: 'foo' }]],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('''bar'''),('foo');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ["'bar'", 'foo']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', birthday: moment('2011-03-27 10:01:55 +0000', 'YYYY-MM-DD HH:mm:ss Z').toDate() }, { name: 'bar', birthday: moment('2012-03-27 10:01:55 +0000', 'YYYY-MM-DD HH:mm:ss Z').toDate() }]],
-          expectation: "INSERT INTO `myTable` (`name`,`birthday`) VALUES ('foo','2011-03-27 10:01:55.000 +00:00'),('bar','2012-03-27 10:01:55.000 +00:00');"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`birthday`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', new Date('2011-03-27 10:01:55.000 +00:00'), 'bar', new Date('2012-03-27 10:01:55.000 +00:00')]
+          }
         }, {
           arguments: ['myTable', [{ name: 'bar', value: null }, { name: 'foo', value: 1 }]],
-          expectation: "INSERT INTO `myTable` (`name`,`value`) VALUES ('bar',NULL),('foo',1);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`value`) VALUES ($1,$2),($3,$4);',
+            bind: ['bar', null, 'foo', 1]
+          }
         }, {
           arguments: ['myTable', [{ name: 'bar', value: undefined }, { name: 'bar', value: 2 }]],
-          expectation: "INSERT INTO `myTable` (`name`,`value`) VALUES ('bar',NULL),('bar',2);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`value`) VALUES ($1,$2),($3,$4);',
+            bind: ['bar', null, 'bar', 2]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', value: true }, { name: 'bar', value: false }]],
-          expectation: "INSERT INTO `myTable` (`name`,`value`) VALUES ('foo',1),('bar',0);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`value`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', true, 'bar', false]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', value: false }, { name: 'bar', value: false }]],
-          expectation: "INSERT INTO `myTable` (`name`,`value`) VALUES ('foo',0),('bar',0);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`value`) VALUES ($1,$2),($3,$4);',
+            bind: ['foo', false, 'bar', false]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);",
-          context: { options: { omitNull: false } }
+          context: { options: { omitNull: false } },
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);",
-          context: { options: { omitNull: true } } // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
+          context: { options: { omitNull: true } }, // Note: We don't honour this because it makes little sense when some rows may have nulls and others not
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo', foo: 1, nullValue: null }, { name: 'bar', foo: 2, nullValue: null }]],
-          expectation: "INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ('foo',1,NULL),('bar',2,NULL);",
-          context: { options: { omitNull: true } } // Note: As above
+          context: { options: { omitNull: true } }, // Note: As above
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`,`foo`,`nullValue`) VALUES ($1,$2,$3),($4,$5,$6);',
+            bind: ['foo', 1, null, 'bar', 2, null]
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { ignoreDuplicates: true }],
-          expectation: "INSERT OR IGNORE INTO `myTable` (`name`) VALUES ('foo'),('bar');"
+          expectation: {
+            query: 'INSERT OR IGNORE INTO `myTable` (`name`) VALUES ($1),($2);',
+            bind: ['foo', 'bar']
+          }
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { updateOnDuplicate: ['name'], upsertKeys: ['name'] }],
-          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON CONFLICT (`name`) DO UPDATE SET `name`=EXCLUDED.`name`;"
+          expectation: {
+            query: 'INSERT INTO `myTable` (`name`) VALUES ($1),($2) ON CONFLICT (`name`) DO UPDATE SET `name`=EXCLUDED.`name`;',
+            bind: ['foo', 'bar']
+          }
         }
       ],
 

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -258,15 +258,15 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
       expectsql(sql.bulkInsertQuery(User.tableName, [{ user_name: 'testuser', pass_word: '12345' }], { updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'], upsertKeys: primaryKeys }, User.fieldRawAttributesMap),
         {
-          default: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
-          snowflake: 'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\');',
+          default: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES ($1,$2);',
+          snowflake: 'INSERT INTO "users" ("user_name","pass_word") VALUES ($1,$2);',
           oracle: 'INSERT INTO "users" ("user_name","pass_word") VALUES (:1,:2)',
-          postgres: 'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\') ON CONFLICT ("user_name") DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
+          postgres: 'INSERT INTO "users" ("user_name","pass_word") VALUES ($1,$2) ON CONFLICT ("user_name") DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
           mssql: 'INSERT INTO [users] ([user_name],[pass_word]) VALUES (N\'testuser\',N\'12345\');',
           db2: 'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\');',
-          mariadb: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
-          mysql: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
-          sqlite: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON CONFLICT (`user_name`) DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
+          mariadb: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES ($1,$2) ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
+          mysql: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES ($1,$2) ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
+          sqlite: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES ($1,$2) ON CONFLICT (`user_name`) DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
         });
     });
 
@@ -286,8 +286,8 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             mssql: 'SET IDENTITY_INSERT [ms] ON; INSERT INTO [ms] DEFAULT VALUES;INSERT INTO [ms] ([id]) VALUES (0),(NULL);; SET IDENTITY_INSERT [ms] OFF;',
             postgres: 'INSERT INTO "ms" ("id") VALUES (0),(DEFAULT);',
             db2: 'INSERT INTO "ms" VALUES (1);INSERT INTO "ms" ("id") VALUES (0),(NULL);',
-            snowflake: 'INSERT INTO "ms" ("id") VALUES (0),(NULL);',
-            default: 'INSERT INTO `ms` (`id`) VALUES (0),(NULL);'
+            snowflake: 'INSERT INTO "ms" ("id") VALUES ($1),($2);',
+            default: 'INSERT INTO `ms` (`id`) VALUES ($1),($2);'
           }
         });
     });
@@ -351,9 +351,9 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             `conflictWhere not supported for dialect ${current.dialect.name}`
           ),
           'postgres':
-            'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\') ON CONFLICT ("user_name") WHERE "deleted_at" IS NULL DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
+            'INSERT INTO "users" ("user_name","pass_word") VALUES ($1,$2) ON CONFLICT ("user_name") WHERE "deleted_at" IS NULL DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
           'sqlite':
-            'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON CONFLICT (`user_name`) WHERE `deleted_at` IS NULL DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
+            'INSERT INTO `users` (`user_name`,`pass_word`) VALUES ($1,$2) ON CONFLICT (`user_name`) WHERE `deleted_at` IS NULL DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
         });
       });
     }


### PR DESCRIPTION
## Description of Changes

When using bulk create, the generated SQL does not use bindings. This creates an issue, since the data is logged along with the running query.

With this PR, the default generated SQL for a bulk insert will use bindings by default, unless `replacements` is being used, or `bindParams` is false.

## List of Breaking Changes

- abstract `QueryGenerator.bulkInsertQuery()` now returns an object with 2 properties: `query` (always returned) and `bind` (only if bind params are used)