### PR TITLE
meta: remove alpha tag from core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -116,8 +116,7 @@
     "db"
   ],
   "publishConfig": {
-    "access": "public",
-    "tag": "alpha"
+    "access": "public"
   },
   "scripts": {
     "----------------------------------------- static analysis -----------------------------------------": "",


### PR DESCRIPTION
## Description of Changes

<!-- Please provide a description of the change here. -->

This makes sure that the new alpha versions are published on the latest tag and used by people. This is similar to how we publish the other packages (like the dialect ones)

