### PR TITLE
fix(oracle): bind parameters in random order and/or when used multiple times.

### DIFF
--- a/src/dialects/oracle/query.js
+++ b/src/dialects/oracle/query.js
@@ -126,7 +126,7 @@ export class OracleQuery extends AbstractQuery {
       } else {
         let matcher = new RegExp(/(:)(([^\d])\w+)/gm)
         let result = null;
-        while ( result = matcher.exec(this.sql) ) {
+        while (( result = matcher.exec(this.sql) )) {
           bindParameters.push(parameters[result[2]])
         }        
         bindParameters.push(...outParameters);

--- a/src/dialects/oracle/query.js
+++ b/src/dialects/oracle/query.js
@@ -125,7 +125,7 @@ export class OracleQuery extends AbstractQuery {
         this.bindParameters = parameters;
       } else {
         let matcher = new RegExp(/(:)(([^\d])\w+)/gm)
-        let result;
+        let result = null;
         while ( result = matcher.exec(this.sql) ) {
           bindParameters.push(parameters[result[2]])
         }        

--- a/src/dialects/oracle/query.js
+++ b/src/dialects/oracle/query.js
@@ -125,12 +125,10 @@ export class OracleQuery extends AbstractQuery {
         this.bindParameters = parameters;
       } else {
         let matcher = new RegExp(/(:)(([^\d])\w+)/gm)
+        let result;
         while ( result = matcher.exec(this.sql) ) {
           bindParameters.push(parameters[result[2]])
         }        
-        // Object.values(parameters).forEach(value => {
-        //   bindParameters.push(value);
-        // });
         bindParameters.push(...outParameters);
         Object.assign(this.bindParameters, bindParameters);
       }

--- a/src/dialects/oracle/query.js
+++ b/src/dialects/oracle/query.js
@@ -124,9 +124,13 @@ export class OracleQuery extends AbstractQuery {
       } else if (this.isRawQuery()) {
         this.bindParameters = parameters;
       } else {
-        Object.values(parameters).forEach(value => {
-          bindParameters.push(value);
-        });
+        let matcher = new RegExp(/(:)(([^\d])\w+)/gm)
+        while ( result = matcher.exec(this.sql) ) {
+          bindParameters.push(parameters[result[2]])
+        }        
+        // Object.values(parameters).forEach(value => {
+        //   bindParameters.push(value);
+        // });
         bindParameters.push(...outParameters);
         Object.assign(this.bindParameters, bindParameters);
       }


### PR DESCRIPTION
it fixes the issue #17322  

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?


## Description of Changes

By using regex to identify all parameters in the query starting with ":" and getting value by the parameter name and then pushing it into the bindParameters.

So it preserver the right order as the parameters were added to the query

## List of Breaking Changes

There are no breaking changes
