### PR TITLE
fix(oracle): validate input with TO_TIMESTAMP_TZ and TO_DATE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         ports:
           - 1433:1433
         options: >-
-          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P \"Password12!\" -l 30 -Q \"SELECT 1\""
+          --health-cmd="/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P \"Password12!\" -l 30 -Q \"SELECT 1\""
           --health-start-period 10s
           --health-interval 10s
           --health-timeout 5s
@@ -265,7 +265,7 @@ jobs:
       SEQ_PW: Password12!
       SEQ_PORT: 1433
     steps:
-      - run: /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
+      - run: /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         ports:
           - 1433:1433
         options: >-
-          --health-cmd="/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P \"Password12!\" -l 30 -Q \"SELECT 1\""
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P \"Password12!\" -l 30 -Q \"SELECT 1\""
           --health-start-period 10s
           --health-interval 10s
           --health-timeout 5s
@@ -265,7 +265,7 @@ jobs:
       SEQ_PW: Password12!
       SEQ_PORT: 1433
     steps:
-      - run: /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
+      - run: /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
         node-version: [10, 18]
         mssql-version: [2017, 2019]
     name: MSSQL ${{ matrix.mssql-version }} (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:${{ matrix.mssql-version }}-latest

--- a/dev/mariadb/10.3/start.sh
+++ b/dev/mariadb/10.3/start.sh
@@ -3,8 +3,8 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mariadb-103 down --remove-orphans
-docker-compose -p sequelize-mariadb-103 up -d
+docker compose -p sequelize-mariadb-103 down --remove-orphans
+docker compose -p sequelize-mariadb-103 up -d
 
 ./../../wait-until-healthy.sh sequelize-mariadb-103
 

--- a/dev/mariadb/10.3/stop.sh
+++ b/dev/mariadb/10.3/stop.sh
@@ -3,6 +3,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mariadb-103 down --remove-orphans
+docker compose -p sequelize-mariadb-103 down --remove-orphans
 
 echo "Local MariaDB-10.3 instance stopped (if it was running)."

--- a/dev/mssql/2019/docker-compose.yml
+++ b/dev/mssql/2019/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 22019:1433
     healthcheck:
-      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "localhost", "-U", "SA", "-P", "Password12!", "-l", "30", "-Q", "SELECT 1"]
+      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "SA", "-P", "Password12!", "-l", "30", "-Q", "SELECT 1"]
       interval: 3s
       timeout: 1s
       retries: 10

--- a/dev/mssql/2019/docker-compose.yml
+++ b/dev/mssql/2019/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 22019:1433
     healthcheck:
-      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "SA", "-P", "Password12!", "-l", "30", "-Q", "SELECT 1"]
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "localhost", "-U", "SA", "-P", "Password12!", "-l", "30", "-Q", "SELECT 1"]
       interval: 3s
       timeout: 1s
       retries: 10

--- a/dev/mssql/2019/start.sh
+++ b/dev/mssql/2019/start.sh
@@ -3,8 +3,8 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mssql-2019 down --remove-orphans
-docker-compose -p sequelize-mssql-2019 up -d
+docker compose -p sequelize-mssql-2019 down --remove-orphans
+docker compose -p sequelize-mssql-2019 up -d
 
 ./../../wait-until-healthy.sh sequelize-mssql-2019
 

--- a/dev/mssql/2019/start.sh
+++ b/dev/mssql/2019/start.sh
@@ -9,7 +9,7 @@ docker compose -p sequelize-mssql-2019 up -d
 ./../../wait-until-healthy.sh sequelize-mssql-2019
 
 docker exec sequelize-mssql-2019 \
-  /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
+  /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
 
 DIALECT=mssql node check.js
 

--- a/dev/mssql/2019/start.sh
+++ b/dev/mssql/2019/start.sh
@@ -9,7 +9,7 @@ docker compose -p sequelize-mssql-2019 up -d
 ./../../wait-until-healthy.sh sequelize-mssql-2019
 
 docker exec sequelize-mssql-2019 \
-  /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
+  /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P "Password12!" -Q "CREATE DATABASE sequelize_test; ALTER DATABASE sequelize_test SET READ_COMMITTED_SNAPSHOT ON;"
 
 DIALECT=mssql node check.js
 

--- a/dev/mssql/2019/stop.sh
+++ b/dev/mssql/2019/stop.sh
@@ -3,6 +3,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mssql-2019 down --remove-orphans
+docker compose -p sequelize-mssql-2019 down --remove-orphans
 
 echo "Local MSSQL-2019 instance stopped (if it was running)."

