### PR TITLE
feat: Always add LIMIT 1 to `findOne` queries (#14549)

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1981,16 +1981,11 @@ class Model {
       }
     }
 
+    // findOne only ever needs one result
+    // conditional temporarily fixes 14618
+    // https://github.com/sequelize/sequelize/issues/14618
     if (options.limit === undefined) {
-      const uniqueSingleColumns = _.chain(this.uniqueKeys).values().filter(c => c.fields.length === 1).map('column').value();
-
-      // Don't add limit if querying directly on the pk or a unique column
-      if (!options.where || !_.some(options.where, (value, key) =>
-        (key === this.primaryKeyAttribute || uniqueSingleColumns.includes(key)) &&
-          (Utils.isPrimitive(value) || Buffer.isBuffer(value))
-      )) {
-        options.limit = 1;
-      }
+      options.limit = 1;
     }
 
     // Bypass a possible overloaded findAll.


### PR DESCRIPTION
(cherry-pick of 9950b4b to v6 branch)

* fix: always add LIMIT 1 to `findOne` queries
* fix: add temp patch for issue 14618

Co-authored-by: Rik Smale <13023439+WikiRik@users.noreply.github.com>