### PR TITLE
feat(cli): add `seed generate` command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,6 +211,7 @@ module.exports = {
     'packages/**/skeletons/**/*',
     '.typedoc-build',
     'packages/cli/migrations/**/*',
+    'packages/cli/seeds/**/*',
   ],
   env: {
     node: true,

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -28,6 +28,8 @@ jobs:
             docs
             meta
           scopes: |
+            cli
+            core
             db2
             ibmi
             mariadb
@@ -38,5 +40,7 @@ jobs:
             snowflake
             sqlite
             types
+            utils
+            validator.js
           ignoreLabels: |
             ignore-semantic-pull-request

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -39,7 +39,6 @@ jobs:
             postgres
             snowflake
             sqlite
-            types
             utils
             validator.js
           ignoreLabels: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 .yarn
 /packages/cli/migrations
+/packages/cli/seeds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,7 +246,11 @@ We will then use the title of your PR as the message of the Squash Commit. It wi
 We use a simple conventional commits convention:
 
 - The allowed commit types are: `docs`, `feat`, `fix`, `meta`.
-- We allow the following commit scopes (they're the list of dialects we support, plus `types` for TypeScript-only changes):
+- We allow the following commit scopes (they're the list of packages and `types` for TypeScript-only changes):
+  - `core`
+  - `utils`
+  - `cli`
+  - `validator.js`
   - `postgres`
   - `mysql`
   - `mariadb`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,7 +246,7 @@ We will then use the title of your PR as the message of the Squash Commit. It wi
 We use a simple conventional commits convention:
 
 - The allowed commit types are: `docs`, `feat`, `fix`, `meta`.
-- We allow the following commit scopes (they're the list of packages and `types` for TypeScript-only changes):
+- We allow the following commit scopes (they're the list of packages):
   - `core`
   - `utils`
   - `cli`
@@ -259,7 +259,6 @@ We use a simple conventional commits convention:
   - `db2`
   - `ibmi`
   - `snowflake`
-  - `types`
 - If your changes impact more than one scope, simply omit the scope.
 
 Example:

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -5,3 +5,4 @@ node_modules
 oclif.lock
 oclif.manifest.json
 /migrations
+/seeds

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,9 @@
     "topics": {
       "migration": {
         "description": "Commands for managing database migrations"
+      },
+      "seed": {
+        "description": "Commands for managing database seeding"
       }
     }
   },

--- a/packages/cli/src/_internal/config.ts
+++ b/packages/cli/src/_internal/config.ts
@@ -12,6 +12,10 @@ const configSchema = z.object({
     .string()
     .default('/migrations')
     .transform(val => path.join(projectRoot, val)),
+  seedFolder: z
+    .string()
+    .default('/seeds')
+    .transform(val => path.join(projectRoot, val)),
 });
 
 export const config = configSchema.parse(result?.config || {});

--- a/packages/cli/src/api/generate-seed.ts
+++ b/packages/cli/src/api/generate-seed.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { SKELETONS_FOLDER } from '../_internal/skeletons.js';
+import { getCurrentYYYYMMDDHHmms, slugify } from '../_internal/utils.js';
+
+export const SUPPORTED_SEED_FORMATS = ['sql', 'typescript', 'cjs', 'esm'] as const;
+export type SupportedSeedFormat = (typeof SUPPORTED_SEED_FORMATS)[number];
+
+const FORMAT_EXTENSIONS: Record<SupportedSeedFormat, string> = {
+  sql: 'sql',
+  typescript: 'ts',
+  cjs: 'cjs',
+  esm: 'mjs',
+};
+
+export interface GenerateSeedOptions {
+  format: SupportedSeedFormat;
+  seedName: string;
+  seedFolder: string;
+}
+
+export async function generateSeed(options: GenerateSeedOptions): Promise<string> {
+  const { format, seedName, seedFolder } = options;
+
+  const seedFilename = `${getCurrentYYYYMMDDHHmms()}-${slugify(seedName)}`;
+  const seedPath = path.join(seedFolder, seedFilename);
+
+  if (format === 'sql') {
+    await fs.mkdir(seedPath, { recursive: true });
+    await Promise.all([
+      fs.writeFile(path.join(seedPath, 'up.sql'), ''),
+      fs.writeFile(path.join(seedPath, 'down.sql'), ''),
+    ]);
+
+    return seedPath;
+  }
+
+  await fs.mkdir(seedFolder, { recursive: true });
+
+  const extension = FORMAT_EXTENSIONS[format];
+  const targetPath = `${seedPath}.${extension}`;
+  const sourcePath = path.join(SKELETONS_FOLDER, `seed.${extension}`);
+
+  await fs.copyFile(sourcePath, targetPath);
+
+  return targetPath;
+}

--- a/packages/cli/src/commands/seed/generate.test.ts
+++ b/packages/cli/src/commands/seed/generate.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@oclif/test';
+import { fileUrlToDirname } from '@sequelize/utils/node';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const __dirname = fileUrlToDirname(import.meta.url);
+const packageRoot = path.join(__dirname, '..', '..', '..');
+
+function oclifTest() {
+  return test.loadConfig({
+    root: packageRoot,
+  });
+}
+
+describe('seed:generate', () => {
+  oclifTest()
+    .stdout()
+    .command(['seed:generate', '--format=sql', '--name=test-seed', '--json'])
+    .it('generates an SQL seed', async ctx => {
+      const asJson = JSON.parse(ctx.stdout);
+
+      expect(Object.keys(asJson)).to.deep.eq(['path']);
+      expect(pathToFileURL(asJson.path).pathname).to.match(/seeds\/[\d\-t]{19}-test-seed/);
+      expect(await fs.readdir(asJson.path)).to.have.members(['up.sql', 'down.sql']);
+    });
+
+  oclifTest()
+    .stdout()
+    .command(['seed:generate', '--format=typescript', '--name=test-seed', '--json'])
+    .it('generates a TypeScript seed', async ctx => {
+      const asJson = JSON.parse(ctx.stdout);
+
+      expect(Object.keys(asJson)).to.deep.eq(['path']);
+      expect(pathToFileURL(asJson.path).pathname).to.match(/seeds\/[\d\-t]{19}-test-seed\.ts/);
+      await fs.access(asJson.path);
+    });
+
+  oclifTest()
+    .stdout()
+    .command(['seed:generate', '--format=cjs', '--name=test-seed', '--json'])
+    .it('generates a CJS seed', async ctx => {
+      const asJson = JSON.parse(ctx.stdout);
+
+      expect(Object.keys(asJson)).to.deep.eq(['path']);
+      expect(pathToFileURL(asJson.path).pathname).to.match(/seeds\/[\d\-t]{19}-test-seed\.cjs/);
+      await fs.access(asJson.path);
+    });
+
+  oclifTest()
+    .stdout()
+    .command(['seed:generate', '--format=esm', '--name=test-seed', '--json'])
+    .it('generates an ESM seed', async ctx => {
+      const asJson = JSON.parse(ctx.stdout);
+
+      expect(Object.keys(asJson)).to.deep.eq(['path']);
+      expect(pathToFileURL(asJson.path).pathname).to.match(/seeds\/[\d\-t]{19}-test-seed\.mjs/);
+      await fs.access(asJson.path);
+    });
+
+  oclifTest()
+    .stdout()
+    .command(['seed:generate', '--format=sql', '--no-interactive', '--json'])
+    .it('supports not specifying a name', async ctx => {
+      const asJson = JSON.parse(ctx.stdout);
+
+      expect(Object.keys(asJson)).to.deep.eq(['path']);
+      expect(pathToFileURL(asJson.path).pathname).to.match(/seeds\/[\d\-t]{19}-unnamed/);
+    });
+});

--- a/packages/cli/src/commands/seed/generate.ts
+++ b/packages/cli/src/commands/seed/generate.ts
@@ -25,7 +25,7 @@ export class GenerateSeed extends SequelizeCommand<(typeof GenerateSeed)['flags'
   static examples = [
     `<%= config.bin %> <%= command.id %>`,
     `<%= config.bin %> <%= command.id %> --format=sql`,
-    `<%= config.bin %> <%= command.id %> --name="create users table"`,
+    `<%= config.bin %> <%= command.id %> --name="users table test data"`,
   ];
 
   async run(): Promise<{ path: string }> {

--- a/packages/cli/src/commands/seed/generate.ts
+++ b/packages/cli/src/commands/seed/generate.ts
@@ -1,0 +1,50 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+import { config } from '../../_internal/config.js';
+import { SequelizeCommand } from '../../_internal/sequelize-command.js';
+import type { SupportedSeedFormat } from '../../api/generate-seed.js';
+import { SUPPORTED_SEED_FORMATS, generateSeed } from '../../api/generate-seed.js';
+
+export class GenerateSeed extends SequelizeCommand<(typeof GenerateSeed)['flags']> {
+  static enableJsonFlag = true;
+
+  static flags = {
+    format: Flags.string({
+      options: SUPPORTED_SEED_FORMATS,
+      summary: 'The format of the seed file to generate',
+      required: true,
+    }),
+    name: Flags.string({
+      summary: 'A short name for the seed file',
+      default: 'unnamed',
+    }),
+  };
+
+  static summary = 'Generates a new seed file';
+
+  static examples = [
+    `<%= config.bin %> <%= command.id %>`,
+    `<%= config.bin %> <%= command.id %> --format=sql`,
+    `<%= config.bin %> <%= command.id %> --name="create users table"`,
+  ];
+
+  async run(): Promise<{ path: string }> {
+    const { format, name: seedName } = this.flags;
+    const { seedFolder } = config;
+
+    const seedPath = await generateSeed({
+      format: format as SupportedSeedFormat,
+      seedName,
+      seedFolder,
+    });
+
+    if (format === 'sql') {
+      this.log(`SQL seed files generated in ${chalk.green(seedPath)}`);
+    } else {
+      this.log(`Seed file generated at ${chalk.green(seedPath)}`);
+    }
+
+    // JSON output
+    return { path: seedPath };
+  }
+}

--- a/packages/cli/static/skeletons/seed.cjs
+++ b/packages/cli/static/skeletons/seed.cjs
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  /** @type {import('@sequelize/cli').MigrationFunction} */
+  async up(queryInterface, sequelize) {
+    /**
+     * Add seed commands here.
+     *
+     * Example:
+     * await queryInterface.bulkInsert('People', [{
+     *   name: 'John Doe',
+     *   isBetaMember: false
+     * }], {});
+     */
+  },
+
+  /** @type {import('@sequelize/cli').MigrationFunction} */
+  async down(queryInterface, sequelize) {
+    /**
+     * Add commands to revert seed here.
+     *
+     * Example:
+     * await queryInterface.bulkDelete('People', null, {});
+     */
+  },
+};

--- a/packages/cli/static/skeletons/seed.cjs
+++ b/packages/cli/static/skeletons/seed.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  /** @type {import('@sequelize/cli').MigrationFunction} */
+  /** @type {import('@sequelize/cli').SeedFunction} */
   async up(queryInterface, sequelize) {
     /**
      * Add seed commands here.
@@ -14,7 +14,7 @@ module.exports = {
      */
   },
 
-  /** @type {import('@sequelize/cli').MigrationFunction} */
+  /** @type {import('@sequelize/cli').SeedFunction} */
   async down(queryInterface, sequelize) {
     /**
      * Add commands to revert seed here.

--- a/packages/cli/static/skeletons/seed.mjs
+++ b/packages/cli/static/skeletons/seed.mjs
@@ -1,0 +1,22 @@
+/** @type {import('@sequelize/cli').MigrationFunction} */
+export async function up(queryInterface, sequelize) {
+  /**
+   * Add seed commands here.
+   *
+   * Example:
+   * await queryInterface.bulkInsert('People', [{
+   *   name: 'John Doe',
+   *   isBetaMember: false
+   * }], {});
+   */
+}
+
+/** @type {import('@sequelize/cli').MigrationFunction} */
+export async function down(queryInterface, sequelize) {
+  /**
+   * Add commands to revert seed here.
+   *
+   * Example:
+   * await queryInterface.bulkDelete('People', null, {});
+   */
+}

--- a/packages/cli/static/skeletons/seed.mjs
+++ b/packages/cli/static/skeletons/seed.mjs
@@ -1,4 +1,4 @@
-/** @type {import('@sequelize/cli').MigrationFunction} */
+/** @type {import('@sequelize/cli').SeedFunction} */
 export async function up(queryInterface, sequelize) {
   /**
    * Add seed commands here.
@@ -11,7 +11,7 @@ export async function up(queryInterface, sequelize) {
    */
 }
 
-/** @type {import('@sequelize/cli').MigrationFunction} */
+/** @type {import('@sequelize/cli').SeedFunction} */
 export async function down(queryInterface, sequelize) {
   /**
    * Add commands to revert seed here.

--- a/packages/cli/static/skeletons/seed.ts
+++ b/packages/cli/static/skeletons/seed.ts
@@ -1,0 +1,28 @@
+import { AbstractQueryInterface, Sequelize } from '@sequelize/core';
+
+export async function up(
+  queryInterface: AbstractQueryInterface,
+  sequelize: Sequelize,
+): Promise<void> {
+  /**
+   * Add seed commands here.
+   *
+   * Example:
+   * await queryInterface.bulkInsert('People', [{
+   *   name: 'John Doe',
+   *   isBetaMember: false
+   * }], {});
+   */
+}
+
+export async function down(
+  queryInterface: AbstractQueryInterface,
+  sequelize: Sequelize,
+): Promise<void> {
+  /**
+   * Add commands to revert seed here.
+   *
+   * Example:
+   * await queryInterface.bulkDelete('People', null, {});
+   */
+}


### PR DESCRIPTION
## Description of Changes

<!-- Please provide a description of the change here. -->

This PR adds the command `seed generate` to the CLI. This command can generate the seed in 4 formats; `sql`, `typescript` (with `import`), `cjs` or `esm`.

This command acts the same way as `migration generate`, added in #17195 

I also updated the pr-title Action and CONTRIBUTING docs to reflect that we allow all packages as scopes.
