### PR TITLE
feat(core/model): validate and add warning ignored for `conflictAttributes` option in `bulkCreate`

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2485,6 +2485,10 @@ ${associationOwner._getAssociationDebugList()}`);
           });
 
           if (options.conflictAttributes) {
+            if (!Array.isArray(options.conflictAttributes) || options.conflictAttributes.length === 0) {
+              throw new Error('conflictAttributes option must be a non-empty array.');
+            }
+
             options.upsertKeys = options.conflictAttributes.map(attrName =>
               modelDefinition.getColumnName(attrName),
             );
@@ -2503,6 +2507,9 @@ ${associationOwner._getAssociationDebugList()}`);
                 ? upsertKeys
                 : Object.values(model.primaryKeys).map(x => x.field);
           }
+        }
+        if (!options.updateOnDuplicate && options.conflictAttributes) {
+          logger.warn('conflictAttributes option is ignored because updateOnDuplicate is not set');
         }
 
         // Map returning attributes to fields


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Hi, thanks for this awesome ORM! We encountered an issue when using the `bulkCreate` method. We initially thought setting the `conflictAttributes` option alone would handle conflicts, but we discovered it's ignored if `updateOnDuplicate` is not set.

Reference: https://github.com/sequelize/sequelize/blob/b2baced63f2e2eabb7f7b0ea2f8f3e62e60ad63d/packages/core/src/model.js#L2482-L2506

To improve developer experience, I added a warning log when `conflictAttributes` is set without `updateOnDuplicate`. I've also added validation for `conflictAttributes`.

## List of Breaking Changes

No
