### PR TITLE
feat(snowflake)!: move snowflake to the `@sequelize/snowflake` package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         run: yarn lerna run test-unit-db2 --scope=@sequelize/core
       - name: Unit tests (core - ibmi)
         run: yarn lerna run test-unit-ibmi --scope=@sequelize/core
-      - name: Unit tests (snowflake)
+      - name: Unit tests (core - snowflake)
         run: yarn lerna run test-unit-snowflake --scope=@sequelize/core
       - name: SQLite SSCCE
         run: yarn sscce-sqlite

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,7 +81,6 @@
     "@types/semver": "7.5.8",
     "@types/sinon": "17.0.3",
     "@types/sinon-chai": "3.2.12",
-    "@types/snowflake-sdk": "1.6.20",
     "@types/uuid": "9.0.8",
     "chai": "4.4.1",
     "chai-as-promised": "7.1.1",
@@ -99,13 +98,7 @@
     "p-timeout": "4.1.0",
     "rimraf": "5.0.5",
     "sinon": "17.0.1",
-    "sinon-chai": "3.7.0",
-    "snowflake-sdk": "1.10.0"
-  },
-  "peerDependenciesMeta": {
-    "snowflake-sdk": {
-      "optional": true
-    }
+    "sinon-chai": "3.7.0"
   },
   "keywords": [
     "mysql",

--- a/packages/core/src/dialects/snowflake/query-generator.d.ts
+++ b/packages/core/src/dialects/snowflake/query-generator.d.ts
@@ -1,3 +1,0 @@
-import { SnowflakeQueryGeneratorTypeScript } from './query-generator-typescript.js';
-
-export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {}

--- a/packages/core/src/sequelize.internals.ts
+++ b/packages/core/src/sequelize.internals.ts
@@ -27,7 +27,8 @@ export function importDialect(dialect: DialectName): typeof AbstractDialect {
       // eslint-disable-next-line import/no-extraneous-dependencies -- legacy function, will be removed. User needs to install the dependency themselves
       return require('@sequelize/db2').Db2Dialect;
     case 'snowflake':
-      return require('./dialects/snowflake').SnowflakeDialect;
+      // eslint-disable-next-line import/no-extraneous-dependencies -- legacy function, will be removed. User needs to install the dependency themselves
+      return require('@sequelize/snowflake').SnowflakeDialect;
     default:
       throw new Error(
         `The dialect ${dialect} is not natively supported. Native dialects: mariadb, mssql, mysql, postgres, sqlite, ibmi, db2 and snowflake.`,

--- a/packages/core/test/unit/dialects/snowflake/query-generator.test.js
+++ b/packages/core/test/unit/dialects/snowflake/query-generator.test.js
@@ -9,9 +9,7 @@ const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
 const { Op } = require('@sequelize/core');
-const {
-  SnowflakeQueryGenerator: QueryGenerator,
-} = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/snowflake/query-generator.js');
+const { SnowflakeQueryGenerator: QueryGenerator } = require('@sequelize/snowflake');
 const { createSequelizeInstance } = require('../../../support');
 
 if (dialect === 'snowflake') {

--- a/packages/core/test/unit/dialects/snowflake/query.test.js
+++ b/packages/core/test/unit/dialects/snowflake/query.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const {
-  SnowflakeQuery: Query,
-} = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/snowflake/query.js');
+const { SnowflakeQuery: Query } = require('@sequelize/snowflake');
 
 const Support = require('../../../support');
 const chai = require('chai');

--- a/packages/snowflake/.eslintrc.js
+++ b/packages/snowflake/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  parserOptions: {
+    project: [`${__dirname}/tsconfig.json`],
+  },
+};

--- a/packages/snowflake/package.json
+++ b/packages/snowflake/package.json
@@ -1,0 +1,42 @@
+{
+  "bugs": "https://github.com/sequelize/sequelize/issues",
+  "description": "Snowflake Connector for Sequelize",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./lib/index.d.mts",
+        "default": "./lib/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    }
+  },
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "sideEffects": false,
+  "homepage": "https://sequelize.org",
+  "license": "MIT",
+  "name": "@sequelize/snowflake",
+  "repository": "https://github.com/sequelize/sequelize",
+  "scripts": {
+    "build": "../../build-packages.mjs snowflake",
+    "test": "concurrently \"npm:test-*\"",
+    "test-typings": "tsc --noEmit --project tsconfig.json",
+    "test-exports": "../../dev/sync-exports.mjs ./src --check-outdated",
+    "sync-exports": "../../dev/sync-exports.mjs ./src"
+  },
+  "type": "commonjs",
+  "version": "0.0.0-development",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@sequelize/core": "workspace:*",
+    "@sequelize/utils": "workspace:*",
+    "@types/snowflake-sdk": "^1.6.20",
+    "lodash": "^4.17.21",
+    "snowflake-sdk": "^1.10.0"
+  }
+}

--- a/packages/snowflake/src/_internal/data-types-overrides.ts
+++ b/packages/snowflake/src/_internal/data-types-overrides.ts
@@ -1,7 +1,7 @@
+import type { AbstractDialect } from '@sequelize/core';
+import type { AcceptedDate } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/data-types.js';
+import * as BaseTypes from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/data-types.js';
 import maxBy from 'lodash/maxBy.js';
-import type { AcceptedDate } from '../abstract/data-types.js';
-import * as BaseTypes from '../abstract/data-types.js';
-import type { AbstractDialect } from '../abstract/index.js';
 
 export class DATE extends BaseTypes.DATE {
   toSql() {

--- a/packages/snowflake/src/dialect.ts
+++ b/packages/snowflake/src/dialect.ts
@@ -1,11 +1,11 @@
-import type { Sequelize } from '../../sequelize.js';
-import { createUnspecifiedOrderedBindCollector } from '../../utils/sql';
-import { AbstractDialect } from '../abstract';
-import { SnowflakeConnectionManager } from './connection-manager';
-import * as DataTypes from './data-types.js';
-import { SnowflakeQuery } from './query';
-import { SnowflakeQueryGenerator } from './query-generator';
+import type { Sequelize } from '@sequelize/core';
+import { AbstractDialect } from '@sequelize/core';
+import { createUnspecifiedOrderedBindCollector } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/sql.js';
+import * as DataTypes from './_internal/data-types-overrides.js';
+import { SnowflakeConnectionManager } from './connection-manager.js';
+import { SnowflakeQueryGenerator } from './query-generator.js';
 import { SnowflakeQueryInterface } from './query-interface.js';
+import { SnowflakeQuery } from './query.js';
 
 export class SnowflakeDialect extends AbstractDialect {
   static supports = AbstractDialect.extendSupport({

--- a/packages/snowflake/src/index.mjs
+++ b/packages/snowflake/src/index.mjs
@@ -1,0 +1,7 @@
+import Pkg from './index.js';
+
+export const SnowflakeConnectionManager = Pkg.SnowflakeConnectionManager;
+export const SnowflakeDialect = Pkg.SnowflakeDialect;
+export const SnowflakeQueryGenerator = Pkg.SnowflakeQueryGenerator;
+export const SnowflakeQueryInterface = Pkg.SnowflakeQueryInterface;
+export const SnowflakeQuery = Pkg.SnowflakeQuery;

--- a/packages/snowflake/src/index.ts
+++ b/packages/snowflake/src/index.ts
@@ -1,0 +1,7 @@
+/** Generated File, do not modify directly. Run "yarn sync-exports" in the folder of the package instead */
+
+export * from './connection-manager.js';
+export * from './dialect.js';
+export * from './query-generator.js';
+export * from './query-interface.js';
+export * from './query.js';

--- a/packages/snowflake/src/query-generator-typescript.internal.ts
+++ b/packages/snowflake/src/query-generator-typescript.internal.ts
@@ -1,15 +1,3 @@
-import { Op } from '../../operators.js';
-import { rejectInvalidOptions } from '../../utils/check';
-import { joinSQLFragments } from '../../utils/join-sql-fragments';
-import { EMPTY_SET } from '../../utils/object.js';
-import { AbstractQueryGenerator } from '../abstract/query-generator';
-import {
-  CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
-  LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS,
-  SHOW_CONSTRAINTS_QUERY_SUPPORTABLE_OPTIONS,
-  START_TRANSACTION_QUERY_SUPPORTABLE_OPTIONS,
-  TRUNCATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator-typescript';
 import type {
   CreateDatabaseQueryOptions,
   ListDatabasesQueryOptions,
@@ -19,9 +7,20 @@ import type {
   StartTransactionQueryOptions,
   TableOrModel,
   TruncateTableQueryOptions,
-} from '../abstract/query-generator.types';
-import type { SnowflakeDialect } from './index.js';
-import { SnowflakeQueryGeneratorInternal } from './query-generator-internal.js';
+} from '@sequelize/core';
+import { AbstractQueryGenerator, Op } from '@sequelize/core';
+import {
+  CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
+  LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS,
+  SHOW_CONSTRAINTS_QUERY_SUPPORTABLE_OPTIONS,
+  START_TRANSACTION_QUERY_SUPPORTABLE_OPTIONS,
+  TRUNCATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator-typescript.js';
+import { rejectInvalidOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
+import { joinSQLFragments } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/join-sql-fragments.js';
+import { EMPTY_SET } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/object.js';
+import type { SnowflakeDialect } from './dialect.js';
+import { SnowflakeQueryGeneratorInternal } from './query-generator.internal.js';
 
 const SHOW_CONSTRAINTS_QUERY_SUPPORTED_OPTIONS = new Set<keyof ShowConstraintsQueryOptions>([
   'constraintName',

--- a/packages/snowflake/src/query-generator.d.ts
+++ b/packages/snowflake/src/query-generator.d.ts
@@ -1,0 +1,3 @@
+import { SnowflakeQueryGeneratorTypeScript } from './query-generator-typescript.internal.js';
+
+export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {}

--- a/packages/snowflake/src/query-generator.internal.ts
+++ b/packages/snowflake/src/query-generator.internal.ts
@@ -1,6 +1,6 @@
-import { AbstractQueryGeneratorInternal } from '../abstract/query-generator-internal.js';
-import type { AddLimitOffsetOptions } from '../abstract/query-generator.internal-types.js';
-import type { SnowflakeDialect } from './index.js';
+import { AbstractQueryGeneratorInternal } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator-internal.js';
+import type { AddLimitOffsetOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator.internal-types.js';
+import type { SnowflakeDialect } from './dialect.js';
 
 const TECHNICAL_SCHEMA_NAMES = Object.freeze([
   'INFORMATION_SCHEMA',

--- a/packages/snowflake/src/query-generator.js
+++ b/packages/snowflake/src/query-generator.js
@@ -1,19 +1,17 @@
 'use strict';
 
-import { rejectInvalidOptions } from '../../utils/check';
-import { quoteIdentifier } from '../../utils/dialect.js';
-import { joinSQLFragments } from '../../utils/join-sql-fragments';
-import { EMPTY_SET } from '../../utils/object.js';
-import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import {
   ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
   CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator';
-
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator.js';
+import { rejectInvalidOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
+import { quoteIdentifier } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/dialect.js';
+import { joinSQLFragments } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/join-sql-fragments.js';
+import { EMPTY_SET } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/object.js';
+import { defaultValueSchemable } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/query-builder-utils.js';
 import each from 'lodash/each';
 import isPlainObject from 'lodash/isPlainObject';
-
-const { SnowflakeQueryGeneratorTypeScript } = require('./query-generator-typescript');
+import { SnowflakeQueryGeneratorTypeScript } from './query-generator-typescript.internal.js';
 
 /**
  * list of reserved words in Snowflake

--- a/packages/snowflake/src/query-interface.ts
+++ b/packages/snowflake/src/query-interface.ts
@@ -1,5 +1,5 @@
-import { AbstractQueryInterface } from '../abstract/query-interface.js';
-import type { SnowflakeDialect } from './index.js';
+import { AbstractQueryInterface } from '@sequelize/core';
+import type { SnowflakeDialect } from './dialect.js';
 
 export class SnowflakeQueryInterface<
   Dialect extends SnowflakeDialect = SnowflakeDialect,

--- a/packages/snowflake/src/query.d.ts
+++ b/packages/snowflake/src/query.d.ts
@@ -1,3 +1,3 @@
-import { AbstractQuery } from '../abstract/query.js';
+import { AbstractQuery } from '@sequelize/core';
 
 export class SnowflakeQuery extends AbstractQuery {}

--- a/packages/snowflake/src/query.js
+++ b/packages/snowflake/src/query.js
@@ -1,14 +1,18 @@
 'use strict';
 
+import {
+  AbstractQuery,
+  DatabaseError,
+  ForeignKeyConstraintError,
+  UniqueConstraintError,
+  ValidationErrorItem,
+} from '@sequelize/core';
+import { logger } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/logger.js';
 import forOwn from 'lodash/forOwn';
 import map from 'lodash/map';
 import mapKeys from 'lodash/mapKeys';
 import reduce from 'lodash/reduce';
 import zipObject from 'lodash/zipObject';
-
-const { AbstractQuery } = require('../abstract/query');
-const sequelizeErrors = require('../../errors');
-const { logger } = require('../../utils/logger');
 
 const ER_DUP_ENTRY = 1062;
 const ER_DEADLOCK = 1213;
@@ -223,9 +227,9 @@ export class SnowflakeQuery extends AbstractQuery {
         const errors = [];
         forOwn(fields, (value, field) => {
           errors.push(
-            new sequelizeErrors.ValidationErrorItem(
+            new ValidationErrorItem(
               this.getUniqueConstraintErrorMessage(field),
-              'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,
+              'unique violation', // ValidationErrorItem.Origins.DB,
               field,
               value,
               this.instance,
@@ -234,7 +238,7 @@ export class SnowflakeQuery extends AbstractQuery {
           );
         });
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields });
+        return new UniqueConstraintError({ message, errors, cause: err, fields });
       }
 
       case ER_ROW_IS_REFERENCED:
@@ -248,7 +252,7 @@ export class SnowflakeQuery extends AbstractQuery {
           ? match[3].split(new RegExp(`${quoteChar}, *${quoteChar}`))
           : undefined;
 
-        return new sequelizeErrors.ForeignKeyConstraintError({
+        return new ForeignKeyConstraintError({
           reltype: String(errCode) === String(ER_ROW_IS_REFERENCED) ? 'parent' : 'child',
           table: match ? match[4] : undefined,
           fields,
@@ -260,7 +264,7 @@ export class SnowflakeQuery extends AbstractQuery {
       }
 
       default:
-        return new sequelizeErrors.DatabaseError(err);
+        return new DatabaseError(err);
     }
   }
 

--- a/packages/snowflake/tsconfig.json
+++ b/packages/snowflake/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig-preset.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/packages/snowflake/typedoc.json
+++ b/packages/snowflake/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "excludeExternals": true
+}

--- a/test/esm-named-exports.test.js
+++ b/test/esm-named-exports.test.js
@@ -65,6 +65,7 @@ const ignoredCjsKeysMap = {
   '@sequelize/mssql': ['__esModule'],
   '@sequelize/mysql': ['__esModule'],
   '@sequelize/postgres': ['__esModule'],
+  '@sequelize/snowflake': ['__esModule'],
   '@sequelize/sqlite': ['__esModule'],
   '@sequelize/utils': ['__esModule'],
   '@sequelize/utils/node': ['__esModule'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,7 +2235,6 @@ __metadata:
     "@types/semver": "npm:7.5.8"
     "@types/sinon": "npm:17.0.3"
     "@types/sinon-chai": "npm:3.2.12"
-    "@types/snowflake-sdk": "npm:1.6.20"
     "@types/uuid": "npm:9.0.8"
     "@types/validator": "npm:^13.7.5"
     bnf-parser: "npm:3.1.6"
@@ -2266,15 +2265,11 @@ __metadata:
     sequelize-pool: "npm:^8.0.0"
     sinon: "npm:17.0.1"
     sinon-chai: "npm:3.7.0"
-    snowflake-sdk: "npm:1.10.0"
     toposort-class: "npm:^1.0.1"
     type-fest: "npm:^4.12.0"
     uuid: "npm:^9.0.0"
     validator: "npm:^13.7.0"
     wkx: "npm:^0.5.0"
-  peerDependenciesMeta:
-    snowflake-sdk:
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2421,6 +2416,18 @@ __metadata:
     postgres-array: "npm:3.0.2"
     semver: "npm:7.6.0"
     wkx: "npm:0.5.0"
+  languageName: unknown
+  linkType: soft
+
+"@sequelize/snowflake@workspace:packages/snowflake":
+  version: 0.0.0-use.local
+  resolution: "@sequelize/snowflake@workspace:packages/snowflake"
+  dependencies:
+    "@sequelize/core": "workspace:*"
+    "@sequelize/utils": "workspace:*"
+    "@types/snowflake-sdk": "npm:^1.6.20"
+    lodash: "npm:^4.17.21"
+    snowflake-sdk: "npm:^1.10.0"
   languageName: unknown
   linkType: soft
 
@@ -3521,7 +3528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/snowflake-sdk@npm:1.6.20":
+"@types/snowflake-sdk@npm:^1.6.20":
   version: 1.6.20
   resolution: "@types/snowflake-sdk@npm:1.6.20"
   dependencies:
@@ -12666,7 +12673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"snowflake-sdk@npm:1.10.0":
+"snowflake-sdk@npm:^1.10.0":
   version: 1.10.0
   resolution: "snowflake-sdk@npm:1.10.0"
   dependencies:


### PR DESCRIPTION
## Goal of the PR

Related issue: #13722
Related PR: #17190 

This PR moves the Snowflake Dialect to the `@sequelize/snowflake` package.

## Relevant impacts

- This package pre-installs the necessary snowflake-specific dependency `snowflake`. Users won't need to install the additional packages anymore. This gives us control over which version we support.
- Unlike the postgres package, this package does not have unit tests yet. Once we add those, the script should be added to the package package.json and CI.

## Other changes

## Breaking changes

- Instead of installing `snowflake-sdk` users need to install `@sequelize/snowflake`.