### PR TITLE
fix(mssql): add ability to use instanceName in connection-manager config

### DIFF
--- a/dev/mssql/latest/docker-compose.yml
+++ b/dev/mssql/latest/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       test:
         [
           'CMD',
-          '/opt/mssql-tools/bin/sqlcmd',
+          '/opt/mssql-tools18/bin/sqlcmd',
+          '-C',
           '-S',
           'localhost',
           '-U',

--- a/dev/mssql/latest/start.sh
+++ b/dev/mssql/latest/start.sh
@@ -8,6 +8,6 @@ docker compose -p sequelize-mssql-latest up -d
 ./../../wait-until-healthy.sh sequelize-mssql-latest
 
 docker exec sequelize-mssql-latest \
-  /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
+  /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
 
 DIALECT=mssql ts-node ../../check-connection.ts

--- a/dev/wait-until-healthy.sh
+++ b/dev/wait-until-healthy.sh
@@ -8,6 +8,14 @@ fi
 for _ in {1..50}
 do
   state=$(docker inspect -f '{{ .State.Health.Status }}' $1 2>&1)
+  echo -ne "$state.\r"
+  sleep 1
+  echo -ne "$state..\r"
+  sleep 1
+  echo -ne "$state...\r"
+  sleep 1
+  echo -ne '\033[K'
+
   return_code=$?
   if [ ${return_code} -eq 0 ] && [ "$state" == "healthy" ]; then
     echo "$1 is healthy!"

--- a/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
+++ b/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
@@ -94,7 +94,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
     await instance.dialect.connectionManager.connect(config);
     expect(connectStub.called).to.equal(true);
   });
-  
+
   it('connectionManager.connect() should not fail with instanceName but no port specified', async () => {
     const connectStub = sinon.stub();
     Connection = {
@@ -140,7 +140,8 @@ describe('[MSSQL Specific] Connection Manager', () => {
     assert(error instanceof ConnectionError);
     expect(error.name).to.equal('SequelizeConnectionError');
     assert(error.cause instanceof Error);
-    expect(error.cause.message).to.equal('Port and instanceName are mutually exclusive, but 2433 and INSTANCENAME provided');
+    expect(error.cause.message).to.equal(
+      'Port and instanceName are mutually exclusive, but 2433 and INSTANCENAME provided',
+    );
   });
-
 });

--- a/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
+++ b/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
@@ -95,7 +95,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
     expect(connectStub.called).to.equal(true);
   });
 
-  it('connectionManager.connect() should not fail with instanceName but no port specified', async () => {
+  it('connectionManager.connect() should not fail with an instanceName but no port specified', async () => {
     const connectStub = sinon.stub();
     Connection = {
       STATE: TediousConnection.prototype.STATE,

--- a/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
+++ b/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
@@ -95,7 +95,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
     expect(connectStub.called).to.equal(true);
   });
 
-  it('connectionManager.connect() should not fail with an instanceName but no port specified', async () => {
+  it('connectionManager.connect() should not fail with an instanceName but no port specified in config', async () => {
     const connectStub = sinon.stub();
     Connection = {
       STATE: TediousConnection.prototype.STATE,

--- a/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
+++ b/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
@@ -99,9 +99,10 @@ describe('[MSSQL Specific] Connection Manager', () => {
     const connectStub = sinon.stub();
     Connection = {
       STATE: TediousConnection.prototype.STATE,
-      state: undefined,
+      state: TediousConnection.prototype.STATE.INITIALIZED,
+      connect: connectStub,
       once(event, cb) {
-        if (event === 'end') {
+        if (event === 'connect') {
           setTimeout(() => {
             cb();
           }, 500);
@@ -115,33 +116,5 @@ describe('[MSSQL Specific] Connection Manager', () => {
 
     await instance.dialect.connectionManager.connect(config);
     expect(connectStub.called).to.equal(true);
-  });
-
-  it('connectionManager.connect() should fail with instanceName and port specified', async () => {
-    Connection = {
-      STATE: TediousConnection.prototype.STATE,
-      state: undefined,
-      once(event, cb) {
-        if (event === 'end') {
-          setTimeout(() => {
-            cb();
-          }, 500);
-        }
-      },
-      removeListener: () => {},
-      on: () => {},
-    };
-
-    config.instanceName = 'INSTANCENAME';
-    config.port = 2433;
-
-    const error = await expect(instance.dialect.connectionManager.connect(config)).to.be.rejected;
-
-    assert(error instanceof ConnectionError);
-    expect(error.name).to.equal('SequelizeConnectionError');
-    assert(error.cause instanceof Error);
-    expect(error.cause.message).to.equal(
-      'Port and instanceName are mutually exclusive, but 2433 and INSTANCENAME provided',
-    );
   });
 });

--- a/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
+++ b/packages/core/test/unit/dialects/mssql/connection-manager.test.ts
@@ -94,4 +94,53 @@ describe('[MSSQL Specific] Connection Manager', () => {
     await instance.dialect.connectionManager.connect(config);
     expect(connectStub.called).to.equal(true);
   });
+  
+  it('connectionManager.connect() should not fail with instanceName but no port specified', async () => {
+    const connectStub = sinon.stub();
+    Connection = {
+      STATE: TediousConnection.prototype.STATE,
+      state: undefined,
+      once(event, cb) {
+        if (event === 'end') {
+          setTimeout(() => {
+            cb();
+          }, 500);
+        }
+      },
+      removeListener: () => {},
+      on: () => {},
+    };
+
+    config.instanceName = 'INSTANCENAME';
+
+    await instance.dialect.connectionManager.connect(config);
+    expect(connectStub.called).to.equal(true);
+  });
+
+  it('connectionManager.connect() should fail with instanceName and port specified', async () => {
+    Connection = {
+      STATE: TediousConnection.prototype.STATE,
+      state: undefined,
+      once(event, cb) {
+        if (event === 'end') {
+          setTimeout(() => {
+            cb();
+          }, 500);
+        }
+      },
+      removeListener: () => {},
+      on: () => {},
+    };
+
+    config.instanceName = 'INSTANCENAME';
+    config.port = 2433;
+
+    const error = await expect(instance.dialect.connectionManager.connect(config)).to.be.rejected;
+
+    assert(error instanceof ConnectionError);
+    expect(error.name).to.equal('SequelizeConnectionError');
+    assert(error.cause instanceof Error);
+    expect(error.cause.message).to.equal('Port and instanceName are mutually exclusive, but 2433 and INSTANCENAME provided');
+  });
+
 });

--- a/packages/mssql/src/connection-manager.ts
+++ b/packages/mssql/src/connection-manager.ts
@@ -52,10 +52,6 @@ export class MsSqlConnectionManager extends AbstractConnectionManager<
       options: removeUndefined(inlinedOptions),
     };
 
-    if (!tediousConfig.options!.port) {
-      tediousConfig.options!.port = 1433;
-    }
-
     try {
       return await new Promise((resolve, reject) => {
         const connection: MsSqlConnection = new this.#lib.Connection(


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ x ] Have you added new tests to prevent regressions?
- [ x ] Did you update the typescript typings accordingly (if applicable)?
- [ x ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ x ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Remove the hardcoded default port as this throws an error when specified with `instanceName` and doesn't throw an error when it's excluded as 1433 is the default port
