### PR TITLE
fix: cast numbers in DataTypes.STRING to strings

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1104,6 +1104,12 @@ class QueryGenerator {
         return this.handleSequelizeMethod(value);
       }
       if (field && field.type) {
+        if (field.type instanceof DataTypes.STRING
+            && ['mysql', 'mariadb'].includes(this.dialect)
+            && ['number', 'boolean'].includes(typeof value)) {
+          value = String(Number(value));
+        }
+              
         this.validate(value, field, options);
 
         if (field.type.stringify) {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Description of Changes

<!-- Please provide a description of the change here. -->

In MySQL strings can equal 0 so this protects against a type casting attack.
