### PR TITLE
meta: replace PAT with Sequelize Bot (GitHub App)

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -9,9 +9,15 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Sequelize Bot Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
+          private-key: '${{ secrets.SEQUELIZE_BOT_PRIVATE_KEY }}'
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: '${{ secrets.AUTOMERGE_PAT }}'
+          GITHUB_TOKEN: '${{ steps.generate-token.outputs.token }}'
           PR_FILTER: 'auto_merge'
           PR_READY_STATE: 'ready_for_review'
           MERGE_CONFLICT_ACTION: 'ignore'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,10 +243,15 @@ jobs:
     needs: [docs, test-sqlite, test-postgres, test-oldest-latest]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Generate Sequelize Bot Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
+          private-key: '${{ secrets.SEQUELIZE_BOT_PRIVATE_KEY }}'
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
@@ -268,6 +273,8 @@ jobs:
       - name: Set npm auth token
         run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
       - run: yarn publish-all
+        env:
+          GITHUB_TOKEN: '${{ steps.generate-token.outputs.token }}'
       - id: sequelize
         uses: sdepold/github-action-get-latest-release@aa12fcb2943e8899cbcc29ff6f73409b32b48fa1 # master
         with:


### PR DESCRIPTION
## Description

Follow-up PR to solve this issue: https://github.com/sequelize/sequelize/pull/17174#issuecomment-2003747324

I created a GitHub App that belongs to the Sequelize org, this GitHub app will handle auto-updating PRs and pushing the release commit, instead of my account

The bot can be seen in the settings of our org for those who have access: https://github.com/organizations/sequelize/settings/apps

## How To Test

- Enable auto-merge once this PR is outdated. The update commit should come from the Sequelize Bot instead of my account.

## To do after the merge

- Delete the PAT from our secrets & from my account