### PR TITLE
feat(mysql)!: move mysql to the `@sequelize/mysql` package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,7 +95,6 @@
     "lcov-result-merger": "5.0.0",
     "mocha": "10.3.0",
     "moment": "2.30.1",
-    "mysql2": "3.9.2",
     "nyc": "15.1.0",
     "odbc": "2.4.8",
     "p-map": "4.0.0",
@@ -111,9 +110,6 @@
   },
   "peerDependenciesMeta": {
     "ibm_db": {
-      "optional": true
-    },
-    "mysql2": {
       "optional": true
     },
     "odbc": {

--- a/packages/core/src/dialects/mysql/query-generator.d.ts
+++ b/packages/core/src/dialects/mysql/query-generator.d.ts
@@ -1,3 +1,0 @@
-import { MySqlQueryGeneratorTypeScript } from './query-generator-typescript.js';
-
-export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {}

--- a/packages/core/src/dialects/mysql/query.d.ts
+++ b/packages/core/src/dialects/mysql/query.d.ts
@@ -1,3 +1,0 @@
-import { AbstractQuery } from '../abstract/query.js';
-
-export class MySqlQuery extends AbstractQuery {}

--- a/packages/core/src/sequelize.internals.ts
+++ b/packages/core/src/sequelize.internals.ts
@@ -11,7 +11,8 @@ export function importDialect(dialect: DialectName): typeof AbstractDialect {
     case 'mssql':
       return require('./dialects/mssql').MsSqlDialect;
     case 'mysql':
-      return require('./dialects/mysql').MySqlDialect;
+      // eslint-disable-next-line import/no-extraneous-dependencies -- legacy function, will be removed. User needs to install the dependency themselves
+      return require('@sequelize/mysql').MySqlDialect;
     case 'postgres':
       // eslint-disable-next-line import/no-extraneous-dependencies -- legacy function, will be removed. User needs to install the dependency themselves
       return require('@sequelize/postgres').PostgresDialect;

--- a/packages/core/test/unit/dialects/mysql/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mysql/query-generator.test.js
@@ -9,9 +9,7 @@ const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
 const { Op } = require('@sequelize/core');
-const {
-  MySqlQueryGenerator: QueryGenerator,
-} = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mysql/query-generator.js');
+const { MySqlQueryGenerator } = require('@sequelize/mysql');
 const { createSequelizeInstance } = require('../../../support');
 
 if (dialect === 'mysql') {
@@ -125,42 +123,42 @@ if (dialect === 'mysql') {
         {
           arguments: ['myTable'],
           expectation: 'SELECT * FROM `myTable`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { attributes: ['id', 'name'] }],
           expectation: 'SELECT `id`, `name` FROM `myTable`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { where: { id: 2 } }],
           expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { where: { name: 'foo' } }],
           expectation: "SELECT * FROM `myTable` WHERE `myTable`.`name` = 'foo';",
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { order: ['id'] }],
           expectation: 'SELECT * FROM `myTable` ORDER BY `id`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { order: ['id', 'DESC'] }],
           expectation: 'SELECT * FROM `myTable` ORDER BY `id`, `DESC`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { order: ['myTable.id'] }],
           expectation: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { order: [['myTable.id', 'DESC']] }],
           expectation: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id` DESC;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: [
@@ -171,7 +169,7 @@ if (dialect === 'mysql') {
             },
           ],
           expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
           needsSequelize: true,
         },
         {
@@ -184,19 +182,19 @@ if (dialect === 'mysql') {
           ],
           expectation:
             'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC, `myTable`.`name`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
           needsSequelize: true,
         },
         {
           title: 'single string argument should be quoted',
           arguments: ['myTable', { group: 'name' }],
           expectation: 'SELECT * FROM `myTable` GROUP BY `name`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           arguments: ['myTable', { group: ['name'] }],
           expectation: 'SELECT * FROM `myTable` GROUP BY `name`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           title: 'functions work for group by',
@@ -209,7 +207,7 @@ if (dialect === 'mysql') {
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
           needsSequelize: true,
         },
         {
@@ -223,13 +221,13 @@ if (dialect === 'mysql') {
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
           needsSequelize: true,
         },
         {
           arguments: ['myTable', { group: 'name', order: [['id', 'DESC']] }],
           expectation: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
         },
         {
           title: 'Empty having',
@@ -242,7 +240,7 @@ if (dialect === 'mysql') {
             },
           ],
           expectation: 'SELECT * FROM `myTable`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
           needsSequelize: true,
         },
         {
@@ -259,7 +257,7 @@ if (dialect === 'mysql') {
           ],
           expectation:
             'SELECT `test`.* FROM (SELECT * FROM `myTable` AS `test` HAVING `test`.`creationYear` > 2002) AS `test`;',
-          context: QueryGenerator,
+          context: MySqlQueryGenerator,
           needsSequelize: true,
         },
       ],

--- a/packages/core/test/unit/dialects/mysql/query.test.js
+++ b/packages/core/test/unit/dialects/mysql/query.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const {
-  MySqlQuery: Query,
-} = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mysql/query.js');
+const { MySqlQuery } = require('@sequelize/mysql');
 
 const Support = require('../../../support');
 const chai = require('chai');
@@ -26,7 +24,7 @@ describe('[MYSQL/MARIADB Specific] Query', () => {
       const invalidWarning = {};
       const warnings = [validWarning, undefined, invalidWarning];
 
-      const query = new Query({}, current, {});
+      const query = new MySqlQuery({}, current, {});
       const stub = sinon.stub(query, 'run');
       stub.onFirstCall().resolves(warnings);
 

--- a/packages/core/test/unit/query-interface/create-table.test.ts
+++ b/packages/core/test/unit/query-interface/create-table.test.ts
@@ -70,15 +70,8 @@ describe('QueryInterface#createTable', () => {
   }
 
   it('supports sql.uuidV1 default values', async () => {
-    const localSequelize =
-      dialect.name === 'mysql'
-        ? createSequelizeInstance({
-            databaseVersion: '8.0.13',
-          })
-        : sequelize;
-    const stub = sinon.stub(localSequelize, 'queryRaw');
-
-    await localSequelize.queryInterface.createTable('table', {
+    const stub = sinon.stub(sequelize, 'queryRaw');
+    await sequelize.queryInterface.createTable('table', {
       id: {
         type: DataTypes.UUID,
         primaryKey: true,

--- a/packages/mysql/.eslintrc.js
+++ b/packages/mysql/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  parserOptions: {
+    project: [`${__dirname}/tsconfig.json`],
+  },
+};

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,0 +1,49 @@
+{
+  "bugs": "https://github.com/sequelize/sequelize/issues",
+  "description": "MySQL Connector for Sequelize",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./lib/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    }
+  },
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "sideEffects": false,
+  "homepage": "https://sequelize.org",
+  "license": "MIT",
+  "name": "@sequelize/mysql",
+  "repository": "https://github.com/sequelize/sequelize",
+  "scripts": {
+    "build": "../../build-packages.mjs mysql",
+    "test": "concurrently \"npm:test-*\"",
+    "test-typings": "tsc --noEmit --project tsconfig.json",
+    "test-exports": "../../dev/sync-exports.mjs ./src --check-outdated",
+    "sync-exports": "../../dev/sync-exports.mjs ./src"
+  },
+  "type": "commonjs",
+  "version": "0.0.0-development",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@sequelize/core": "workspace:*",
+    "@sequelize/utils": "workspace:*",
+    "dayjs": "^1.11.10",
+    "lodash": "4.17.21",
+    "mysql2": "3.9.2",
+    "wkx": "0.5.0"
+  },
+  "devDependencies": {
+    "@types/chai": "4.3.14",
+    "@types/mocha": "10.0.6",
+    "chai": "4.4.1",
+    "mocha": "10.3.0"
+  }
+}

--- a/packages/mysql/src/_internal/data-types-db.ts
+++ b/packages/mysql/src/_internal/data-types-db.ts
@@ -1,8 +1,8 @@
+import { isValidTimeZone } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/dayjs.js';
 import dayjs from 'dayjs';
 import type { TypeCastField } from 'mysql2';
 import wkx from 'wkx';
-import { isValidTimeZone } from '../../utils/dayjs.js';
-import type { MySqlDialect } from './index.js';
+import type { MySqlDialect } from '../dialect.js';
 
 /**
  * First pass of DB value parsing: Parses based on the MySQL Type ID.

--- a/packages/mysql/src/_internal/data-types-overrides.ts
+++ b/packages/mysql/src/_internal/data-types-overrides.ts
@@ -1,10 +1,15 @@
+import type { BindParamOptions, GeoJson } from '@sequelize/core';
+import type { AcceptedDate } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/data-types.js';
+import * as BaseTypes from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/data-types.js';
+import { isValidTimeZone } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/dayjs.js';
 import { isString } from '@sequelize/utils';
 import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import wkx from 'wkx';
-import type { GeoJson } from '../../geo-json.js';
-import { isValidTimeZone } from '../../utils/dayjs';
-import type { AcceptedDate, BindParamOptions } from '../abstract/data-types.js';
-import * as BaseTypes from '../abstract/data-types.js';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export class FLOAT extends BaseTypes.FLOAT {
   protected getNumberSqlTypeName(): string {

--- a/packages/mysql/src/dialect.ts
+++ b/packages/mysql/src/dialect.ts
@@ -1,13 +1,16 @@
-import type { Sequelize } from '../../sequelize.js';
-import { createUnspecifiedOrderedBindCollector, escapeMysqlMariaDbString } from '../../utils/sql';
-import type { SupportableNumericOptions } from '../abstract';
-import { AbstractDialect } from '../abstract';
-import { MySqlConnectionManager } from './connection-manager';
-import * as DataTypes from './data-types';
-import { registerMySqlDbDataTypeParsers } from './data-types.db.js';
-import { MySqlQuery } from './query';
-import { MySqlQueryGenerator } from './query-generator';
-import { MySqlQueryInterface } from './query-interface';
+import type { Sequelize } from '@sequelize/core';
+import { AbstractDialect } from '@sequelize/core';
+import type { SupportableNumericOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/index.js';
+import {
+  createUnspecifiedOrderedBindCollector,
+  escapeMysqlMariaDbString,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/sql.js';
+import { registerMySqlDbDataTypeParsers } from './_internal/data-types-db.js';
+import * as DataTypes from './_internal/data-types-overrides.js';
+import { MySqlConnectionManager } from './connection-manager.js';
+import { MySqlQueryGenerator } from './query-generator.js';
+import { MySqlQueryInterface } from './query-interface.js';
+import { MySqlQuery } from './query.js';
 
 const numericOptions: SupportableNumericOptions = {
   zerofill: true,

--- a/packages/mysql/src/index.mjs
+++ b/packages/mysql/src/index.mjs
@@ -1,0 +1,8 @@
+import Pkg from './index.js';
+
+export const MySqlConnectionManager = Pkg.MySqlConnectionManager;
+export const MySqlConnection = Pkg.MySqlConnection;
+export const MySqlDialect = Pkg.MySqlDialect;
+export const MySqlQueryGenerator = Pkg.MySqlQueryGenerator;
+export const MySqlQueryInterface = Pkg.MySqlQueryInterface;
+export const MySqlQuery = Pkg.MySqlQuery;

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -1,0 +1,7 @@
+/** Generated File, do not modify directly. Run "yarn sync-exports" in the folder of the package instead */
+
+export * from './connection-manager.js';
+export * from './dialect.js';
+export * from './query-generator.js';
+export * from './query-interface.js';
+export * from './query.js';

--- a/packages/mysql/src/query-generator-typescript.internal.ts
+++ b/packages/mysql/src/query-generator-typescript.internal.ts
@@ -1,26 +1,25 @@
-import { Op } from '../../operators.js';
-import type { Expression } from '../../sequelize.js';
-import { rejectInvalidOptions } from '../../utils/check';
-import { joinSQLFragments } from '../../utils/join-sql-fragments';
-import { buildJsonPath } from '../../utils/json.js';
-import { EMPTY_SET } from '../../utils/object.js';
-import { generateIndexName } from '../../utils/string';
-import { AbstractQueryGenerator } from '../abstract/query-generator';
-import type { EscapeOptions } from '../abstract/query-generator-typescript';
-import {
-  REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-  TRUNCATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator-typescript';
 import type {
+  Expression,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   RemoveIndexQueryOptions,
   ShowConstraintsQueryOptions,
   TableOrModel,
   TruncateTableQueryOptions,
-} from '../abstract/query-generator.types';
-import type { MySqlDialect } from './index.js';
-import { MySqlQueryGeneratorInternal } from './query-generator-internal.js';
+} from '@sequelize/core';
+import { AbstractQueryGenerator, Op } from '@sequelize/core';
+import type { EscapeOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator-typescript.js';
+import {
+  REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+  TRUNCATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator-typescript.js';
+import { rejectInvalidOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
+import { joinSQLFragments } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/join-sql-fragments.js';
+import { buildJsonPath } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/json.js';
+import { EMPTY_SET } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/object.js';
+import { generateIndexName } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/string.js';
+import type { MySqlDialect } from './dialect.js';
+import { MySqlQueryGeneratorInternal } from './query-generator.internal.js';
 
 /**
  * Temporary class to ease the TypeScript migration

--- a/packages/mysql/src/query-generator.d.ts
+++ b/packages/mysql/src/query-generator.d.ts
@@ -1,0 +1,3 @@
+import { MySqlQueryGeneratorTypeScript } from './query-generator-typescript.internal.js';
+
+export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {}

--- a/packages/mysql/src/query-generator.internal.ts
+++ b/packages/mysql/src/query-generator.internal.ts
@@ -1,7 +1,7 @@
-import { formatMySqlStyleLimitOffset } from '../../utils/sql.js';
-import { AbstractQueryGeneratorInternal } from '../abstract/query-generator-internal.js';
-import type { AddLimitOffsetOptions } from '../abstract/query-generator.internal-types.js';
-import type { MySqlDialect } from './index.js';
+import { AbstractQueryGeneratorInternal } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator-internal.js';
+import type { AddLimitOffsetOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator.internal-types.js';
+import { formatMySqlStyleLimitOffset } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/sql.js';
+import type { MySqlDialect } from './dialect.js';
 
 const TECHNICAL_SCHEMAS = Object.freeze([
   'MYSQL',

--- a/packages/mysql/src/query-generator.js
+++ b/packages/mysql/src/query-generator.js
@@ -1,18 +1,19 @@
 'use strict';
 
-import { inspect } from 'node:util';
-import { BaseSqlExpression } from '../../expression-builders/base-sql-expression.js';
-import { rejectInvalidOptions } from '../../utils/check';
-import { joinSQLFragments } from '../../utils/join-sql-fragments';
-import { EMPTY_SET } from '../../utils/object.js';
-import { defaultValueSchemable } from '../../utils/query-builder-utils';
-import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
-import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
-
+import {
+  attributeTypeToSql,
+  normalizeDataType,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/data-types-utils.js';
+import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator.js';
+import { BaseSqlExpression } from '@sequelize/core/_non-semver-use-at-your-own-risk_/expression-builders/base-sql-expression.js';
+import { rejectInvalidOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
+import { joinSQLFragments } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/join-sql-fragments.js';
+import { EMPTY_SET } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/object.js';
+import { defaultValueSchemable } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/query-builder-utils.js';
+import { inspect } from '@sequelize/utils';
 import each from 'lodash/each';
 import isPlainObject from 'lodash/isPlainObject';
-
-const { MySqlQueryGeneratorTypeScript } = require('./query-generator-typescript');
+import { MySqlQueryGeneratorTypeScript } from './query-generator-typescript.internal.js';
 
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 

--- a/packages/mysql/src/query-interface.d.ts
+++ b/packages/mysql/src/query-interface.d.ts
@@ -1,5 +1,5 @@
-import { AbstractQueryInterface } from '../abstract/query-interface.js';
-import type { MySqlDialect } from './index.js';
+import { AbstractQueryInterface } from '@sequelize/core';
+import type { MySqlDialect } from './dialect.js';
 
 export class MySqlQueryInterface<
   Dialect extends MySqlDialect = MySqlDialect,

--- a/packages/mysql/src/query-interface.js
+++ b/packages/mysql/src/query-interface.js
@@ -1,10 +1,11 @@
 'use strict';
 
-import { getObjectFromMap } from '../../utils/object';
-import { assertNoReservedBind, combineBinds } from '../../utils/sql';
-
-const { AbstractQueryInterface } = require('../abstract/query-interface');
-const { QueryTypes } = require('../../query-types');
+import { AbstractQueryInterface, QueryTypes } from '@sequelize/core';
+import { getObjectFromMap } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/object.js';
+import {
+  assertNoReservedBind,
+  combineBinds,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/sql.js';
 
 /**
  * The interface that Sequelize uses to talk with MySQL/MariaDB database

--- a/packages/mysql/src/query.d.ts
+++ b/packages/mysql/src/query.d.ts
@@ -1,0 +1,3 @@
+import { AbstractQuery } from '@sequelize/core';
+
+export class MySqlQuery extends AbstractQuery {}

--- a/packages/mysql/tsconfig.json
+++ b/packages/mysql/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig-preset.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/mysql/typedoc.json
+++ b/packages/mysql/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "excludeExternals": true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,7 +2257,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     mocha: "npm:10.3.0"
     moment: "npm:2.30.1"
-    mysql2: "npm:3.9.2"
     nyc: "npm:15.1.0"
     odbc: "npm:2.4.8"
     p-map: "npm:4.0.0"
@@ -2281,8 +2280,6 @@ __metadata:
     wkx: "npm:^0.5.0"
   peerDependenciesMeta:
     ibm_db:
-      optional: true
-    mysql2:
       optional: true
     odbc:
       optional: true
@@ -2350,6 +2347,23 @@ __metadata:
     typedoc-plugin-mdn-links: "npm:3.1.18"
     typedoc-plugin-missing-exports: "npm:2.2.0"
     typescript: "npm:5.4.3"
+  languageName: unknown
+  linkType: soft
+
+"@sequelize/mysql@workspace:packages/mysql":
+  version: 0.0.0-use.local
+  resolution: "@sequelize/mysql@workspace:packages/mysql"
+  dependencies:
+    "@sequelize/core": "workspace:*"
+    "@sequelize/utils": "workspace:*"
+    "@types/chai": "npm:4.3.14"
+    "@types/mocha": "npm:10.0.6"
+    chai: "npm:4.4.1"
+    dayjs: "npm:^1.11.10"
+    lodash: "npm:4.17.21"
+    mocha: "npm:10.3.0"
+    mysql2: "npm:3.9.2"
+    wkx: "npm:0.5.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Goal of the PR

Related issue: #13722
Related PR: #17190 

This PR moves the MySql Dialect to the `@sequelize/mysql` package.

## Relevant impacts

- This package pre-installs the necessary mysql-specific dependency `mysql`. Users won't need to install the additional packages anymore. This gives us control over which version we support.
- Unlike the postgres package, this package does not have unit tests yet. Once we add those, the script should be added to the package package.json and CI.

## Other changes

## Breaking changes

- Instead of installing `mysql2` users need to install `@sequelize/mysql`.