### PR TITLE
fix: remove deprecated tasksRunnerOptions

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -11,24 +11,19 @@
   },
   "targetDefaults": {
     "build": {
+      "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["prod", "^prod"],
       "outputs": ["{projectRoot}/lib"]
     },
     "test-typings": {
+      "cache": true,
       "inputs": ["default", "^prod"]
     },
     "test-unit": {
+      "cache": true,
       "dependsOn": ["build"],
       "inputs": ["default", "^prod"]
-    }
-  },
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx/tasks-runners/default",
-      "options": {
-        "cacheableOperations": ["build", "test-typings", "test-unit"]
-      }
     }
   },
   "workspaceLayout": {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

The `tasksRunnerOptions` has been deprecated. Custom task runners will no longer be supported in Nx 21

