### PR TITLE
meta: exclude renovate from auto-update

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -15,3 +15,4 @@ jobs:
           PR_FILTER: 'auto_merge'
           PR_READY_STATE: 'ready_for_review'
           MERGE_CONFLICT_ACTION: 'fail'
+          EXCLUDED_LABELS: 'no-autoupdate'

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -14,5 +14,5 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.AUTOMERGE_PAT }}'
           PR_FILTER: 'auto_merge'
           PR_READY_STATE: 'ready_for_review'
-          MERGE_CONFLICT_ACTION: 'fail'
+          MERGE_CONFLICT_ACTION: 'ignore'
           EXCLUDED_LABELS: 'no-autoupdate'

--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,6 @@
       "automerge": true
     }
   ],
+  "labels": ["no-autoupdate"],
   "postUpdateOptions": ["yarnDedupeHighest"]
 }


### PR DESCRIPTION
## Description of Changes

Renovate auto-updates their PRs themselves. By doing it ourselves, we block their process and the PR remains open indefinitely.

This PR applies the label "no-autoupdate" to renovate PRs, and excludes PRs with this label from being automatically updated

In order to test this, I'll only enable automerge on this PR once it is outdated.