--- a/dev/mysql/5.7/start.sh
+++ b/dev/mysql/5.7/start.sh
@@ -3,8 +3,8 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mysql-57 down --remove-orphans
-docker-compose -p sequelize-mysql-57 up -d
+docker compose -p sequelize-mysql-57 down --remove-orphans
+docker compose -p sequelize-mysql-57 up -d
 
 ./../../wait-until-healthy.sh sequelize-mysql-57
 

--- a/dev/mysql/5.7/stop.sh
+++ b/dev/mysql/5.7/stop.sh
@@ -3,6 +3,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mysql-57 down --remove-orphans
+docker compose -p sequelize-mysql-57 down --remove-orphans
 
 echo "Local MySQL-5.7 instance stopped (if it was running)."

--- a/dev/mysql/8.0/start.sh
+++ b/dev/mysql/8.0/start.sh
@@ -3,8 +3,8 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mysql-80 down --remove-orphans
-docker-compose -p sequelize-mysql-80 up -d
+docker compose -p sequelize-mysql-80 down --remove-orphans
+docker compose -p sequelize-mysql-80 up -d
 
 ./../../wait-until-healthy.sh sequelize-mysql-80
 

--- a/dev/mysql/8.0/stop.sh
+++ b/dev/mysql/8.0/stop.sh
@@ -3,6 +3,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-mysql-80 down --remove-orphans
+docker compose -p sequelize-mysql-80 down --remove-orphans
 
 echo "Local MySQL-8.0 instance stopped (if it was running)."

--- a/dev/oracle/18-slim/start.sh
+++ b/dev/oracle/18-slim/start.sh
@@ -5,10 +5,10 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 # Remove an existing Oracle DB docker image
-docker-compose -p oraclexedb down --remove-orphans
+docker compose -p oraclexedb down --remove-orphans
 
 # Bring up new Oracle DB docker image
-docker-compose -p oraclexedb up -d
+docker compose -p oraclexedb up -d
 
 # Wait until Oracle DB is set up and docker state is healthy
 ./../wait-until-healthy.sh oraclexedb

--- a/dev/oracle/18-slim/stop.sh
+++ b/dev/oracle/18-slim/stop.sh
@@ -5,6 +5,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p oraclexedb down --remove-orphans
+docker compose -p oraclexedb down --remove-orphans
 
 echo "Local Oracle DB instance stopped (if it was running)."

--- a/dev/oracle/23-slim/start.sh
+++ b/dev/oracle/23-slim/start.sh
@@ -5,10 +5,10 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 # Remove an existing Oracle DB docker image
-docker-compose -p oraclexedb down --remove-orphans
+docker compose -p oraclexedb down --remove-orphans
 
 # Bring up new Oracle DB docker image
-docker-compose -p oraclexedb up -d
+docker compose -p oraclexedb up -d
 
 # Wait until Oracle DB is set up and docker state is healthy
 ./../wait-until-healthy.sh oraclexedb

--- a/dev/oracle/23-slim/stop.sh
+++ b/dev/oracle/23-slim/stop.sh
@@ -5,6 +5,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p oraclexedb down --remove-orphans
+docker compose -p oraclexedb down --remove-orphans
 
 echo "Local Oracle DB instance stopped (if it was running)."

--- a/dev/postgres/10/start.sh
+++ b/dev/postgres/10/start.sh
@@ -3,8 +3,8 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-postgres-10 down --remove-orphans
-docker-compose -p sequelize-postgres-10 up -d
+docker compose -p sequelize-postgres-10 down --remove-orphans
+docker compose -p sequelize-postgres-10 up -d
 
 ./../../wait-until-healthy.sh sequelize-postgres-10
 

--- a/dev/postgres/10/stop.sh
+++ b/dev/postgres/10/stop.sh
@@ -3,6 +3,6 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 
-docker-compose -p sequelize-postgres-10 down --remove-orphans
+docker compose -p sequelize-postgres-10 down --remove-orphans
 
 echo "Local Postgres-10 instance stopped (if it was running)."

--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -128,7 +128,7 @@ class ConnectionManager extends AbstractConnectionManager {
           'options',
           // The stream acts as a user-defined socket factory for postgres. In particular, it enables IAM autentication
           // with Google Cloud SQL. see: https://github.com/sequelize/sequelize/issues/16001#issuecomment-1561136388
-          'stream',
+          'stream'
         ]));
     }
 

