### PR TITLE
fix(core): Further improve type declaration for model validation functions

### DIFF
--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2115,7 +2115,7 @@ export interface ModelOptions<M extends Model = Model> {
         /**
          * Custom validation functions run on all instances of the model.
          */
-        [name: string]: ((this: M) => void) | ((this: M, callback: (err: unknown) => void) => void);
+        [name: string]: ((this: CreationAttributes<M>) => void) | ((this: CreationAttributes<M>, callback: (err: unknown) => void) => void);
       }
     | undefined;
 

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2115,7 +2115,9 @@ export interface ModelOptions<M extends Model = Model> {
         /**
          * Custom validation functions run on all instances of the model.
          */
-        [name: string]: ((this: CreationAttributes<M>) => void) | ((this: CreationAttributes<M>, callback: (err: unknown) => void) => void);
+        [name: string]:
+          | ((this: CreationAttributes<M>) => void)
+          | ((this: CreationAttributes<M>, callback: (err: unknown) => void) => void);
       }
     | undefined;
 


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?

This change is only around the type annotations, so it should not cause any runtime regressions. I'd be happy to add some type-level tests but I'm not really sure how to pull that off in a reasonable way.

- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This is a small follow-up on https://github.com/sequelize/sequelize/pull/17586 where the `this` argument for the model validation functions is typed as `M` (an instance of the model class itself), but in reality it does not necessarily have all the model fields available. Using `CreationAttributes<M>` seems like a reasonable choice that is both practical and does not promise too much.

## List of Breaking Changes

This should not be a breaking change - except on the type level and only in case the code relies on fields on `this` that may not really be there.