### PR TITLE
fix(mariadb): fix inefficient regular expression in error message

### DIFF
--- a/packages/mariadb/src/query.js
+++ b/packages/mariadb/src/query.js
@@ -215,7 +215,7 @@ export class MariaDbQuery extends AbstractQuery {
   formatError(err) {
     switch (err.errno) {
       case ER_DUP_ENTRY: {
-        const match = err.message.match(/Duplicate entry '([\S\s]*)' for key '?((.|\s)*?)'?\s.*$/);
+        const match = err.message.match(/Duplicate entry '([\S\s]*)' for key '?([^']*?)'?\s.*$/);
 
         let fields = {};
         let message = 'Validation error';


### PR DESCRIPTION
Fixes [https://github.com/sequelize/sequelize/security/code-scanning/75](https://github.com/sequelize/sequelize/security/code-scanning/75)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
