### PR TITLE
fix(core): Improve type declaration for model validation functions

### DIFF
--- a/packages/core/src/model-definition.ts
+++ b/packages/core/src/model-definition.ts
@@ -201,7 +201,7 @@ export class ModelDefinition<M extends Model = Model> {
 
     // TODO: deep freeze this.options
     // caution: mergeModelOptions mutates its first input
-    this.options = mergeModelOptions(
+    this.options = mergeModelOptions<M>(
       // default options
       {
         noPrimaryKey: false,
@@ -959,11 +959,11 @@ function banReferenceModel<T>(reference: T): T {
  * @param options
  * @param overrideOnConflict
  */
-export function mergeModelOptions(
-  existingModelOptions: ModelOptions,
-  options: ModelOptions,
+export function mergeModelOptions<M extends Model>(
+  existingModelOptions: ModelOptions<M>,
+  options: ModelOptions<M>,
   overrideOnConflict: boolean,
-): ModelOptions {
+): ModelOptions<M> {
   // merge-able: scopes, indexes
   for (const [optionName, optionValue] of Object.entries(options) as Array<
     [keyof ModelOptions, any]

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2115,7 +2115,7 @@ export interface ModelOptions<M extends Model = Model> {
         /**
          * Custom validation functions run on all instances of the model.
          */
-        [name: string]: (value: unknown) => boolean;
+        [name: string]: ((this: M) => void) | ((this: M, callback: (err: unknown) => void) => void);
       }
     | undefined;
 


### PR DESCRIPTION
Closes #17569.

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?

This change is only around the type annotations, so it should not cause any runtime regressions. I'd be happy to add some type-level tests but I'm not really sure how to pull that off in a reasonable way.

- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Improves the type declaration for model validation functions. Currently the declaration forces validation functions to return a `boolean` even though that value is never used.

## List of Breaking Changes

This should not be a breaking change - except on the type level and only in case the original (faulty) types are already being followed.