### PR TITLE
fix(sqlite3): alter table with composite primary key

### DIFF
--- a/packages/sqlite3/src/query-interface.internal.ts
+++ b/packages/sqlite3/src/query-interface.internal.ts
@@ -61,10 +61,12 @@ export class SqliteQueryInterfaceInternal extends AbstractQueryInterfaceInternal
               continue;
             }
 
-            for (const field of index.fields) {
-              if (columns[field.attribute]) {
-                columns[field.attribute].unique = true;
-              }
+            if (index.fields.length !== 1) {
+              continue;
+            }
+
+            if (columns[index.fields[0].attribute]) {
+              columns[index.fields[0].attribute].unique = true;
             }
           }
 

--- a/packages/sqlite3/src/query-interface.ts
+++ b/packages/sqlite3/src/query-interface.ts
@@ -103,10 +103,8 @@ export class SqliteQueryInterface<
 
       const indexes = await this.showIndex(tableName, options);
       for (const index of indexes) {
-        for (const field of index.fields) {
-          if (index.unique !== undefined) {
-            data[field.attribute].unique = index.unique;
-          }
+        if (index.fields.length === 1 && index.unique !== undefined) {
+            data[index.fields[0].attribute].unique = index.unique;
         }
       }
 


### PR DESCRIPTION

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->
When altering a table with a composite primary key the sqlite3 dialect would incorrectly add UNIQUE constraints to each member of a composite primary key.  Fix unique constraints being incorrectly inferred in this case.

Closes #17580
Also fixes #12992 (based solely on the SSCCE provided in that issue no longer throwing).

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
