### PR TITLE
fix: unify returning queries 

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2531,7 +2531,7 @@ ${associationOwner._getAssociationDebugList()}`);
                 !instance ||
                 (key === model.primaryKeyAttribute &&
                   instance.get(model.primaryKeyAttribute) &&
-                  ['mysql', 'mariadb', 'sqlite3'].includes(dialect))
+                  ['mysql', 'mariadb'].includes(dialect))
               ) {
                 // The query.js for these DBs is blind, it autoincrements the
                 // primarykey value, even if it was set manually. Also, it can

--- a/packages/core/test/integration/model/update.test.ts
+++ b/packages/core/test/integration/model/update.test.ts
@@ -451,6 +451,8 @@ describe('Model.update', () => {
 
             expectsql(sqlQuery, {
               default: `UPDATE [users1] SET [secretValue]=$sequelize_1,[updatedAt]=$sequelize_2 WHERE [id] = $sequelize_3`,
+              sqlite3:
+                'UPDATE `users1` SET `secretValue`=$sequelize_1,`updatedAt`=$sequelize_2 WHERE `id` = $sequelize_3 RETURNING *',
               postgres: `UPDATE "users1" SET "secretValue"=$1,"updatedAt"=$2 WHERE "id" = $3 RETURNING *`,
               mysql: 'UPDATE `users1` SET `secretValue`=?,`updatedAt`=? WHERE `id` = ?',
               mariadb: 'UPDATE `users1` SET `secretValue`=?,`updatedAt`=? WHERE `id` = ?',

--- a/packages/core/test/integration/model/upsert.test.js
+++ b/packages/core/test/integration/model/upsert.test.js
@@ -63,7 +63,7 @@ describe('Model', () => {
     describe('upsert', () => {
       it('works with upsert on id', async function () {
         const [, created0] = await this.User.upsert({ id: 42, username: 'john' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.true;
@@ -71,7 +71,7 @@ describe('Model', () => {
 
         this.clock.tick(1000);
         const [, created] = await this.User.upsert({ id: 42, username: 'doe' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -85,7 +85,7 @@ describe('Model', () => {
 
       it('works with upsert on a composite key', async function () {
         const [, created0] = await this.User.upsert({ foo: 'baz', bar: 19, username: 'john' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.true;
@@ -93,7 +93,7 @@ describe('Model', () => {
 
         this.clock.tick(1000);
         const [, created] = await this.User.upsert({ foo: 'baz', bar: 19, username: 'doe' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -144,7 +144,7 @@ describe('Model', () => {
           User.upsert({ a: 'a', b: 'a', username: 'curt' }),
         ]);
 
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created1[1]).to.be.null;
           expect(created2[1]).to.be.null;
         } else {
@@ -155,7 +155,7 @@ describe('Model', () => {
         this.clock.tick(1000);
         // Update the first one
         const [, created] = await User.upsert({ a: 'a', b: 'b', username: 'doe' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -202,7 +202,7 @@ describe('Model', () => {
 
         await User.sync({ force: true });
         const [, created] = await User.upsert({ id: 1, email: 'notanemail' }, options);
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.true;
@@ -215,7 +215,7 @@ describe('Model', () => {
           username: 'john',
           blob: Buffer.from('kaj'),
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.ok;
@@ -227,7 +227,7 @@ describe('Model', () => {
           username: 'doe',
           blob: Buffer.from('andrea'),
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -242,14 +242,14 @@ describe('Model', () => {
 
       it('works with .field', async function () {
         const [, created0] = await this.User.upsert({ id: 42, baz: 'foo' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.ok;
         }
 
         const [, created] = await this.User.upsert({ id: 42, baz: 'oof' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -261,7 +261,7 @@ describe('Model', () => {
 
       it('works with primary key using .field', async function () {
         const [, created0] = await this.ModelWithFieldPK.upsert({ userId: 42, foo: 'first' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.ok;
@@ -269,7 +269,7 @@ describe('Model', () => {
 
         this.clock.tick(1000);
         const [, created] = await this.ModelWithFieldPK.upsert({ userId: 42, foo: 'second' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -285,7 +285,7 @@ describe('Model', () => {
           username: 'john',
           foo: this.sequelize.fn('upper', 'mixedCase1'),
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.ok;
@@ -297,7 +297,7 @@ describe('Model', () => {
           username: 'doe',
           foo: this.sequelize.fn('upper', 'mixedCase2'),
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -380,7 +380,7 @@ describe('Model', () => {
         await this.User.create({ id: 42, username: 'john' });
         const user = await this.User.findByPk(42);
         const [, created] = await this.User.upsert({ id: user.id, username: user.username });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           // After set node-mysql flags = '-FOUND_ROWS' / foundRows=false
@@ -410,7 +410,7 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'City',
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.ok;
@@ -421,7 +421,7 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'New City',
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -462,7 +462,7 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'City',
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.ok;
@@ -473,7 +473,7 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'New City',
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).to.be.false;
@@ -506,7 +506,7 @@ describe('Model', () => {
 
         await User.sync({ force: true });
         const [, created0] = await User.upsert({ name: 'user1', address: 'address', city: 'City' });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
         } else {
           expect(created0).to.be.ok;
@@ -517,7 +517,7 @@ describe('Model', () => {
           address: 'address',
           city: 'New City',
         });
-        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
         } else {
           expect(created).not.to.be.ok;
@@ -618,7 +618,7 @@ describe('Model', () => {
             );
             expect(user0.get('id')).to.equal(42);
             expect(user0.get('username')).to.equal('john');
-            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
               expect(created0).to.be.null;
             } else {
               expect(created0).to.be.true;
@@ -630,7 +630,7 @@ describe('Model', () => {
             );
             expect(user.get('id')).to.equal(42);
             expect(user.get('username')).to.equal('doe');
-            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
             } else {
               expect(created).to.be.false;
@@ -657,7 +657,7 @@ describe('Model', () => {
             );
             expect(user0.get('id')).to.equal(42);
             expect(user0.get('username')).to.equal('john');
-            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
               expect(created0).to.be.null;
             } else {
               expect(created0).to.be.true;
@@ -669,7 +669,7 @@ describe('Model', () => {
             );
             expect(user.get('id')).to.equal(42);
             expect(user.get('username')).to.equal('doe');
-            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
             } else {
               expect(created).to.be.false;
@@ -695,7 +695,7 @@ describe('Model', () => {
             );
             expect(user0.get('id')).to.equal('surya');
             expect(user0.get('username')).to.equal('john');
-            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
               expect(created0).to.be.null;
             } else {
               expect(created0).to.be.true;
@@ -707,7 +707,7 @@ describe('Model', () => {
             );
             expect(user.get('id')).to.equal('surya');
             expect(user.get('username')).to.equal('doe');
-            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
             } else {
               expect(created).to.be.false;
@@ -730,7 +730,7 @@ describe('Model', () => {
             expect(user.name).to.equal('Test default value');
             expect(user.code).to.equal(2020);
 
-            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
             } else {
               expect(created).to.be.true;

--- a/packages/core/test/integration/model/upsert.test.js
+++ b/packages/core/test/integration/model/upsert.test.js
@@ -63,20 +63,16 @@ describe('Model', () => {
     describe('upsert', () => {
       it('works with upsert on id', async function () {
         const [, created0] = await this.User.upsert({ id: 42, username: 'john' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.true;
         }
 
         this.clock.tick(1000);
         const [, created] = await this.User.upsert({ id: 42, username: 'doe' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -89,20 +85,16 @@ describe('Model', () => {
 
       it('works with upsert on a composite key', async function () {
         const [, created0] = await this.User.upsert({ foo: 'baz', bar: 19, username: 'john' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.true;
         }
 
         this.clock.tick(1000);
         const [, created] = await this.User.upsert({ foo: 'baz', bar: 19, username: 'doe' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -152,12 +144,9 @@ describe('Model', () => {
           User.upsert({ a: 'a', b: 'a', username: 'curt' }),
         ]);
 
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created1[1]).to.be.null;
           expect(created2[1]).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created1[1]).to.be.undefined;
-          expect(created2[1]).to.be.undefined;
         } else {
           expect(created1[1]).to.be.true;
           expect(created2[1]).to.be.true;
@@ -166,10 +155,8 @@ describe('Model', () => {
         this.clock.tick(1000);
         // Update the first one
         const [, created] = await User.upsert({ a: 'a', b: 'b', username: 'doe' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -215,10 +202,8 @@ describe('Model', () => {
 
         await User.sync({ force: true });
         const [, created] = await User.upsert({ id: 1, email: 'notanemail' }, options);
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.true;
         }
@@ -230,10 +215,8 @@ describe('Model', () => {
           username: 'john',
           blob: Buffer.from('kaj'),
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.ok;
         }
@@ -244,10 +227,8 @@ describe('Model', () => {
           username: 'doe',
           blob: Buffer.from('andrea'),
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -261,19 +242,15 @@ describe('Model', () => {
 
       it('works with .field', async function () {
         const [, created0] = await this.User.upsert({ id: 42, baz: 'foo' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.ok;
         }
 
         const [, created] = await this.User.upsert({ id: 42, baz: 'oof' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -284,20 +261,16 @@ describe('Model', () => {
 
       it('works with primary key using .field', async function () {
         const [, created0] = await this.ModelWithFieldPK.upsert({ userId: 42, foo: 'first' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.ok;
         }
 
         this.clock.tick(1000);
         const [, created] = await this.ModelWithFieldPK.upsert({ userId: 42, foo: 'second' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -312,10 +285,8 @@ describe('Model', () => {
           username: 'john',
           foo: this.sequelize.fn('upper', 'mixedCase1'),
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.ok;
         }
@@ -326,10 +297,8 @@ describe('Model', () => {
           username: 'doe',
           foo: this.sequelize.fn('upper', 'mixedCase2'),
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -411,10 +380,8 @@ describe('Model', () => {
         await this.User.create({ id: 42, username: 'john' });
         const user = await this.User.findByPk(42);
         const [, created] = await this.User.upsert({ id: user.id, username: user.username });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           // After set node-mysql flags = '-FOUND_ROWS' / foundRows=false
           // result from upsert should be false when upsert a row to its current value
@@ -443,10 +410,8 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'City',
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.ok;
         }
@@ -456,10 +421,8 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'New City',
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -499,10 +462,8 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'City',
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.ok;
         }
@@ -512,10 +473,8 @@ describe('Model', () => {
           email: 'user1@domain.ext',
           city: 'New City',
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).to.be.false;
         }
@@ -547,10 +506,8 @@ describe('Model', () => {
 
         await User.sync({ force: true });
         const [, created0] = await User.upsert({ name: 'user1', address: 'address', city: 'City' });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created0).to.be.undefined;
         } else {
           expect(created0).to.be.ok;
         }
@@ -560,10 +517,8 @@ describe('Model', () => {
           address: 'address',
           city: 'New City',
         });
-        if (['sqlite3', 'postgres'].includes(dialectName)) {
+        if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
-        } else if (dialectName === 'db2') {
-          expect(created).to.be.undefined;
         } else {
           expect(created).not.to.be.ok;
         }
@@ -663,7 +618,7 @@ describe('Model', () => {
             );
             expect(user0.get('id')).to.equal(42);
             expect(user0.get('username')).to.equal('john');
-            if (['sqlite3', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
               expect(created0).to.be.null;
             } else {
               expect(created0).to.be.true;
@@ -675,7 +630,7 @@ describe('Model', () => {
             );
             expect(user.get('id')).to.equal(42);
             expect(user.get('username')).to.equal('doe');
-            if (['sqlite3', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
             } else {
               expect(created).to.be.false;
@@ -702,7 +657,7 @@ describe('Model', () => {
             );
             expect(user0.get('id')).to.equal(42);
             expect(user0.get('username')).to.equal('john');
-            if (['sqlite3', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
               expect(created0).to.be.null;
             } else {
               expect(created0).to.be.true;
@@ -714,7 +669,7 @@ describe('Model', () => {
             );
             expect(user.get('id')).to.equal(42);
             expect(user.get('username')).to.equal('doe');
-            if (['sqlite3', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
             } else {
               expect(created).to.be.false;
@@ -740,7 +695,7 @@ describe('Model', () => {
             );
             expect(user0.get('id')).to.equal('surya');
             expect(user0.get('username')).to.equal('john');
-            if (['sqlite3', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
               expect(created0).to.be.null;
             } else {
               expect(created0).to.be.true;
@@ -752,7 +707,7 @@ describe('Model', () => {
             );
             expect(user.get('id')).to.equal('surya');
             expect(user.get('username')).to.equal('doe');
-            if (['sqlite3', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
             } else {
               expect(created).to.be.false;
@@ -775,10 +730,8 @@ describe('Model', () => {
             expect(user.name).to.equal('Test default value');
             expect(user.code).to.equal(2020);
 
-            if (['sqlite3', 'postgres'].includes(dialectName)) {
+            if (['db2', 'sqlite', 'postgres'].includes(dialectName)) {
               expect(created).to.be.null;
-            } else if (dialectName === 'db2') {
-              expect(created).to.be.undefined;
             } else {
               expect(created).to.be.true;
             }

--- a/packages/core/test/unit/query-generator/arithmetic-query.test.ts
+++ b/packages/core/test/unit/query-generator/arithmetic-query.test.ts
@@ -23,14 +23,16 @@ describe('QueryGenerator#arithmeticQuery', () => {
 
     expectsql(sqlPlus, {
       default: `UPDATE [myTable] SET [foo]=[foo]+ 3`,
-      postgres: `UPDATE "myTable" SET "foo"="foo"+ 3 RETURNING *`,
       mssql: `UPDATE [myTable] SET [foo]=[foo]+ 3 OUTPUT INSERTED.*`,
+      sqlite3: 'UPDATE `myTable` SET `foo`=`foo`+ 3 RETURNING *',
+      postgres: `UPDATE "myTable" SET "foo"="foo"+ 3 RETURNING *`,
     });
 
     expectsql(sqlMinus, {
       default: `UPDATE [myTable] SET [foo]=[foo]- 3`,
-      postgres: `UPDATE "myTable" SET "foo"="foo"- 3 RETURNING *`,
       mssql: `UPDATE [myTable] SET [foo]=[foo]- 3 OUTPUT INSERTED.*`,
+      sqlite3: 'UPDATE `myTable` SET `foo`=`foo`- 3 RETURNING *',
+      postgres: `UPDATE "myTable" SET "foo"="foo"- 3 RETURNING *`,
     });
   });
 
@@ -39,8 +41,9 @@ describe('QueryGenerator#arithmeticQuery', () => {
 
     expectsql(sql, {
       default: `UPDATE [myTable] SET [foo]=[foo]+ bar`,
-      postgres: `UPDATE "myTable" SET "foo"="foo"+ bar RETURNING *`,
       mssql: `UPDATE [myTable] SET [foo]=[foo]+ bar OUTPUT INSERTED.*`,
+      sqlite3: 'UPDATE `myTable` SET `foo`=`foo`+ bar RETURNING *',
+      postgres: `UPDATE "myTable" SET "foo"="foo"+ bar RETURNING *`,
     });
   });
 
@@ -49,8 +52,9 @@ describe('QueryGenerator#arithmeticQuery', () => {
 
     expectsql(sql, {
       default: `UPDATE [myTable] SET [foo]=[foo]+ 3 WHERE [bar] = 'biz'`,
-      postgres: `UPDATE "myTable" SET "foo"="foo"+ 3 WHERE "bar" = 'biz' RETURNING *`,
       mssql: `UPDATE [myTable] SET [foo]=[foo]+ 3 OUTPUT INSERTED.* WHERE [bar] = N'biz'`,
+      sqlite3: "UPDATE `myTable` SET `foo`=`foo`+ 3 WHERE `bar` = 'biz' RETURNING *",
+      postgres: `UPDATE "myTable" SET "foo"="foo"+ 3 WHERE "bar" = 'biz' RETURNING *`,
     });
   });
 
@@ -74,8 +78,9 @@ describe('QueryGenerator#arithmeticQuery', () => {
 
     expectsql(sql, {
       default: `UPDATE [myTable] SET [foo]=[foo]- -1`,
-      postgres: `UPDATE "myTable" SET "foo"="foo"- -1 RETURNING *`,
       mssql: `UPDATE [myTable] SET [foo]=[foo]- -1 OUTPUT INSERTED.*`,
+      sqlite3: 'UPDATE `myTable` SET `foo`=`foo`- -1 RETURNING *',
+      postgres: `UPDATE "myTable" SET "foo"="foo"- -1 RETURNING *`,
     });
   });
 
@@ -107,8 +112,9 @@ describe('QueryGenerator#arithmeticQuery', () => {
 
     expectsql(sql, {
       default: `UPDATE [Users] SET [age]=[age]+ 2,[name]='John' WHERE id = 47`,
-      postgres: `UPDATE "Users" SET "age"="age"+ 2,"name"='John' WHERE id = 47 RETURNING *`,
       mssql: `UPDATE [Users] SET [age]=[age]+ 2,[name]=N'John' OUTPUT INSERTED.* WHERE id = 47`,
+      sqlite3: "UPDATE `Users` SET `age`=`age`+ 2,`name`='John' WHERE id = 47 RETURNING *",
+      postgres: `UPDATE "Users" SET "age"="age"+ 2,"name"='John' WHERE id = 47 RETURNING *`,
     });
   });
 });

--- a/packages/core/test/unit/query-generator/insert-query.test.ts
+++ b/packages/core/test/unit/query-generator/insert-query.test.ts
@@ -150,7 +150,7 @@ describe('QueryGenerator#insertQuery', () => {
       expectsql(query, {
         default: `INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1) RETURNING [id], [firstName];`,
         // TODO: insertQuery should throw if returning is not supported
-        'mysql mariadb sqlite3': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
+        'mysql mariadb': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
         // TODO: insertQuery should throw if returning is not supported
         snowflake: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1);`,
         mssql:
@@ -177,7 +177,7 @@ describe('QueryGenerator#insertQuery', () => {
       expectsql(query, {
         default: `INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1) RETURNING [*], [myColumn];`,
         // TODO: insertQuery should throw if returning is not supported
-        'mysql mariadb sqlite3': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
+        'mysql mariadb': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
         // TODO: insertQuery should throw if returning is not supported
         snowflake: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1);`,
         mssql:
@@ -207,7 +207,7 @@ describe('QueryGenerator#insertQuery', () => {
         {
           default: `INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1) RETURNING *;`,
           // TODO: insertQuery should throw if returning is not supported
-          'mysql mariadb sqlite3': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
+          'mysql mariadb': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
           // TODO: insertQuery should throw if returning is not supported
           snowflake: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1);`,
           mssql: new Error(

--- a/packages/core/test/unit/query-interface/decrement.test.ts
+++ b/packages/core/test/unit/query-interface/decrement.test.ts
@@ -49,8 +49,10 @@ describe('QueryInterface#decrement', () => {
     const firstCall = stub.getCall(0);
     expectsql(firstCall.args[0], {
       default: `UPDATE [Users] SET [age]=[age]- ':age',[name]=':name' WHERE [firstName] = ':firstName'`,
-      postgres: `UPDATE "Users" SET "age"="age"- ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
       mssql: `UPDATE [Users] SET [age]=[age]- N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [firstName] = N':firstName'`,
+      sqlite3:
+        "UPDATE `Users` SET `age`=`age`- ':age',`name`=':name' WHERE `firstName` = ':firstName' RETURNING `:data`",
+      postgres: `UPDATE "Users" SET "age"="age"- ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
     });
     expect(firstCall.args[1]?.bind).to.be.undefined;
   });

--- a/packages/core/test/unit/query-interface/increment.test.ts
+++ b/packages/core/test/unit/query-interface/increment.test.ts
@@ -49,8 +49,10 @@ describe('QueryInterface#increment', () => {
     const firstCall = stub.getCall(0);
     expectsql(firstCall.args[0], {
       default: `UPDATE [Users] SET [age]=[age]+ ':age',[name]=':name' WHERE [firstName] = ':firstName'`,
-      postgres: `UPDATE "Users" SET "age"="age"+ ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
       mssql: `UPDATE [Users] SET [age]=[age]+ N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [firstName] = N':firstName'`,
+      sqlite3:
+        "UPDATE `Users` SET `age`=`age`+ ':age',`name`=':name' WHERE `firstName` = ':firstName' RETURNING `:data`",
+      postgres: `UPDATE "Users" SET "age"="age"+ ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
     });
     expect(firstCall.args[1]?.bind).to.be.undefined;
   });

--- a/packages/core/test/unit/query-interface/insert.test.ts
+++ b/packages/core/test/unit/query-interface/insert.test.ts
@@ -42,8 +42,9 @@ describe('QueryInterface#insert', () => {
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
     expectsql(firstCall.args[0], {
-      postgres: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1) RETURNING ":data";`,
       default: 'INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1);',
+      sqlite3: 'INSERT INTO `Users` (`firstName`) VALUES ($sequelize_1) RETURNING `:data`;',
+      postgres: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1) RETURNING ":data";`,
       mssql: `INSERT INTO [Users] ([firstName]) OUTPUT INSERTED.[:data] VALUES ($sequelize_1);`,
       db2: `SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1));`,
       ibmi: `SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1))`,

--- a/packages/core/test/unit/query-interface/update.test.ts
+++ b/packages/core/test/unit/query-interface/update.test.ts
@@ -45,6 +45,8 @@ describe('QueryInterface#update', () => {
     const firstCall = stub.getCall(0);
     expectsql(firstCall.args[0], {
       default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [firstName] = $sequelize_2',
+      sqlite3:
+        'UPDATE `Users` SET `firstName`=$sequelize_1 WHERE `firstName` = $sequelize_2 RETURNING `:data`',
       postgres:
         'UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "firstName" = $sequelize_2 RETURNING ":data"',
       mssql:

--- a/packages/core/test/unit/sql/insert.test.js
+++ b/packages/core/test/unit/sql/insert.test.js
@@ -39,6 +39,8 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("user_name") VALUES ($sequelize_1))',
             mssql:
               'DECLARE @tmp TABLE ([id] INTEGER,[user_name] NVARCHAR(255)); INSERT INTO [users] ([user_name]) OUTPUT INSERTED.[id], INSERTED.[user_name] INTO @tmp VALUES ($sequelize_1); SELECT * FROM @tmp;',
+            sqlite3:
+              'INSERT INTO `users` (`user_name`) VALUES ($sequelize_1) RETURNING `id`, `user_name`;',
             postgres:
               'INSERT INTO "users" ("user_name") VALUES ($sequelize_1) RETURNING "id", "user_name";',
             db2: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("user_name") VALUES ($sequelize_1));',

--- a/packages/core/test/unit/sql/update.test.js
+++ b/packages/core/test/unit/sql/update.test.js
@@ -81,6 +81,8 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             ibmi: 'UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2',
             mssql:
               'DECLARE @tmp TABLE ([id] INTEGER,[user_name] NVARCHAR(255)); UPDATE [users] SET [user_name]=$sequelize_1 OUTPUT INSERTED.[id], INSERTED.[user_name] INTO @tmp WHERE [id] = $sequelize_2; SELECT * FROM @tmp',
+            sqlite3:
+              'UPDATE `users` SET `user_name`=$sequelize_1 WHERE `id` = $sequelize_2 RETURNING `id`, `user_name`',
             postgres:
               'UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2 RETURNING "id", "user_name"',
             db2: 'SELECT * FROM FINAL TABLE (UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2);',

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -1885,7 +1885,7 @@ Caused by: "undefined" cannot be escaped`),
       //  postgres:, ^@
       //  snowflake, ibmi, db2: position()
       //  mssql: CHARINDEX()
-      //  sqlite: INSTR()
+      //  sqlite3: INSTR()
 
       testSql(
         {
@@ -2137,7 +2137,7 @@ Caused by: "undefined" cannot be escaped`),
       //  postgres:, position()
       //  snowflake, ibmi, db2: position()
       //  mssql: CHARINDEX()
-      //  sqlite: INSTR()
+      //  sqlite3: INSTR()
 
       testSql(
         {

--- a/packages/db2/src/query-interface.js
+++ b/packages/db2/src/query-interface.js
@@ -75,9 +75,7 @@ export class Db2QueryInterface extends Db2QueryInterfaceTypeScript {
 
     delete options.replacements;
 
-    const result = await this.sequelize.queryRaw(sql, options);
-
-    return [result, undefined];
+    return this.sequelize.queryRaw(sql, options);
   }
 
   // TODO: drop "schema" options from the option bag, it must be passed through tableName instead.

--- a/packages/postgres/src/query.js
+++ b/packages/postgres/src/query.js
@@ -287,21 +287,16 @@ export class PostgresQuery extends AbstractQuery {
           throw new EmptyResultError();
         }
 
-        if (rows[0]) {
+        if (Array.isArray(rows) && rows[0]) {
           for (const attributeOrColumnName of Object.keys(rows[0])) {
             const modelDefinition = this.model.modelDefinition;
-
-            // TODO: this should not be searching in both column names & attribute names. It will lead to collisions. Use only one or the other.
-            const attribute =
-              modelDefinition.attributes.get(attributeOrColumnName) ??
-              modelDefinition.columns.get(attributeOrColumnName);
-
+            const attribute = modelDefinition.columns.get(attributeOrColumnName);
             const updatedValue = this._parseDatabaseValue(
               rows[0][attributeOrColumnName],
               attribute?.type,
             );
 
-            this.instance.set(attribute?.fieldName ?? attributeOrColumnName, updatedValue, {
+            this.instance.set(attribute?.attributeName ?? attributeOrColumnName, updatedValue, {
               raw: true,
               comesFromDatabase: true,
             });

--- a/packages/sqlite3/src/dialect.ts
+++ b/packages/sqlite3/src/dialect.ts
@@ -45,6 +45,7 @@ export class SqliteDialect extends AbstractDialect<SqliteDialectOptions, SqliteC
     'DEFAULT VALUES': true,
     'UNION ALL': false,
     'RIGHT JOIN': false,
+    returnValues: 'returning',
     inserts: {
       ignoreDuplicates: ' OR IGNORE',
       updateOnDuplicate: ' ON CONFLICT DO UPDATE SET',

--- a/packages/sqlite3/src/query-generator.js
+++ b/packages/sqlite3/src/query-generator.js
@@ -130,6 +130,16 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
     const values = [];
     const bind = Object.create(null);
     const bindParam = options.bindParam === undefined ? this.bindParam(bind) : options.bindParam;
+    let suffix = '';
+
+    if (options.returning) {
+      const returnValues = this.generateReturnValues(attributes, options);
+
+      suffix += returnValues.returningFragment;
+
+      // ensure that the return output is properly mapped to model fields.
+      options.mapToModel = true;
+    }
 
     if (attributes) {
       each(attributes, (attribute, key) => {
@@ -158,10 +168,10 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
 
     if (options.limit) {
       query =
-        `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${this.whereQuery(where, whereOptions)} LIMIT ${this.escape(options.limit, undefined, options)})`.trim();
+        `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${this.whereQuery(where, whereOptions)} LIMIT ${this.escape(options.limit, undefined, options)})${suffix}`.trim();
     } else {
       query =
-        `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} ${this.whereQuery(where, whereOptions)}`.trim();
+        `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} ${this.whereQuery(where, whereOptions)}${suffix}`.trim();
     }
 
     const result = { query };


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This is another change split from #16988.

This PR unifies the way data from the database is mapped to a Model instance for inserts, updates and upserts.

## List of Breaking Changes

SQLite now supports returning database values from inserts, updates and upserts.