--- a/src/sql-string.js
+++ b/src/sql-string.js
@@ -78,50 +78,65 @@ function escape(val, timeZone, dialect, format) {
     }
   } else if (dialect === 'oracle' && typeof val === 'string') {
     if (val.startsWith('TO_TIMESTAMP_TZ') || val.startsWith('TO_DATE')) {
+      // Split the string using parentheses to isolate the function name, parameters, and potential extra parts
       const splitVal = val.split(/\(|\)/);
     
+      // Validate that the split result has exactly three parts (function name, parameters, and an empty string)
+      // and that there are no additional SQL commands after the function call (indicated by the last empty string).
       if (splitVal.length !== 3 || splitVal[2] !== '') {
-        throw new Error('Invalid SQL function call.');
+        throw new Error('Invalid SQL function call.'); // Error if function call has unexpected format
       }
     
-      const functionName = splitVal[0].trim();
-      const insideParens = splitVal[1].trim();
+      // Extract the function name (either 'TO_TIMESTAMP_TZ' or 'TO_DATE') and the contents inside the parentheses
+      const functionName = splitVal[0].trim(); // Function name should be 'TO_TIMESTAMP_TZ' or 'TO_DATE'
+      const insideParens = splitVal[1].trim(); // This contains the parameters (date value and format string)
     
       if (functionName !== 'TO_TIMESTAMP_TZ' && functionName !== 'TO_DATE') {
         throw new Error('Invalid SQL function call. Expected TO_TIMESTAMP_TZ or TO_DATE.');
       }
     
+      // Split the parameters inside the parentheses by commas (should contain exactly two: date and format)
       const params = insideParens.split(',');
     
-      if (params.length < 2) {
-        throw new Error('Invalid format for TO_TIMESTAMP_TZ or TO_DATE');
+      // Validate that the parameters contain exactly two parts (date value and format string)
+      if (params.length !== 2) {
+        throw new Error('Unexpected input received.\nSequelize supports TO_TIMESTAMP_TZ or TO_DATE exclusively with a combination of value and format.');
       }
     
+      // Extract the date value (first parameter) and remove single quotes around it
       const dateValue = params[0].trim().replace(/'/g, '');
       const formatValue = params[1].trim();
     
       if (functionName === 'TO_TIMESTAMP_TZ') {
         const expectedFormat = "'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM'";
+        // Validate that the formatValue is equal to expectedFormat since that is the only format used within sequelize
         if (formatValue !== expectedFormat) {
-          throw new Error(`Invalid format string for TO_TIMESTAMP_TZ. Expected format: ${ expectedFormat}`);
+          throw new Error(`Invalid format string for TO_TIMESTAMP_TZ. Expected format: ${expectedFormat}`);
         }
-    
+      
+        // Validate the date value using Moment.js with the expected format
         const formattedDate = moment(dateValue).format('YYYY-MM-DD HH:mm:ss.SSS Z');
+      
+        // If the formatted date doesn't match the input date value, throw an error
         if (formattedDate !== dateValue) {
           throw new Error("Invalid date value for TO_TIMESTAMP_TZ. Expected format: 'YYYY-MM-DD HH:mm:ss.SSS Z'");
         }
       } else if (functionName === 'TO_DATE') {
         const expectedFormat = "'YYYY/MM/DD'";
+        // Validate that the formatValue is equal to expectedFormat since that is the only format used within sequelize
         if (formatValue !== expectedFormat) {
-          throw new Error(`Invalid format string for TO_DATE. Expected format: ${ expectedFormat}`);
+          throw new Error(`Invalid format string for TO_DATE. Expected format: ${expectedFormat}`);
         }
-    
+      
+        // Validate the date value using Moment.js with the expected format
         const formattedDate = moment(dateValue).format('YYYY-MM-DD');
+      
+        // If the formatted date doesn't match the input date value, throw an error
         if (formattedDate !== dateValue) {
           throw new Error("Invalid date value for TO_DATE. Expected format: 'YYYY-MM-DD'");
         }
       }
-    
+
       return val;
     }
     

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -67,6 +67,15 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     });
 
     testsql({
+      name: 'TO_DATE(\'0\',\'Y\')||\'\' OR 1=1--'
+    }, {
+      default: 'WHERE [name] = \'TO_DATE(\'\'0\'\',\'\'Y\'\')||\'\'\'\' OR 1=1--\'',
+      'mariadb mysql': "WHERE `name` = 'TO_DATE(\\'0\\',\\'Y\\')||\\'\\' OR 1=1--'",
+      mssql: 'WHERE [name] = N\'TO_DATE(\'\'0\'\',\'\'Y\'\')||\'\'\'\' OR 1=1--\'',
+      oracle: new Error('Invalid SQL function call.')
+    });
+
+    testsql({
       name: 'a project',
       [Op.or]: [
         { id: [1, 2, 3] },


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Description of Changes

<!-- Please provide a description of the change here. -->

This adds input validation as a workaround to prevent SQL injection using `TO_TIMESTAMP` or `TO_DATE`. It's not pretty, but it should do the trick while we fix it properly in v7 where the internals should be more suitable. This fix is the least intrusive.
