### PR TITLE
fix: add `readOnly` to the transaction options types and docs

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1169,6 +1169,7 @@ class Sequelize {
    * @param {string}   [options.type='DEFERRED'] See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
    * @param {string}   [options.isolationLevel] See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
    * @param {string}   [options.deferrable] Sets the constraints to be deferred or immediately checked. See `Sequelize.Deferrable`. PostgreSQL Only
+   * @param {boolean}  [options.readOnly] Whether this transaction will only be used to read data. Used to determine whether sequelize is allowed to use a read replication server.
    * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {Function} [autoCallback] The callback is called with the transaction object, and should return a promise. If the promise is resolved, the transaction commits; if the promise rejects, the transaction rolls back
    *

--- a/src/transaction.d.ts
+++ b/src/transaction.d.ts
@@ -139,6 +139,7 @@ export interface TransactionOptions extends Logging {
   isolationLevel?: Transaction.ISOLATION_LEVELS;
   type?: Transaction.TYPES;
   deferrable?: string | Deferrable;
+  readOnly?: boolean;
   /**
    * Parent transaction.
    */

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -17,6 +17,7 @@ class Transaction {
    * @param {string} [options.type] Sets the type of the transaction. Sqlite only
    * @param {string} [options.isolationLevel] Sets the isolation level of the transaction.
    * @param {string} [options.deferrable] Sets the constraints to be deferred or immediately checked. PostgreSQL only
+   * @param {boolean} [options.readOnly] Whether this transaction will only be used to read data. Used to determine whether sequelize is allowed to use a read replication server.
    */
   constructor(sequelize, options) {
     this.sequelize = sequelize;


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? [Transaction readOnly option is not documented.](https://github.com/sequelize/website/issues/562)
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Closes Sequelize/website#562.

Adds to documentation and types the previously not documented option `readOnly` of the transaction constructor.

## List of Breaking Changes

None.
