### PR TITLE
feat: add missing createRoles association method for HasMany relationship

### DIFF
--- a/packages/core/src/associations/base.ts
+++ b/packages/core/src/associations/base.ts
@@ -260,6 +260,7 @@ export type MultiAssociationAccessors = {
   addMultiple: string,
   add: string,
   create: string,
+  createMultiple: string,
   remove: string,
   removeMultiple: string,
   hasSingle: string,

--- a/packages/core/src/associations/belongs-to-many.ts
+++ b/packages/core/src/associations/belongs-to-many.ts
@@ -349,6 +349,8 @@ export class BelongsToManyAssociation<
       addMultiple: `add${plural}`,
       add: `add${singular}`,
       create: `create${singular}`,
+      createMultiple: `create${plural}`,
+      // TODO: add createMultiple association method for BelongsTo relationship
       remove: `remove${singular}`,
       removeMultiple: `remove${plural}`,
       hasSingle: `has${singular}`,

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -556,6 +556,50 @@ export class HasManyAssociation<
       [this.foreignKey]: sourceInstance.get(this.sourceKey),
     }, options);
   }
+
+  /**
+   * Create a new instances of the associated model and associate it with this.
+   *
+   * @param sourceInstance source instance
+   * @param values values for target model instance
+   * @param options Options passed to `target.bulkCreate`
+   */
+  async createMultiple(
+    sourceInstance: S,
+    values: AllowIterable<CreationAttributes<T>>,
+    options:
+      | HasManyCreateAssociationMixinOptions<T>
+      | HasManyCreateAssociationMixinOptions<T>['fields'] = {},
+  ): Promise<T[]> {
+    if (Array.isArray(options)) {
+      options = {
+        fields: options,
+      };
+    }
+
+    if (this.scope) {
+      for (const attribute of Object.keys(this.scope)) {
+        // @ts-expect-error -- TODO: fix the typing of {@link AssociationScope}
+        for (const value of values) {
+          value[attribute] = this.scope[attribute];
+        }
+
+        if (options.fields) {
+          options.fields.push(attribute);
+        }
+      }
+    }
+
+    if (options.fields) {
+      options.fields.push(this.foreignKey);
+    }
+
+    for (const value of values) {
+      value[this.foreignKey] = sourceInstance.get(this.sourceKey);
+    }
+
+    return this.target.bulkCreate(values as ReadonlyArray<CreationAttributes<T>>, options);
+  }
 }
 
 // workaround https://github.com/evanw/esbuild/issues/1260

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -133,6 +133,7 @@ export class HasManyAssociation<
       addMultiple: `add${plural}`,
       add: `add${singular}`,
       create: `create${singular}`,
+      createMultiple: `create${plural}`,
       remove: `remove${singular}`,
       removeMultiple: `remove${plural}`,
       hasSingle: `has${singular}`,

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -183,12 +183,13 @@ export class HasManyAssociation<
     mixinMethods(
       this,
       mixinTargetPrototype,
-      ['get', 'count', 'hasSingle', 'hasAll', 'set', 'add', 'addMultiple', 'remove', 'removeMultiple', 'create'],
+      ['get', 'count', 'hasSingle', 'hasAll', 'set', 'add', 'addMultiple', 'remove', 'removeMultiple', 'create', 'createMultiple'],
       {
         hasSingle: 'has',
         hasAll: 'has',
         addMultiple: 'add',
         removeMultiple: 'remove',
+        createMultiple: 'createMultiple',
       },
     );
   }

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1749,6 +1749,10 @@ ${associationOwner._getAssociationDebugList()}`);
    */
   static async create(values, options) {
     options = cloneDeep(options) ?? {};
+    const association = this._searchInclude(values);
+    if (association.length > 0 && !options.include) {
+      options.include = association;
+    }
 
     return await this.build(values, {
       isNewRecord: true,
@@ -1757,6 +1761,18 @@ ${associationOwner._getAssociationDebugList()}`);
       raw: options.raw,
       silent: options.silent,
     }).save(options);
+  }
+
+  static _searchInclude(values) {
+    const association = [];
+    const associationKeys = Object.keys(this.associations);
+    for (const value in values) {
+      if (associationKeys.includes(value)) {
+        association.push({ association: value });
+      }
+    }
+
+    return association;
   }
 
   /**

--- a/packages/core/test/integration/model/create.test.js
+++ b/packages/core/test/integration/model/create.test.js
@@ -1508,6 +1508,36 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
     });
+    it('should create associated objects without include option', async function () {
+      const Player = this.customSequelize.define('player', {
+        name: {
+          type: DataTypes.STRING,
+        },
+        teamId: {
+          type: DataTypes.INTEGER,
+        },
+      });
+      const Team = this.customSequelize.define('team', {
+        id: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+        name: {
+          type: DataTypes.STRING,
+        },
+      });
+      Player.team = Player.belongsTo(Team, {
+        as: 'team',
+        foreignKey: 'teamId',
+        targetKey: 'id',
+      });
+      await this.customSequelize.sync({ force: true });
+      const createdPlayer = await Player.create({
+        name: 'Player 1', team: { id: 1, name: 'My new team' },
+      });
+      expect(createdPlayer.team instanceof Team).to.be.ok;
+      expect(createdPlayer.teamId).to.equal(1);
+    });
   });
 
   it('should return autoIncrement primary key (create)', async function () {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes
- Added new method `createMultiple` to create multiple associated instances.
Example use case:
```
class Article extends Model:
  declare: id: number;
  @HasMany(() => Label, 'articleId')
  declare createLabels: HasManyCreateAssociationMixin<Label>
class Label extends Model:
  declare id: number;
  declare articleId: number

const article = await Article.create();
const labels = await article.createLabels([{id: 100}, {id: 200}])
// created two instances
```
this PR closes #11372 

<!-- Please provide a description of the change here. -->


