### PR TITLE
feat: add missing createRoles association method for HasMany relationship

### DIFF
--- a/packages/core/src/associations/base.ts
+++ b/packages/core/src/associations/base.ts
@@ -258,17 +258,17 @@ export type SingleAssociationAccessors = {
 };
 
 export type MultiAssociationAccessors = {
-  get: string,
-  set: string,
-  addMultiple: string,
-  add: string,
-  create: string,
-  createMultiple: string,
-  remove: string,
-  removeMultiple: string,
-  hasSingle: string,
-  hasAll: string,
-  count: string,
+  get: string;
+  set: string;
+  addMultiple: string;
+  add: string;
+  create: string;
+  createMultiple: string;
+  remove: string;
+  removeMultiple: string;
+  hasSingle: string;
+  hasAll: string;
+  count: string;
 };
 
 /** Foreign Key Options */

--- a/packages/core/src/associations/base.ts
+++ b/packages/core/src/associations/base.ts
@@ -258,16 +258,17 @@ export type SingleAssociationAccessors = {
 };
 
 export type MultiAssociationAccessors = {
-  get: string;
-  set: string;
-  addMultiple: string;
-  add: string;
-  create: string;
-  remove: string;
-  removeMultiple: string;
-  hasSingle: string;
-  hasAll: string;
-  count: string;
+  get: string,
+  set: string,
+  addMultiple: string,
+  add: string,
+  create: string,
+  createMultiple: string,
+  remove: string,
+  removeMultiple: string,
+  hasSingle: string,
+  hasAll: string,
+  count: string,
 };
 
 /** Foreign Key Options */

--- a/packages/core/src/associations/belongs-to-many.ts
+++ b/packages/core/src/associations/belongs-to-many.ts
@@ -368,6 +368,8 @@ export class BelongsToManyAssociation<
       addMultiple: `add${plural}`,
       add: `add${singular}`,
       create: `create${singular}`,
+      createMultiple: `create${plural}`,
+      // TODO: add createMultiple association method for BelongsTo relationship
       remove: `remove${singular}`,
       removeMultiple: `remove${plural}`,
       hasSingle: `has${singular}`,

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -160,6 +160,7 @@ export class HasManyAssociation<
       addMultiple: `add${plural}`,
       add: `add${singular}`,
       create: `create${singular}`,
+      createMultiple: `create${plural}`,
       remove: `remove${singular}`,
       removeMultiple: `remove${plural}`,
       hasSingle: `has${singular}`,

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -217,23 +217,13 @@ export class HasManyAssociation<
     mixinMethods(
       this,
       mixinTargetPrototype,
-      [
-        'get',
-        'count',
-        'hasSingle',
-        'hasAll',
-        'set',
-        'add',
-        'addMultiple',
-        'remove',
-        'removeMultiple',
-        'create',
-      ],
+      ['get', 'count', 'hasSingle', 'hasAll', 'set', 'add', 'addMultiple', 'remove', 'removeMultiple', 'create', 'createMultiple'],
       {
         hasSingle: 'has',
         hasAll: 'has',
         addMultiple: 'add',
         removeMultiple: 'remove',
+        createMultiple: 'createMultiple',
       },
     );
   }

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -218,7 +218,19 @@ export class HasManyAssociation<
     mixinMethods(
       this,
       mixinTargetPrototype,
-      ['get', 'count', 'hasSingle', 'hasAll', 'set', 'add', 'addMultiple', 'remove', 'removeMultiple', 'create', 'createMultiple'],
+      [
+        'get',
+        'count',
+        'hasSingle',
+        'hasAll',
+        'set',
+        'add',
+        'addMultiple',
+        'remove',
+        'removeMultiple',
+        'create',
+        'createMultiple',
+      ],
       {
         hasSingle: 'has',
         hasAll: 'has',


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes
- Added new method `createMultiple` to create multiple associated instances.
Example use case:
```
class Article extends Model:
  declare: id: number;
  @HasMany(() => Label, 'articleId')
  declare createLabels: HasManyCreateAssociationMixin<Label>
class Label extends Model:
  declare id: number;
  declare articleId: number

const article = await Article.create();
const labels = await article.createLabels([{id: 100}, {id: 200}])
// created two instances
```
this PR closes #11372 

<!-- Please provide a description of the change here. -->



