### PR TITLE
fix: set sequelize dialect type in query generator and interface

### DIFF
--- a/packages/core/src/abstract-dialect/dialect.ts
+++ b/packages/core/src/abstract-dialect/dialect.ts
@@ -496,7 +496,7 @@ export abstract class AbstractDialect<
     return merge(cloneDeep(this.supports) ?? {}, supportsOverwrite);
   }
 
-  readonly sequelize: Sequelize;
+  readonly sequelize: Sequelize<this>;
 
   abstract readonly Query: typeof AbstractQuery;
   abstract readonly queryGenerator: AbstractQueryGenerator;
@@ -543,7 +543,7 @@ export abstract class AbstractDialect<
   }
 
   constructor(params: AbstractDialectParams<Options>) {
-    this.sequelize = params.sequelize;
+    this.sequelize = params.sequelize as Sequelize<this>;
     this.name = params.name;
     this.dataTypesDocumentationUrl = params.dataTypesDocumentationUrl;
     this.options = params.options ? getImmutablePojo(params.options) : EMPTY_OBJECT;

--- a/packages/core/src/abstract-dialect/query-generator-typescript.ts
+++ b/packages/core/src/abstract-dialect/query-generator-typescript.ts
@@ -22,7 +22,8 @@ import { IndexHints } from '../index-hints.js';
 import type { ModelDefinition } from '../model-definition.js';
 import type { Attributes, Model, ModelStatic } from '../model.js';
 import { Op } from '../operators.js';
-import type { BindOrReplacements, Expression } from '../sequelize.js';
+import type { BindOrReplacements, Expression, Sequelize } from '../sequelize.js';
+import type { NormalizedOptions } from '../sequelize.types.js';
 import { bestGuessDataTypeOfVal } from '../sql-string.js';
 import { TableHints } from '../table-hints.js';
 import type { IsolationLevel } from '../transaction.js';
@@ -171,12 +172,12 @@ export interface Bindable {
  * This is a temporary class used to progressively migrate the AbstractQueryGenerator class to TypeScript by slowly moving its functions here.
  * Always use {@link AbstractQueryGenerator} instead.
  */
-export class AbstractQueryGeneratorTypeScript {
-  readonly dialect: AbstractDialect;
+export class AbstractQueryGeneratorTypeScript<Dialect extends AbstractDialect = AbstractDialect> {
+  readonly dialect: Dialect;
   readonly #internals: AbstractQueryGeneratorInternal;
 
   constructor(
-    dialect: AbstractDialect,
+    dialect: Dialect,
     internals: AbstractQueryGeneratorInternal = new AbstractQueryGeneratorInternal(dialect),
   ) {
     this.dialect = dialect;
@@ -187,11 +188,11 @@ export class AbstractQueryGeneratorTypeScript {
     return this.#internals.whereSqlBuilder;
   }
 
-  protected get sequelize() {
+  protected get sequelize(): Sequelize<Dialect> {
     return this.dialect.sequelize;
   }
 
-  protected get options() {
+  protected get options(): NormalizedOptions<Dialect> {
     return this.sequelize.options;
   }
 

--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -11,6 +11,7 @@ import type {
   SearchPathable,
 } from '../model.js';
 import type { DataType } from './data-types.js';
+import type { AbstractDialect } from './dialect.js';
 import { AbstractQueryGeneratorTypeScript } from './query-generator-typescript.js';
 import type { AttributeToSqlOptions } from './query-generator.internal-types.js';
 import type { TableOrModel } from './query-generator.types.js';
@@ -80,7 +81,9 @@ export interface AddColumnQueryOptions {
  * The implementation varies between SQL dialects, and is overridden by subclasses. You can access your dialect's version
  * through {@link Sequelize#queryGenerator}.
  */
-export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
+export class AbstractQueryGenerator<
+  Dialect extends AbstractDialect = AbstractDialect,
+> extends AbstractQueryGeneratorTypeScript<Dialect> {
   quoteIdentifiers(identifiers: string): string;
 
   selectQuery<M extends Model>(

--- a/packages/core/src/abstract-dialect/query-interface-typescript.ts
+++ b/packages/core/src/abstract-dialect/query-interface-typescript.ts
@@ -74,7 +74,7 @@ export class AbstractQueryInterfaceTypeScript<Dialect extends AbstractDialect = 
       internalQueryInterface ?? new AbstractQueryInterfaceInternal(dialect);
   }
 
-  get sequelize(): Sequelize {
+  get sequelize(): Sequelize<Dialect> {
     return this.dialect.sequelize;
   }
 

--- a/packages/core/src/sequelize-typescript.ts
+++ b/packages/core/src/sequelize-typescript.ts
@@ -345,7 +345,7 @@ If you really need to access the connection manager, access it through \`sequeli
   }
 
   readonly #models = new Set<ModelStatic>();
-  readonly models = new ModelSetView(this, this.#models);
+  readonly models = new ModelSetView<Dialect>(this, this.#models);
   #isClosed: boolean = false;
   readonly pool: ReplicationPool<Connection<Dialect>, ConnectionOptions<Dialect>>;
 

--- a/packages/db2/src/dialect.ts
+++ b/packages/db2/src/dialect.ts
@@ -119,9 +119,7 @@ export class Db2Dialect extends AbstractDialect<Db2DialectOptions, Db2Connection
   }
 
   getDefaultSchema(): string {
-    return (
-      (this.sequelize as Sequelize<this>).options.replication.write.username?.toUpperCase() ?? ''
-    );
+    return this.sequelize.options.replication.write.username?.toUpperCase() ?? '';
   }
 
   parseConnectionUrl(): Db2ConnectionOptions {

--- a/packages/mariadb/src/dialect.ts
+++ b/packages/mariadb/src/dialect.ts
@@ -150,7 +150,7 @@ export class MariaDbDialect extends AbstractDialect<
   }
 
   getDefaultSchema(): string {
-    return (this.sequelize as Sequelize<MariaDbDialect>).options.replication.write.database ?? '';
+    return this.sequelize.options.replication.write.database ?? '';
   }
 
   parseConnectionUrl(url: string): MariaDbConnectionOptions {

--- a/packages/mysql/src/dialect.ts
+++ b/packages/mysql/src/dialect.ts
@@ -146,7 +146,7 @@ export class MySqlDialect extends AbstractDialect<MySqlDialectOptions, MySqlConn
   }
 
   getDefaultSchema(): string {
-    return (this.sequelize as Sequelize<MySqlDialect>).options.replication.write.database ?? '';
+    return this.sequelize.options.replication.write.database ?? '';
   }
 
   parseConnectionUrl(url: string): MySqlConnectionOptions {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This PR sets the Sequelize dialect type for the `queryGenerator` and `queryInterface`.

Currently the sequelize instance in the `queryGenerator` and `queryInterface` uses the `AbstractDialect` which mean accessing the `sequelize.options` from inside these classes does not return the correct typed values.

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
