### PR TITLE
To use connectAsync for authentication to snowflake with Okta. 

### DIFF
--- a/packages/snowflake/src/connection-manager.ts
+++ b/packages/snowflake/src/connection-manager.ts
@@ -120,6 +120,77 @@ export class SnowflakeConnectionManager extends AbstractConnectionManager<
     }
   }
 
+
+  async connectOkta(config: ConnectionOptions<SnowflakeDialect>): Promise<SnowflakeConnection> {
+    try {
+      const connection = this.#lib.createConnection({
+        schema: this.sequelize.options.schema,
+        ...config,
+      }) as SnowflakeConnection;
+
+      await new Promise<void>((resolve, reject) => {
+        connection.connectAsync(err => {
+          if (err) {
+            return void reject(err);
+          }
+
+          resolve();
+        });
+      });
+
+      debug('connection acquired');
+
+      if (!this.sequelize.options.keepDefaultTimezone) {
+        // TODO: remove default timezone.
+        // default value is '+00:00', put a quick workaround for it.
+        const tzOffset =
+          this.sequelize.options.timezone === '+00:00'
+            ? 'Etc/UTC'
+            : this.sequelize.options.timezone;
+        const isNamedTzOffset = tzOffset.includes('/');
+        if (!isNamedTzOffset) {
+          throw new Error(
+            'Snowflake only supports named timezones for the sequelize "timezone" option.',
+          );
+        }
+
+        await new Promise<void>((resolve, reject) => {
+          connection.execute({
+            sqlText: `ALTER SESSION SET timezone = '${tzOffset}'`,
+            complete(err) {
+              if (err) {
+                return void reject(err);
+              }
+
+              resolve();
+            },
+          });
+        });
+      }
+
+      return connection;
+    } catch (error) {
+      if (!isErrorWithStringCode(error)) {
+        throw error;
+      }
+
+      switch (error.code) {
+        case 'ECONNREFUSED':
+          throw new ConnectionRefusedError(error);
+        case 'ER_ACCESS_DENIED_ERROR':
+          throw new AccessDeniedError(error);
+        case 'ENOTFOUND':
+          throw new HostNotFoundError(error);
+        case 'EHOSTUNREACH':
+          throw new HostNotReachableError(error);
+        case 'EINVAL':
+          throw new InvalidConnectionError(error);
+        default:
+          throw new ConnectionError(error);
+      }
+    }
+  }
+
   async disconnect(connection: SnowflakeConnection): Promise<void> {
     // Don't disconnect connections with CLOSED state
     if (!connection.isUp()) {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->
- Add in a check if authenticator is passed in the config, use connectAsync instead of connect to create the connection. 

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
