### PR TITLE
fix(core): allow users to specify `createdAt` in `updateOnDuplicate`

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2349,7 +2349,7 @@ ${associationOwner._getAssociationDebugList()}`);
       if (options.updateOnDuplicate !== undefined) {
         if (Array.isArray(options.updateOnDuplicate) && options.updateOnDuplicate.length > 0) {
           options.updateOnDuplicate = intersection(
-            without(Object.keys(model.tableAttributes), createdAtAttr),
+            Object.keys(model.tableAttributes),
             options.updateOnDuplicate,
           );
         } else {


### PR DESCRIPTION
Fixes issue #17347

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

Allows to provide `updateAt` field in `updateOnDuplicate` option to enable updating the `createdAt` timestamp on duplicate. In older versions (<2018) it was possible to provide a boolean to enable all fields to be updated on duplicate, however this behavior is not supported anymore and users need to explicitly provide a list of field names allowing finer grained control over what's updated. The explicit exclusion of `createdAt` is thus no longer necessary and simply a remainder of the old, removed functionality.

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
