### PR TITLE
fix: make `BaseSqlExpression` a unique class

### DIFF
--- a/packages/core/src/expression-builders/association-path.ts
+++ b/packages/core/src/expression-builders/association-path.ts
@@ -1,7 +1,7 @@
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 export class AssociationPath extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'associationPath';
+  protected declare readonly [SQL_IDENTIFIER]: 'associationPath';
 
   constructor(
     readonly associationPath: readonly string[],

--- a/packages/core/src/expression-builders/association-path.ts
+++ b/packages/core/src/expression-builders/association-path.ts
@@ -1,7 +1,7 @@
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 export class AssociationPath extends BaseSqlExpression {
-  private declare readonly brand: 'associationPath';
+  static readonly [SQL_IDENTIFIER]: string = 'associationPath';
 
   constructor(
     readonly associationPath: readonly string[],

--- a/packages/core/src/expression-builders/association-path.ts
+++ b/packages/core/src/expression-builders/association-path.ts
@@ -1,7 +1,7 @@
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 export class AssociationPath extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'associationPath';
+  protected readonly [SQL_IDENTIFIER]: string = 'associationPath';
 
   constructor(
     readonly associationPath: readonly string[],

--- a/packages/core/src/expression-builders/attribute.ts
+++ b/packages/core/src/expression-builders/attribute.ts
@@ -9,7 +9,7 @@ import type { JsonPath } from './json-path.js';
  * Use {@link attribute} instead.
  */
 export class Attribute extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'attribute';
+  protected readonly [SQL_IDENTIFIER]: string = 'attribute';
 
   constructor(readonly attributeName: string) {
     super();

--- a/packages/core/src/expression-builders/attribute.ts
+++ b/packages/core/src/expression-builders/attribute.ts
@@ -1,6 +1,6 @@
 import { parseAttributeSyntax } from '../utils/attribute-syntax.js';
 import type { AssociationPath } from './association-path.js';
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 import type { Cast } from './cast.js';
 import type { DialectAwareFn } from './dialect-aware-fn.js';
 import type { JsonPath } from './json-path.js';
@@ -9,7 +9,7 @@ import type { JsonPath } from './json-path.js';
  * Use {@link attribute} instead.
  */
 export class Attribute extends BaseSqlExpression {
-  private declare readonly brand: 'attribute';
+  static readonly [SQL_IDENTIFIER]: string = 'attribute';
 
   constructor(readonly attributeName: string) {
     super();

--- a/packages/core/src/expression-builders/attribute.ts
+++ b/packages/core/src/expression-builders/attribute.ts
@@ -9,7 +9,7 @@ import type { JsonPath } from './json-path.js';
  * Use {@link attribute} instead.
  */
 export class Attribute extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'attribute';
+  protected declare readonly [SQL_IDENTIFIER]: 'attribute';
 
   constructor(readonly attributeName: string) {
     super();

--- a/packages/core/src/expression-builders/base-sql-expression.ts
+++ b/packages/core/src/expression-builders/base-sql-expression.ts
@@ -14,7 +14,7 @@ import type { Where } from './where.js';
 /**
  * A symbol that can be used as the key for a static property on a BaseSqlExpression class to uniquely identify it.
  */
-export const SQL_IDENTIFIER = Symbol('SQL_IDENTIFIER');
+export declare const SQL_IDENTIFIER: unique symbol;
 
 /**
  * Utility functions for representing SQL functions, and columns that should be escaped.
@@ -23,7 +23,7 @@ export const SQL_IDENTIFIER = Symbol('SQL_IDENTIFIER');
  * @private
  */
 export class BaseSqlExpression {
-  declare static readonly [SQL_IDENTIFIER]: string;
+  protected declare readonly [SQL_IDENTIFIER]: string;
 }
 
 export type DynamicSqlExpression =

--- a/packages/core/src/expression-builders/base-sql-expression.ts
+++ b/packages/core/src/expression-builders/base-sql-expression.ts
@@ -12,12 +12,19 @@ import type { Value } from './value.js';
 import type { Where } from './where.js';
 
 /**
+ * A symbol that can be used as the key for a static property on a BaseSqlExpression class to uniquely identify it.
+ */
+export const SQL_IDENTIFIER = Symbol('SQL_IDENTIFIER');
+
+/**
  * Utility functions for representing SQL functions, and columns that should be escaped.
  * Please do not use these functions directly, use Sequelize.fn and Sequelize.col instead.
  *
  * @private
  */
-export class BaseSqlExpression {}
+export class BaseSqlExpression {
+  declare static readonly [SQL_IDENTIFIER]: string;
+}
 
 export type DynamicSqlExpression =
   | List

--- a/packages/core/src/expression-builders/cast.ts
+++ b/packages/core/src/expression-builders/cast.ts
@@ -2,14 +2,14 @@ import { isPlainObject } from '@sequelize/utils';
 import type { DataType } from '../abstract-dialect/data-types.js';
 import { Op } from '../operators.js';
 import type { Expression } from '../sequelize.js';
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 import { where } from './where.js';
 
 /**
  * Do not use me directly. Use {@link cast}
  */
 export class Cast extends BaseSqlExpression {
-  private declare readonly brand: 'cast';
+  static readonly [SQL_IDENTIFIER]: string = 'cast';
 
   constructor(
     readonly expression: Expression,

--- a/packages/core/src/expression-builders/cast.ts
+++ b/packages/core/src/expression-builders/cast.ts
@@ -9,7 +9,7 @@ import { where } from './where.js';
  * Do not use me directly. Use {@link cast}
  */
 export class Cast extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'cast';
+  protected readonly [SQL_IDENTIFIER]: string = 'cast';
 
   constructor(
     readonly expression: Expression,

--- a/packages/core/src/expression-builders/cast.ts
+++ b/packages/core/src/expression-builders/cast.ts
@@ -9,7 +9,7 @@ import { where } from './where.js';
  * Do not use me directly. Use {@link cast}
  */
 export class Cast extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'cast';
+  protected declare readonly [SQL_IDENTIFIER]: 'cast';
 
   constructor(
     readonly expression: Expression,

--- a/packages/core/src/expression-builders/col.ts
+++ b/packages/core/src/expression-builders/col.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link col}
  */
 export class Col extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'col';
+  protected readonly [SQL_IDENTIFIER]: string = 'col';
 
   readonly identifiers: string[];
 

--- a/packages/core/src/expression-builders/col.ts
+++ b/packages/core/src/expression-builders/col.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link col}
  */
 export class Col extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'col';
+  protected declare readonly [SQL_IDENTIFIER]: 'col';
 
   readonly identifiers: string[];
 

--- a/packages/core/src/expression-builders/col.ts
+++ b/packages/core/src/expression-builders/col.ts
@@ -1,10 +1,10 @@
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
  * Do not use me directly. Use {@link col}
  */
 export class Col extends BaseSqlExpression {
-  private declare readonly brand: 'col';
+  static readonly [SQL_IDENTIFIER]: string = 'col';
 
   readonly identifiers: string[];
 

--- a/packages/core/src/expression-builders/fn.ts
+++ b/packages/core/src/expression-builders/fn.ts
@@ -1,14 +1,14 @@
 import { isPlainObject } from '@sequelize/utils';
 import { Op } from '../operators.js';
 import type { Expression } from '../sequelize.js';
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 import { where } from './where.js';
 
 /**
  * Do not use me directly. Use {@link fn}
  */
 export class Fn extends BaseSqlExpression {
-  private declare readonly brand: 'fn';
+  static readonly [SQL_IDENTIFIER]: string = 'fn';
 
   readonly fn: string;
   readonly args: readonly Expression[];

--- a/packages/core/src/expression-builders/fn.ts
+++ b/packages/core/src/expression-builders/fn.ts
@@ -8,7 +8,7 @@ import { where } from './where.js';
  * Do not use me directly. Use {@link fn}
  */
 export class Fn extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'fn';
+  protected declare readonly [SQL_IDENTIFIER]: 'fn';
 
   readonly fn: string;
   readonly args: readonly Expression[];

--- a/packages/core/src/expression-builders/fn.ts
+++ b/packages/core/src/expression-builders/fn.ts
@@ -8,7 +8,7 @@ import { where } from './where.js';
  * Do not use me directly. Use {@link fn}
  */
 export class Fn extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'fn';
+  protected readonly [SQL_IDENTIFIER]: string = 'fn';
 
   readonly fn: string;
   readonly args: readonly Expression[];

--- a/packages/core/src/expression-builders/identifier.ts
+++ b/packages/core/src/expression-builders/identifier.ts
@@ -1,10 +1,10 @@
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
  * Use {@link identifier} instead.
  */
 export class Identifier extends BaseSqlExpression {
-  private declare readonly brand: 'identifier';
+  static readonly [SQL_IDENTIFIER]: string = 'identifier';
 
   constructor(readonly value: string) {
     super();

--- a/packages/core/src/expression-builders/identifier.ts
+++ b/packages/core/src/expression-builders/identifier.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Use {@link identifier} instead.
  */
 export class Identifier extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'identifier';
+  protected declare readonly [SQL_IDENTIFIER]: 'identifier';
 
   constructor(readonly value: string) {
     super();

--- a/packages/core/src/expression-builders/identifier.ts
+++ b/packages/core/src/expression-builders/identifier.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Use {@link identifier} instead.
  */
 export class Identifier extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'identifier';
+  protected readonly [SQL_IDENTIFIER]: string = 'identifier';
 
   constructor(readonly value: string) {
     super();

--- a/packages/core/src/expression-builders/json-path.ts
+++ b/packages/core/src/expression-builders/json-path.ts
@@ -5,7 +5,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link jsonPath}.
  */
 export class JsonPath extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'jsonPath';
+  protected declare readonly [SQL_IDENTIFIER]: 'jsonPath';
 
   constructor(
     readonly expression: Expression,

--- a/packages/core/src/expression-builders/json-path.ts
+++ b/packages/core/src/expression-builders/json-path.ts
@@ -5,7 +5,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link jsonPath}.
  */
 export class JsonPath extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'jsonPath';
+  protected readonly [SQL_IDENTIFIER]: string = 'jsonPath';
 
   constructor(
     readonly expression: Expression,

--- a/packages/core/src/expression-builders/json-path.ts
+++ b/packages/core/src/expression-builders/json-path.ts
@@ -1,11 +1,11 @@
 import type { Expression } from '../sequelize.js';
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
  * Do not use me directly. Use {@link jsonPath}.
  */
 export class JsonPath extends BaseSqlExpression {
-  private declare readonly brand: 'jsonPath';
+  static readonly [SQL_IDENTIFIER]: string = 'jsonPath';
 
   constructor(
     readonly expression: Expression,

--- a/packages/core/src/expression-builders/list.ts
+++ b/packages/core/src/expression-builders/list.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Use {@link list} instead.
  */
 export class List extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'list';
+  protected readonly [SQL_IDENTIFIER]: string = 'list';
 
   constructor(readonly values: unknown[]) {
     super();

--- a/packages/core/src/expression-builders/list.ts
+++ b/packages/core/src/expression-builders/list.ts
@@ -1,10 +1,10 @@
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
  * Use {@link list} instead.
  */
 export class List extends BaseSqlExpression {
-  private declare readonly brand: 'list';
+  static readonly [SQL_IDENTIFIER]: string = 'list';
 
   constructor(readonly values: unknown[]) {
     super();

--- a/packages/core/src/expression-builders/list.ts
+++ b/packages/core/src/expression-builders/list.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Use {@link list} instead.
  */
 export class List extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'list';
+  protected declare readonly [SQL_IDENTIFIER]: 'list';
 
   constructor(readonly values: unknown[]) {
     super();

--- a/packages/core/src/expression-builders/literal.ts
+++ b/packages/core/src/expression-builders/literal.ts
@@ -1,11 +1,10 @@
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
  * Do not use me directly. Use {@link literal}
  */
 export class Literal extends BaseSqlExpression {
-  /** this (type-only) brand prevents TypeScript from thinking Cast is assignable to Literal because they share the same shape */
-  private declare readonly brand: 'literal';
+  static readonly [SQL_IDENTIFIER]: string = 'literal';
 
   readonly val: ReadonlyArray<string | BaseSqlExpression>;
 

--- a/packages/core/src/expression-builders/literal.ts
+++ b/packages/core/src/expression-builders/literal.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link literal}
  */
 export class Literal extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'literal';
+  protected declare readonly [SQL_IDENTIFIER]: 'literal';
 
   readonly val: ReadonlyArray<string | BaseSqlExpression>;
 

--- a/packages/core/src/expression-builders/literal.ts
+++ b/packages/core/src/expression-builders/literal.ts
@@ -4,7 +4,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link literal}
  */
 export class Literal extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'literal';
+  protected readonly [SQL_IDENTIFIER]: string = 'literal';
 
   readonly val: ReadonlyArray<string | BaseSqlExpression>;
 

--- a/packages/core/src/expression-builders/value.ts
+++ b/packages/core/src/expression-builders/value.ts
@@ -6,7 +6,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * in a template string tagged with {@link sql}.
  */
 export class Value extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'value';
+  protected readonly [SQL_IDENTIFIER]: string = 'value';
 
   constructor(readonly value: unknown) {
     super();

--- a/packages/core/src/expression-builders/value.ts
+++ b/packages/core/src/expression-builders/value.ts
@@ -1,4 +1,4 @@
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
  * Used to represent a value that will either be escaped to a literal, or a bind parameter.
@@ -6,7 +6,7 @@ import { BaseSqlExpression } from './base-sql-expression.js';
  * in a template string tagged with {@link sql}.
  */
 export class Value extends BaseSqlExpression {
-  private declare readonly brand: 'value';
+  static readonly [SQL_IDENTIFIER]: string = 'value';
 
   constructor(readonly value: unknown) {
     super();

--- a/packages/core/src/expression-builders/value.ts
+++ b/packages/core/src/expression-builders/value.ts
@@ -6,7 +6,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * in a template string tagged with {@link sql}.
  */
 export class Value extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'value';
+  protected declare readonly [SQL_IDENTIFIER]: 'value';
 
   constructor(readonly value: unknown) {
     super();

--- a/packages/core/src/expression-builders/where.ts
+++ b/packages/core/src/expression-builders/where.ts
@@ -12,7 +12,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link where}
  */
 export class Where<Operator extends keyof WhereOperators = typeof Op.eq> extends BaseSqlExpression {
-  static readonly [SQL_IDENTIFIER]: string = 'where';
+  protected readonly [SQL_IDENTIFIER]: string = 'where';
 
   readonly where: PojoWhere | WhereOptions;
 

--- a/packages/core/src/expression-builders/where.ts
+++ b/packages/core/src/expression-builders/where.ts
@@ -6,13 +6,13 @@ import { PojoWhere } from '../abstract-dialect/where-sql-builder.js';
 import type { WhereOperators } from '../model.js';
 import type { Op } from '../operators.js';
 import type { Expression } from '../sequelize.js';
-import { BaseSqlExpression } from './base-sql-expression.js';
+import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
  * Do not use me directly. Use {@link where}
  */
 export class Where<Operator extends keyof WhereOperators = typeof Op.eq> extends BaseSqlExpression {
-  private declare readonly brand: 'where';
+  static readonly [SQL_IDENTIFIER]: string = 'where';
 
   readonly where: PojoWhere | WhereOptions;
 

--- a/packages/core/src/expression-builders/where.ts
+++ b/packages/core/src/expression-builders/where.ts
@@ -12,7 +12,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
  * Do not use me directly. Use {@link where}
  */
 export class Where<Operator extends keyof WhereOperators = typeof Op.eq> extends BaseSqlExpression {
-  protected readonly [SQL_IDENTIFIER]: string = 'where';
+  protected declare readonly [SQL_IDENTIFIER]: 'where';
 
   readonly where: PojoWhere | WhereOptions;
 

--- a/packages/core/test/types/sequelize.ts
+++ b/packages/core/test/types/sequelize.ts
@@ -81,6 +81,11 @@ MyModel.hasOne(Model2);
 MyModel.findAll();
 
 async function test() {
+  // @ts-expect-error -- this should fail
+  await sequelize.query(1234);
+  // @ts-expect-error -- this should fail
+  await sequelize.query(/test/);
+
   const [results, meta]: [unknown[], unknown] = await sequelize.query('SELECT * FROM `user`', {
     type: QueryTypes.RAW,
   });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This PR is split from #17063 and makes `BaseSqlExpression` and its extended classes unique.
This is required to be able to set options to restrict its values to `BaseSqlExpression`'s.

## List of Breaking Changes

`BaseSqlExpression` is now a unique class.
