### PR TITLE
fix(mssql): update mssql to v18.6.1

### DIFF
--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -41,7 +41,7 @@
     "@sequelize/utils": "workspace:*",
     "dayjs": "^1.11.10",
     "lodash": "^4.17.21",
-    "tedious": "^18.1.0"
+    "tedious": "^18.6.1"
   },
   "devDependencies": {
     "@types/chai": "4.3.19",

--- a/packages/mssql/src/_internal/connection-options.ts
+++ b/packages/mssql/src/_internal/connection-options.ts
@@ -80,7 +80,6 @@ export const STRING_CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<StringConn
   server: undefined,
   serverName: undefined,
   tdsVersion: undefined,
-  textsize: undefined,
   workstationId: undefined,
 });
 
@@ -118,4 +117,5 @@ export const NUMBER_CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<NumberConn
   packetSize: undefined,
   port: undefined,
   requestTimeout: undefined,
+  textsize: undefined,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,14 +1193,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.4.0, @azure/core-auth@npm:^1.5.0":
-  version: 1.7.1
-  resolution: "@azure/core-auth@npm:1.7.1"
+"@azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.4.0, @azure/core-auth@npm:^1.5.0, @azure/core-auth@npm:^1.7.2":
+  version: 1.8.0
+  resolution: "@azure/core-auth@npm:1.8.0"
   dependencies:
     "@azure/abort-controller": "npm:^2.0.0"
     "@azure/core-util": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/34ea323097174495cd4cfc291cc39de7af53523a7fbc31b6fd3468c8dd47aa214734b4ddb540c70da8d693fc57629ed52337b5d770a940a97e9edb18f3d285a7
+  checksum: 10c0/db9d78da0ae9c43258bc735c7eeda598370559c0d0146293cdfc096191712ee6e0fcc1b1da105bd095df0d034603eead949a8598b2209880a14bad822a5f81d2
   languageName: node
   linkType: hard
 
@@ -3172,7 +3172,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     mocha: "npm:10.7.3"
     sinon: "npm:18.0.1"
-    tedious: "npm:^18.1.0"
+    tedious: "npm:^18.6.1"
   languageName: unknown
   linkType: soft
 
@@ -14842,10 +14842,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tedious@npm:^18.1.0":
-  version: 18.2.1
-  resolution: "tedious@npm:18.2.1"
+"tedious@npm:^18.6.1":
+  version: 18.6.2
+  resolution: "tedious@npm:18.6.2"
   dependencies:
+    "@azure/core-auth": "npm:^1.7.2"
     "@azure/identity": "npm:^4.2.1"
     "@azure/keyvault-keys": "npm:^4.4.0"
     "@js-joda/core": "npm:^5.6.1"
@@ -14855,7 +14856,7 @@ __metadata:
     js-md4: "npm:^0.3.2"
     native-duplexpair: "npm:^1.0.0"
     sprintf-js: "npm:^1.1.3"
-  checksum: 10c0/80c4f71bbf5c8c15df2405ff0c0d301e8780f476090e3e317422ed3c844d00613c4a40c98f8bff04f1c07afe0d9341de075fe20d51d7e5174b4221177e29097d
+  checksum: 10c0/db0bdc2ed8ad1b11e6382d9530c924a890d0c05bd1cb8055ba8eed69317db050006666b8e5079a92c3041ed8fa2ed57d2b50c501cf5793d1433e7a9df6878835
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Fixes the build error for MSSQL in #17267

## List of Breaking Changes

MSSQL `textsize` connection option accepts number not string.
