### PR TITLE
feat(cli): add support for legacy timestamp

### DIFF
--- a/packages/cli/src/_internal/utils.ts
+++ b/packages/cli/src/_internal/utils.ts
@@ -10,6 +10,18 @@ export function getCurrentYYYYMMDDHHmms() {
   )}`;
 }
 
+export function LEGACY_getCurrentYYYYMMDDHHmms() {
+  const date = new Date();
+
+  return `${date.getUTCFullYear()}${padNumber(date.getUTCMonth() + 1, 2)}${padNumber(
+    date.getUTCDate(),
+    2,
+  )}${padNumber(date.getUTCHours(), 2)}${padNumber(date.getUTCMinutes(), 2)}${padNumber(
+    date.getUTCSeconds(),
+    2,
+  )}`;
+}
+
 export function padNumber(value: number, length: number): string {
   return String(value).padStart(length, '0');
 }

--- a/packages/cli/src/api/generate-migration.ts
+++ b/packages/cli/src/api/generate-migration.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { SKELETONS_FOLDER } from '../_internal/skeletons.js';
-import { getCurrentYYYYMMDDHHmms, slugify } from '../_internal/utils.js';
+import {
+  LEGACY_getCurrentYYYYMMDDHHmms,
+  getCurrentYYYYMMDDHHmms,
+  slugify,
+} from '../_internal/utils.js';
 
 export const SUPPORTED_MIGRATION_FORMATS = ['sql', 'typescript', 'cjs', 'esm'] as const;
 export type SupportedMigrationFormat = (typeof SUPPORTED_MIGRATION_FORMATS)[number];
@@ -17,12 +21,22 @@ export interface GenerateMigrationOptions {
   format: SupportedMigrationFormat;
   migrationName: string;
   migrationFolder: string;
+  legacyTimestamp?: boolean;
 }
 
 export async function generateMigration(options: GenerateMigrationOptions): Promise<string> {
-  const { format, migrationName, migrationFolder } = options;
+  const { format, migrationName, migrationFolder, legacyTimestamp } = options;
 
-  const migrationFilename = `${getCurrentYYYYMMDDHHmms()}-${slugify(migrationName)}`;
+  let migrationFilename = '';
+
+  if (legacyTimestamp) {
+    migrationFilename += `${LEGACY_getCurrentYYYYMMDDHHmms()}`;
+  } else {
+    migrationFilename += `${getCurrentYYYYMMDDHHmms()}`;
+  }
+
+  migrationFilename += `-${slugify(migrationName)}`;
+
   const migrationPath = path.join(migrationFolder, migrationFilename);
 
   if (format === 'sql') {

--- a/packages/cli/src/api/generate-seed.ts
+++ b/packages/cli/src/api/generate-seed.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { SKELETONS_FOLDER } from '../_internal/skeletons.js';
-import { getCurrentYYYYMMDDHHmms, slugify } from '../_internal/utils.js';
+import { LEGACY_getCurrentYYYYMMDDHHmms, getCurrentYYYYMMDDHHmms, slugify } from '../_internal/utils.js';
 
 export const SUPPORTED_SEED_FORMATS = ['sql', 'typescript', 'cjs', 'esm'] as const;
 export type SupportedSeedFormat = (typeof SUPPORTED_SEED_FORMATS)[number];
@@ -17,12 +17,22 @@ export interface GenerateSeedOptions {
   format: SupportedSeedFormat;
   seedName: string;
   seedFolder: string;
+  legacyTimestamp?: boolean;
 }
 
 export async function generateSeed(options: GenerateSeedOptions): Promise<string> {
-  const { format, seedName, seedFolder } = options;
+  const { format, seedName, seedFolder, legacyTimestamp } = options;
 
-  const seedFilename = `${getCurrentYYYYMMDDHHmms()}-${slugify(seedName)}`;
+  let seedFilename = '';
+
+  if (legacyTimestamp) {
+    seedFilename += `${LEGACY_getCurrentYYYYMMDDHHmms()}`;
+  } else {
+    seedFilename += `${getCurrentYYYYMMDDHHmms()}`;
+  }
+
+  seedFilename += `-${slugify(seedName)}`;
+
   const seedPath = path.join(seedFolder, seedFilename);
 
   if (format === 'sql') {

--- a/packages/cli/src/api/generate-seed.ts
+++ b/packages/cli/src/api/generate-seed.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { SKELETONS_FOLDER } from '../_internal/skeletons.js';
-import { LEGACY_getCurrentYYYYMMDDHHmms, getCurrentYYYYMMDDHHmms, slugify } from '../_internal/utils.js';
+import {
+  LEGACY_getCurrentYYYYMMDDHHmms,
+  getCurrentYYYYMMDDHHmms,
+  slugify,
+} from '../_internal/utils.js';
 
 export const SUPPORTED_SEED_FORMATS = ['sql', 'typescript', 'cjs', 'esm'] as const;
 export type SupportedSeedFormat = (typeof SUPPORTED_SEED_FORMATS)[number];

--- a/packages/cli/src/commands/migration/generate.test.ts
+++ b/packages/cli/src/commands/migration/generate.test.ts
@@ -78,7 +78,13 @@ describe('migration:generate', () => {
 
   oclifTest()
     .stdout()
-    .command(['migration:generate', '--format=sql', '--name=test-migration', '--legacyTimestamp', '--json'])
+    .command([
+      'migration:generate',
+      '--format=sql',
+      '--name=test-migration',
+      '--legacyTimestamp',
+      '--json',
+    ])
     .it('supports specifying the legacyTimestamp option', async ctx => {
       const asJson = JSON.parse(ctx.stdout);
 

--- a/packages/cli/src/commands/migration/generate.test.ts
+++ b/packages/cli/src/commands/migration/generate.test.ts
@@ -75,4 +75,15 @@ describe('migration:generate', () => {
       expect(Object.keys(asJson)).to.deep.eq(['path']);
       expect(pathToFileURL(asJson.path).pathname).to.match(/migrations\/[\d\-t]{19}-unnamed/);
     });
+
+  oclifTest()
+    .stdout()
+    .command(['migration:generate', '--format=sql', '--name=test-migration', '--legacyTimestamp', '--json'])
+    .it('supports specifying the legacyTimestamp option', async ctx => {
+      const asJson = JSON.parse(ctx.stdout);
+
+      expect(Object.keys(asJson)).to.deep.eq(['path']);
+      expect(pathToFileURL(asJson.path).pathname).to.match(/migrations\/[\d]{14}-test-migration/);
+      expect(await fs.readdir(asJson.path)).to.have.members(['up.sql', 'down.sql']);
+    });
 });

--- a/packages/cli/src/commands/migration/generate.ts
+++ b/packages/cli/src/commands/migration/generate.ts
@@ -18,6 +18,9 @@ export class GenerateMigration extends SequelizeCommand<(typeof GenerateMigratio
       summary: 'A short name for the migration file',
       default: 'unnamed',
     }),
+    legacyTimestamp: Flags.boolean({
+      summary: 'When enabled, use the legacy timestamp format from earlier versions of the CLI',
+    }),
   };
 
   static summary = 'Generates a new migration file';
@@ -26,16 +29,18 @@ export class GenerateMigration extends SequelizeCommand<(typeof GenerateMigratio
     `<%= config.bin %> <%= command.id %>`,
     `<%= config.bin %> <%= command.id %> --format=sql`,
     `<%= config.bin %> <%= command.id %> --name="create users table"`,
+    `<%= config.bin %> <%= command.id %> --legacyTimestamp`,
   ];
 
   async run(): Promise<{ path: string }> {
-    const { format, name: migrationName } = this.flags;
+    const { format, name: migrationName, legacyTimestamp } = this.flags;
     const { migrationFolder } = config;
 
     const migrationPath = await generateMigration({
       format: format as SupportedMigrationFormat,
       migrationName,
       migrationFolder,
+      legacyTimestamp,
     });
 
     if (format === 'sql') {

--- a/packages/cli/src/commands/seed/generate.test.ts
+++ b/packages/cli/src/commands/seed/generate.test.ts
@@ -67,4 +67,15 @@ describe('seed:generate', () => {
       expect(Object.keys(asJson)).to.deep.eq(['path']);
       expect(pathToFileURL(asJson.path).pathname).to.match(/seeds\/[\d\-t]{19}-unnamed/);
     });
+
+  oclifTest()
+    .stdout()
+    .command(['seed:generate', '--format=sql', '--name=test-seed', '--legacyTimestamp', '--json'])
+    .it('supports specifying the legacyTimestamp option', async ctx => {
+      const asJson = JSON.parse(ctx.stdout);
+
+      expect(Object.keys(asJson)).to.deep.eq(['path']);
+      expect(pathToFileURL(asJson.path).pathname).to.match(/seeds\/[\d]{14}-test-seed/);
+      expect(await fs.readdir(asJson.path)).to.have.members(['up.sql', 'down.sql']);
+    });
 });

--- a/packages/cli/src/commands/seed/generate.ts
+++ b/packages/cli/src/commands/seed/generate.ts
@@ -18,6 +18,9 @@ export class GenerateSeed extends SequelizeCommand<(typeof GenerateSeed)['flags'
       summary: 'A short name for the seed file',
       default: 'unnamed',
     }),
+    legacyTimestamp: Flags.boolean({
+      summary: 'When enabled, use the legacy timestamp format from earlier versions of the CLI',
+    }),
   };
 
   static summary = 'Generates a new seed file';
@@ -26,16 +29,18 @@ export class GenerateSeed extends SequelizeCommand<(typeof GenerateSeed)['flags'
     `<%= config.bin %> <%= command.id %>`,
     `<%= config.bin %> <%= command.id %> --format=sql`,
     `<%= config.bin %> <%= command.id %> --name="users table test data"`,
+    `<%= config.bin %> <%= command.id %> --legacyTimestamp`,
   ];
 
   async run(): Promise<{ path: string }> {
-    const { format, name: seedName } = this.flags;
+    const { format, name: seedName, legacyTimestamp } = this.flags;
     const { seedFolder } = config;
 
     const seedPath = await generateSeed({
       format: format as SupportedSeedFormat,
       seedName,
       seedFolder,
+      legacyTimestamp,
     });
 
     if (format === 'sql') {


### PR DESCRIPTION
## Description of Changes

<!-- Please provide a description of the change here. -->

I noticed that the timestamp format is different in the new CLI. This PR adds a `legacyTimestamp` option to the commands so users can choose to keep newly generated filenames more consistent with CLI v6.

Locally the tests weren't actually running but I haven't figured out why. Will need to do some debugging to see what I missed