### PR TITLE
fix: update bulkDeleteQuery supported options

### DIFF
--- a/packages/core/src/dialects/abstract/index.ts
+++ b/packages/core/src/dialects/abstract/index.ts
@@ -264,7 +264,7 @@ export type DialectSupports = {
     ifExists: boolean;
   };
   delete: {
-    modelWithLimit: boolean;
+    limit: boolean;
   };
 };
 
@@ -465,7 +465,7 @@ export abstract class AbstractDialect<Options extends object = {}> {
       ifExists: false,
     },
     delete: {
-      modelWithLimit: false,
+      limit: true,
     },
   });
 

--- a/packages/core/src/dialects/mssql/index.ts
+++ b/packages/core/src/dialects/mssql/index.ts
@@ -66,7 +66,7 @@ export class MsSqlDialect extends AbstractDialect {
       useBegin: true,
     },
     delete: {
-      modelWithLimit: true,
+      limit: false,
     },
   });
 

--- a/packages/core/src/dialects/mssql/query-generator-typescript.ts
+++ b/packages/core/src/dialects/mssql/query-generator-typescript.ts
@@ -340,8 +340,8 @@ SELECT REVERSE(SUBSTRING(@ms_ver, CHARINDEX('.', @ms_ver)+1, 20)) AS 'version'`;
     return 'NEWID()';
   }
 
-  bulkDeleteQuery(tableName: TableOrModel, options: BulkDeleteQueryOptions) {
-    const sql = super.bulkDeleteQuery(tableName, options);
+  bulkDeleteQuery(tableOrModel: TableOrModel, options: BulkDeleteQueryOptions) {
+    const sql = super.bulkDeleteQuery(tableOrModel, options);
 
     return `${sql}; SELECT @@ROWCOUNT AS AFFECTEDROWS;`;
   }

--- a/packages/core/src/dialects/snowflake/index.ts
+++ b/packages/core/src/dialects/snowflake/index.ts
@@ -57,7 +57,7 @@ export class SnowflakeDialect extends AbstractDialect {
       ifExists: true,
     },
     delete: {
-      modelWithLimit: true,
+      limit: false,
     },
   });
 

--- a/packages/core/src/dialects/sqlite/index.ts
+++ b/packages/core/src/dialects/sqlite/index.ts
@@ -54,6 +54,9 @@ export class SqliteDialect extends AbstractDialect {
     truncate: {
       restartIdentity: false,
     },
+    delete: {
+      limit: false,
+    },
   });
 
   readonly defaultVersion = '3.8.0';

--- a/packages/postgres/src/dialect.ts
+++ b/packages/postgres/src/dialect.ts
@@ -116,7 +116,7 @@ export class PostgresDialect extends AbstractDialect<PostgresDialectOptions> {
       readOnly: true,
     },
     delete: {
-      modelWithLimit: true,
+      limit: false,
     },
   });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This is another change split from #17063.

This PR fixes the supported options for delete to make them match what the dialects actually support plus a few other misc changes.

