### PR TITLE
fix(core): Adjust model validator types yet again

### DIFF
--- a/packages/core/src/model-definition.ts
+++ b/packages/core/src/model-definition.ts
@@ -201,12 +201,13 @@ export class ModelDefinition<M extends Model = Model> {
 
     // TODO: deep freeze this.options
     // caution: mergeModelOptions mutates its first input
+    const validate = {} satisfies ModelOptions<M>['validate'];
     this.options = mergeModelOptions<M>(
       // default options
       {
         noPrimaryKey: false,
         timestamps: true,
-        validate: {},
+        validate,
         freezeTableName: false,
         underscored: false,
         paranoid: false,

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2115,9 +2115,7 @@ export interface ModelOptions<M extends Model = Model> {
         /**
          * Custom validation functions run on all instances of the model.
          */
-        [name: string]: 
-          | ((this: CreationAttributes<M> & ExtractMethods<M>) => void)
-          | ((this: CreationAttributes<M> & ExtractMethods<M>, callback: (err: unknown) => void) => void);
+        [name: string]: ((this: CreationAttributes<M> & ExtractMethods<M>, callback?: (err: unknown) => void) => void);
       }
     | undefined;
 

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2115,7 +2115,10 @@ export interface ModelOptions<M extends Model = Model> {
         /**
          * Custom validation functions run on all instances of the model.
          */
-        [name: string]: ((this: CreationAttributes<M> & ExtractMethods<M>, callback?: (err: unknown) => void) => void);
+        [name: string]: (
+          this: CreationAttributes<M> & ExtractMethods<M>,
+          callback?: (err: unknown) => void,
+        ) => void;
       }
     | undefined;
 
@@ -3472,5 +3475,6 @@ export type Attributes<M extends Model> = M['_attributes'];
 
 export type AttributeNames<M extends Model> = Extract<keyof M['_attributes'], string>;
 
-export type ExtractMethods<M extends Model> =
-    { [K in keyof M as M[K] extends Function ? K : never]: M[K] };
+export type ExtractMethods<M extends Model> = {
+  [K in keyof M as M[K] extends Function ? K : never]: M[K];
+};

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2147,7 +2147,7 @@ export type BuiltModelOptions<M extends Model = Model> = Omit<
     InitOptions<M>,
     'modelName' | 'indexes' | 'underscored' | 'validate' | 'tableName'
   >,
-  'name'
+  'name' | 'sequelize'
 > & { name: BuiltModelName };
 
 /**

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2115,9 +2115,9 @@ export interface ModelOptions<M extends Model = Model> {
         /**
          * Custom validation functions run on all instances of the model.
          */
-        [name: string]:
-          | ((this: CreationAttributes<M>) => void)
-          | ((this: CreationAttributes<M>, callback: (err: unknown) => void) => void);
+        [name: string]: 
+          | ((this: CreationAttributes<M> & ExtractMethods<M>) => void)
+          | ((this: CreationAttributes<M> & ExtractMethods<M>, callback: (err: unknown) => void) => void);
       }
     | undefined;
 
@@ -3473,3 +3473,6 @@ export type CreationAttributes<M extends Model> = MakeNullishOptional<M['_creati
 export type Attributes<M extends Model> = M['_attributes'];
 
 export type AttributeNames<M extends Model> = Extract<keyof M['_attributes'], string>;
+
+export type ExtractMethods<M extends Model> =
+    { [K in keyof M as M[K] extends Function ? K : never]: M[K] };


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?

This change is only around the type annotations, so it should not cause any runtime regressions. I'd be happy to add some type-level tests but I'm not really sure how to pull that off in a reasonable way.

- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This is yet another small follow-up on https://github.com/sequelize/sequelize/pull/17586 and https://github.com/sequelize/sequelize/pull/17686. I rushed a bit too much towards a fix for the issues we were seeing in our code base and overdid the weakening of the type for the the `this` argument in model validation functions. Specifically, the type now in the `main` branch disallows model method calls on the object that is being validated - but such calls work just fine.

This PR contains two changes:

1. It strengthens the type from `CreationAttributes<M>` to a type that also includes all the function members on `M`.
1. It avoids the sum type on the validation functions (with / without callback) to make it easier for TypeScript to infer types correctly.

This time we have tested the changes more thoroughly and our code seems generally happy with these types.

## List of Breaking Changes

This should not be a breaking change - except on the type level in case the original types resulted in the `any` type "invading" a validation function (using `any` as defaults for generic arguments on types such as `Model` is tricky but also 
a lot harder to do something about).