### PR TITLE
fix(postgres): correct existing enum type matching

### DIFF
--- a/packages/core/test/integration/query-interface/createTable.test.js
+++ b/packages/core/test/integration/query-interface/createTable.test.js
@@ -182,6 +182,31 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           expect(table.someEnum.comment).to.equal('special enum col');
         }
       });
+
+      it('should work with multiple enums', async function () {
+        await this.queryInterface.createTable('SomeTable', {
+          someEnum: DataTypes.ENUM('value1', 'value2', 'value3'),
+        });
+
+        // Drop the table, this will leave the enum type behind
+        await this.queryInterface.dropTable('SomeTable');
+
+        // Create the table again with a second enum this time
+        await this.queryInterface.createTable('SomeTable', {
+          someEnum: DataTypes.ENUM('value1', 'value2', 'value3'),
+          someOtherEnum: DataTypes.ENUM('otherValue1', 'otherValue2', 'otherValue3'),
+        });
+
+        const table = await this.queryInterface.describeTable('SomeTable');
+        if (dialect.includes('postgres')) {
+          expect(table.someEnum.special).to.deep.equal(['value1', 'value2', 'value3']);
+          expect(table.someOtherEnum.special).to.deep.equal([
+            'otherValue1',
+            'otherValue2',
+            'otherValue3',
+          ]);
+        }
+      });
     });
   });
 });

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -147,9 +147,10 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
               addEnumValue(field, remainingEnumValues[reverseIdx], lastOldEnumValue, 'after');
             }
           }
-
-          enumIdx++;
         }
+
+        // Continue to the next enum
+        enumIdx++;
       }
     }
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

`ensureEnums` prepares a query per enum and puts them in a results array, in-enum-column-order. It can look like this:

```
results =[
  {
    enum_name: 'enum_SomeTable_someEnum',
    enum_value: '{value1,value2,value3}'
  },
  null,
  {
    enum_name: 'enum_SomeTable_someEnumb',
    enum_value: '{value1,value2,value3}'
  },
  null
]
```

However, the index that increments through the enum results array is only happening if an enum already exists and we edit it. This can cause an issue where, if the first enum is in the results array, it can prevent `ensureEnums` from creating other missing enum columns.

This PR adds a test that exposes the issue and then I move the increment into the correct scope.


## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
