### PR TITLE
feat: respect position of inherited attributes

### DIFF
--- a/packages/core/src/decorators/legacy/attribute.ts
+++ b/packages/core/src/decorators/legacy/attribute.ts
@@ -10,7 +10,7 @@ import {
 } from './attribute-utils.js';
 import type { PropertyOrGetterDescriptor } from './decorator-utils.js';
 
-export interface InheritedAttributeOptions extends Partial<AttributeOptions> {
+export type InheritedAttributeOptions = Partial<AttributeOptions> & {
   /**
    * If true, the attribute will be inserted before the descendant's attributes.
    */
@@ -20,7 +20,7 @@ export interface InheritedAttributeOptions extends Partial<AttributeOptions> {
    * This is the default behavior.
    */
   insertAfter?: boolean;
-}
+};
 
 type AttributeDecoratorOption = DataType | InheritedAttributeOptions;
 

--- a/packages/core/src/decorators/legacy/attribute.ts
+++ b/packages/core/src/decorators/legacy/attribute.ts
@@ -10,7 +10,19 @@ import {
 } from './attribute-utils.js';
 import type { PropertyOrGetterDescriptor } from './decorator-utils.js';
 
-type AttributeDecoratorOption = DataType | Partial<AttributeOptions>;
+export interface InheritedAttributeOptions extends Partial<AttributeOptions> {
+  /**
+   * If true, the attribute will be inserted before the descendant's attributes.
+   */
+  insertBefore?: boolean;
+  /**
+   * If true, the attribute will be inserted after the descendant's attributes.
+   * This is the default behavior.
+   */
+  insertAfter?: boolean;
+}
+
+type AttributeDecoratorOption = DataType | InheritedAttributeOptions;
 
 /**
  * The `@Attribute` decorator is used to add an attribute to a model. It is used on an instance property.
@@ -43,6 +55,12 @@ export const Attribute = createRequiredAttributeOptionsDecorator<AttributeDecora
       return {
         type: attrOptionOrDataType,
       };
+    }
+
+    if (attrOptionOrDataType.insertBefore && attrOptionOrDataType.insertAfter) {
+      throw new Error(
+        `Cannot set both 'insertBefore' and 'insertAfter' to true on the same attribute`,
+      );
     }
 
     return attrOptionOrDataType;

--- a/packages/core/src/decorators/shared/model.ts
+++ b/packages/core/src/decorators/shared/model.ts
@@ -7,6 +7,7 @@ import type { AttributeOptions, ModelAttributes, ModelOptions, ModelStatic } fro
 import type { Sequelize } from '../../sequelize.js';
 import { isModelStatic } from '../../utils/model-utils.js';
 import { cloneDeep, getAllOwnEntries } from '../../utils/object.js';
+import type { InheritedAttributeOptions } from '../legacy/attribute.js';
 
 export interface RegisteredModelOptions extends ModelOptions {
   /**
@@ -17,7 +18,7 @@ export interface RegisteredModelOptions extends ModelOptions {
 }
 
 export interface RegisteredAttributeOptions {
-  [key: string]: Partial<AttributeOptions>;
+  [key: string]: InheritedAttributeOptions;
 }
 
 interface RegisteredOptions {
@@ -199,17 +200,23 @@ function getRegisteredModelOptions(model: ModelStatic): ModelOptions {
 }
 
 function getRegisteredAttributeOptions(model: ModelStatic): RegisteredAttributeOptions {
-  const descendantAttributes = {
-    ...(registeredOptions.get(model)?.attributes ?? (EMPTY_OBJECT as RegisteredAttributeOptions)),
+  const descendantAttributes: RegisteredAttributeOptions = {
+    ...(registeredOptions.get(model)?.attributes ?? EMPTY_OBJECT),
   };
+  const insertAfterAttributes: RegisteredAttributeOptions = {};
+  const insertBeforeAttributes: RegisteredAttributeOptions = {};
 
   const parentModel = Object.getPrototypeOf(model);
   if (isModelStatic(parentModel)) {
     const parentAttributes: RegisteredAttributeOptions = getRegisteredAttributeOptions(parentModel);
 
     for (const attributeName of Object.keys(parentAttributes)) {
-      const descendantAttribute = descendantAttributes[attributeName];
       const parentAttribute = { ...parentAttributes[attributeName] };
+      if (parentAttribute.insertBefore && parentAttribute.insertAfter) {
+        throw new Error(
+          `Attribute ${attributeName} on model ${model.name} cannot have both 'insertBefore' and 'insertAfter' set to true.`,
+        );
+      }
 
       if (parentAttribute.type) {
         if (typeof parentAttribute.type === 'function') {
@@ -225,9 +232,8 @@ function getRegisteredAttributeOptions(model: ModelStatic): RegisteredAttributeO
       parentAttribute.references = cloneDeep(parentAttribute.references);
       parentAttribute.validate = cloneDeep(parentAttribute.validate);
 
-      if (!descendantAttribute) {
-        descendantAttributes[attributeName] = parentAttribute;
-      } else {
+      const descendantAttribute = descendantAttributes[attributeName];
+      if (descendantAttribute) {
         descendantAttributes[attributeName] = mergeAttributeOptions(
           attributeName,
           model,
@@ -235,11 +241,19 @@ function getRegisteredAttributeOptions(model: ModelStatic): RegisteredAttributeO
           descendantAttribute,
           true,
         );
+      } else if (parentAttribute.insertBefore) {
+        insertBeforeAttributes[attributeName] = parentAttribute;
+      } else {
+        insertAfterAttributes[attributeName] = parentAttribute;
       }
     }
   }
 
-  return descendantAttributes;
+  return {
+    ...insertBeforeAttributes,
+    ...descendantAttributes,
+    ...insertAfterAttributes,
+  };
 }
 
 export function isDecoratedModel(model: ModelStatic): boolean {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Adds the ability to specify the position of inherited attributes in models.

The current behaviour is that all inherited attributes are added after the models' own attributes.
With this PR, you can now choose to use this behaviour or specify for the inherited attributes to appear before the models' own attributes.