### PR TITLE
fix(mssql): upgrade to tedious 18

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,6 @@
     "@types/sinon": "17.0.3",
     "@types/sinon-chai": "3.2.12",
     "@types/snowflake-sdk": "1.6.20",
-    "@types/tedious": "4.0.14",
     "@types/uuid": "9.0.8",
     "chai": "4.4.1",
     "chai-as-promised": "7.1.1",
@@ -104,7 +103,7 @@
     "sinon-chai": "3.7.0",
     "snowflake-sdk": "1.10.0",
     "sqlite3": "5.1.7",
-    "tedious": "16.7.0"
+    "tedious": "18.1.0"
   },
   "peerDependenciesMeta": {
     "ibm_db": {

--- a/packages/core/src/dialects/mssql/query-interface-typescript.ts
+++ b/packages/core/src/dialects/mssql/query-interface-typescript.ts
@@ -53,7 +53,6 @@ export class MsSqlQueryInterfaceTypescript<
         new Promise<void>((resolve, reject) => {
           connection.saveTransaction(
             error => (error ? reject(error) : resolve()),
-            // @ts-expect-error -- TODO: remove this when tedious types are fixed
             options.savepointName,
           );
         }),
@@ -74,7 +73,6 @@ export class MsSqlQueryInterfaceTypescript<
         new Promise<void>((resolve, reject) => {
           connection.rollbackTransaction(
             error => (error ? reject(error) : resolve()),
-            // @ts-expect-error -- TODO: remove this when tedious types are fixed
             options.savepointName,
           );
         }),

--- a/packages/core/test/integration/dialects/mssql/connection-manager.test.js
+++ b/packages/core/test/integration/dialects/mssql/connection-manager.test.js
@@ -30,7 +30,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
 
     it('ENOTFOUND', async () => {
       const sequelize = Support.createSingleTestSequelizeInstance({
-        host: 'http://wowow.example.com',
+        host: 'wowow.example.com',
       });
       await expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(
         Sequelize.HostNotFoundError,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,7 +1668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@js-joda/core@npm:^5.5.3":
+"@js-joda/core@npm:^5.6.1":
   version: 5.6.1
   resolution: "@js-joda/core@npm:5.6.1"
   checksum: 10c0/4d51c1418e426c78fbb43fa75a4de865c2ba496012f0a359604703908672a7a52dbe6602678449838cb11f995551d5afc141f1cd0343012b0d3309aaaa60054c
@@ -2227,7 +2227,6 @@ __metadata:
     "@types/sinon": "npm:17.0.3"
     "@types/sinon-chai": "npm:3.2.12"
     "@types/snowflake-sdk": "npm:1.6.20"
-    "@types/tedious": "npm:4.0.14"
     "@types/uuid": "npm:9.0.8"
     "@types/validator": "npm:^13.7.5"
     bnf-parser: "npm:3.1.6"
@@ -2266,7 +2265,7 @@ __metadata:
     sinon-chai: "npm:3.7.0"
     snowflake-sdk: "npm:1.10.0"
     sqlite3: "npm:5.1.7"
-    tedious: "npm:16.7.0"
+    tedious: "npm:18.1.0"
     toposort-class: "npm:^1.0.1"
     type-fest: "npm:^3.0.0"
     uuid: "npm:^9.0.0"
@@ -3315,7 +3314,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:20.11.24":
+"@types/node@npm:*, @types/node@npm:20.11.24, @types/node@npm:>=18":
   version: 20.11.24
   resolution: "@types/node@npm:20.11.24"
   dependencies:
@@ -3411,15 +3410,6 @@ __metadata:
     "@types/node": "npm:*"
     generic-pool: "npm:^3.9.0"
   checksum: 10c0/b49b4fd25a6d701228a9c2a0f1e0dd4d2405464606f90ff8085f5eb1d69ab811c0acde171cbe115f3a08055640c0538f968281fde848fc4e53ea5ceaa8beda58
-  languageName: node
-  linkType: hard
-
-"@types/tedious@npm:4.0.14":
-  version: 4.0.14
-  resolution: "@types/tedious@npm:4.0.14"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/d2914f8e9b5b998e4275ec5f0130cba1c2fb47e75616b5c125a65ef6c1db2f1dc3f978c7900693856a15d72bbb4f4e94f805537a4ecb6dc126c64415d31c0590
   languageName: node
   linkType: hard
 
@@ -4276,7 +4266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^6.0.3":
+"bl@npm:^6.0.11":
   version: 6.0.11
   resolution: "bl@npm:6.0.11"
   dependencies:
@@ -5372,7 +5362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.1, define-data-property@npm:^1.1.2, define-data-property@npm:^1.1.4":
+"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.2, define-data-property@npm:^1.1.4":
   version: 1.1.4
   resolution: "define-data-property@npm:1.1.4"
   dependencies:
@@ -5759,22 +5749,6 @@ __metadata:
     unbox-primitive: "npm:^1.0.2"
     which-typed-array: "npm:^1.1.14"
   checksum: 10c0/dc332c3a010c5e7b77b7ea8a4532ac455fa02e7bcabf996a47447165bafa72d0d99967407d0cf5dbbb5fbbf87f53cd8b706608ec70953523b8cd2b831b9a9d64
-  languageName: node
-  linkType: hard
-
-"es-aggregate-error@npm:^1.0.9":
-  version: 1.0.12
-  resolution: "es-aggregate-error@npm:1.0.12"
-  dependencies:
-    define-data-property: "npm:^1.1.1"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.22.3"
-    es-errors: "npm:^1.1.0"
-    function-bind: "npm:^1.1.2"
-    globalthis: "npm:^1.0.3"
-    has-property-descriptors: "npm:^1.0.1"
-    set-function-name: "npm:^2.0.1"
-  checksum: 10c0/6d8e872f405843cc95ebd5e4e0784eb7a86228ba8c2c0161be483f1065c2146bb22ba22fccb5f42bb95bbe54f136ab00cb50d688b3fb1001bf21ef82e87993a8
   languageName: node
   linkType: hard
 
@@ -8501,13 +8475,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsbi@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "jsbi@npm:4.3.0"
-  checksum: 10c0/1817ac1b50ea3f4438bcd84cadc9aee7a8657829f65b55ea6f151f401dbbd3babedbfdd3e4f481bd7b5472abb7823efa640fd7e5eee7c30cea6431f7a8b74696
-  languageName: node
-  linkType: hard
-
 "jsbn@npm:1.1.0":
   version: 1.1.0
   resolution: "jsbn@npm:1.1.0"
@@ -9967,13 +9934,6 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/1cdaee96ba3898905a9ad775dd88556478fcd73bbe815e575725209da37057d187fb96e7efb785e331f4b3725e9939014a69d2edd7bf6969fad73344e1fcaf2f
-  languageName: node
-  linkType: hard
-
-"node-abort-controller@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "node-abort-controller@npm:3.1.1"
-  checksum: 10c0/f7ad0e7a8e33809d4f3a0d1d65036a711c39e9d23e0319d80ebe076b9a3b4432b4d6b86a7fab65521de3f6872ffed36fc35d1327487c48eb88c517803403eda3
   languageName: node
   linkType: hard
 
@@ -11523,7 +11483,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0, punycode@npm:^2.3.0":
+"punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
@@ -12651,7 +12611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:^1.1.2, sprintf-js@npm:^1.1.3":
+"sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
   checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
@@ -13116,23 +13076,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tedious@npm:16.7.0":
-  version: 16.7.0
-  resolution: "tedious@npm:16.7.0"
+"tedious@npm:18.1.0":
+  version: 18.1.0
+  resolution: "tedious@npm:18.1.0"
   dependencies:
     "@azure/identity": "npm:^3.4.1"
     "@azure/keyvault-keys": "npm:^4.4.0"
-    "@js-joda/core": "npm:^5.5.3"
-    bl: "npm:^6.0.3"
-    es-aggregate-error: "npm:^1.0.9"
+    "@js-joda/core": "npm:^5.6.1"
+    "@types/node": "npm:>=18"
+    bl: "npm:^6.0.11"
     iconv-lite: "npm:^0.6.3"
     js-md4: "npm:^0.3.2"
-    jsbi: "npm:^4.3.0"
     native-duplexpair: "npm:^1.0.0"
-    node-abort-controller: "npm:^3.1.1"
-    punycode: "npm:^2.3.0"
-    sprintf-js: "npm:^1.1.2"
-  checksum: 10c0/fc925c993e35f2e55abffc862a5ef47adc2ac998b7ca3ad3fb7235dbfb998ab0977c9bb48b09071bbcab12e02059518c9ed9edc9a308cb9d22a88a1335c833d0
+    sprintf-js: "npm:^1.1.3"
+  checksum: 10c0/f9bda17d5d394885a757cffcfb51ce9b35e29ca58a85a03e0e73e03392e84f4a8e665f4d33498725ef24b3a0c519d331b6ca18971c6a5dbaed471f937634f225
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

Tedious 18 now ships with first-party typings so we can remove `@types/tedious`.
Drafting this for now since I want to check what we've put in the docs for TypeScript usage of mssql.

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->

People that use TypeScript should upgrade to v18 as well.
