### PR TITLE
meta: update auto-update version

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           app-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
           private-key: '${{ secrets.SEQUELIZE_BOT_PRIVATE_KEY }}'
-      - uses: sequelize/pr-auto-update-and-handle-conflicts@3ff4c1ae3b521ccd0a6bed0de19911d555b7da8d # 1.0.0
+      - uses: sequelize/pr-auto-update-and-handle-conflicts@257ac5f68859672393e3320495164251140bd801 # v1.0.0
         with:
           conflict-label: 'conflicted'
           conflict-requires-ready-state: 'ready_for_review'


### PR DESCRIPTION

## Description of Changes

This PR updates the auto-update action to v1.0.1, which fixes the action expecting an empty label (instead of not expecting labels) if `x-requires-label` is empty