### PR TITLE
fix: handle null values returned by union all, when running includes …

### DIFF
--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -321,7 +321,7 @@ export class HasManyAssociation<
 
     for (const instance of results) {
       const value = instance.get(this.foreignKey, { raw: true });
-      result.get(value)!.push(instance);
+      result.get(value)?.push(instance);
     }
 
     return result;


### PR DESCRIPTION
Handle null values returned by union all, when running includes separately

fixes: #17476

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->
fixes: #17476

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
None
