### PR TITLE
meta(mssql): use ubuntu-20.04 for tests on 2017

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
       matrix:
         node-version: [18, 20]
         database-version: [oldest, latest]
-        dialect: [mysql, mariadb, mssql, db2]
+        dialect: [mysql, mariadb, db2]
     name: ${{ matrix.dialect }} ${{ matrix.database-version }} (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: [unit-test, test-typings]
@@ -253,10 +253,58 @@ jobs:
       - run: yarn start-${{ matrix.dialect }}-${{ matrix.database-version }}
       - name: Integration Tests
         run: yarn lerna run test-integration --scope=@sequelize/core
+  test-mssql-latest:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20]
+    name: mssql latest (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    needs: [unit-test, test-typings]
+    env:
+      DIALECT: mssql
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: install-build-artifact-node-${{ matrix.node-version }}
+      - name: Extract artifact
+        run: tar -xf install-build-node-${{ matrix.node-version }}.tar
+      - run: yarn start-mssql-latest
+      - name: Integration Tests
+        run: yarn lerna run test-integration --scope=@sequelize/core
+  test-mssql-oldest:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20]
+    name: mssql oldest (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-20.04
+    needs: [unit-test, test-typings]
+    env:
+      DIALECT: mssql
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: install-build-artifact-node-${{ matrix.node-version }}
+      - name: Extract artifact
+        run: tar -xf install-build-node-${{ matrix.node-version }}.tar
+      - run: yarn start-mssql-oldest
+      - name: Integration Tests
+        run: yarn lerna run test-integration --scope=@sequelize/core
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [docs, test-sqlite3, test-postgres, test-oldest-latest]
+    needs: [docs, test-sqlite3, test-postgres, test-oldest-latest, test-mssql-latest, test-mssql-oldest]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     env:
       NPM_TOKEN: '${{ secrets.NPM_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [docs, test-sqlite3, test-postgres, test-oldest-latest, test-mssql-latest, test-mssql-oldest]
+    needs:
+      [docs, test-sqlite3, test-postgres, test-oldest-latest, test-mssql-latest, test-mssql-oldest]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     env:
       NPM_TOKEN: '${{ secrets.NPM_TOKEN }}'


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

As per https://github.com/actions/runner-images/issues/10649, ubuntu server 24.04 does not support running MSSQL 2017
