### PR TITLE
Fix findCreateFind type comment

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -2394,7 +2394,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   ): Promise<[M, boolean]>;
 
   /**
-   * A more performant findOrCreate that will not work under a transaction (at least not in postgres)
+   * A more performant findOrCreate that will not work under a transaction (working in postgres)
    * Will execute a find call, if empty then attempt to create, if unique constraint then attempt to find again
    */
   public static findCreateFind<M extends Model>(


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

#13482 didn't update the type comment to match the .js comment; this syncs the two comments.

## List of Breaking Changes

N/A
