### PR TITLE
fix(postgres): insert USING clause before COMMENT in enum type definition

### DIFF
--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -171,6 +171,15 @@ if (dialect.startsWith('postgres')) {
           ],
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
+        {
+          arguments: [
+            'myTable',
+            {
+              col_1: `ENUM('value 1', 'value 2') NOT NULL; COMMENT ON COLUMN "myTable"."col_1" IS 'column 1'`,
+            },
+          ],
+          expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1"); COMMENT ON COLUMN "myTable"."col_1" IS 'column 1';`,
+        },
       ],
 
       selectQuery: [

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -166,7 +166,22 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
           /^ENUM\(.+\)/,
           this.pgEnumName(tableName, attributeName, { schema: false }),
         );
-        definition += ` USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(tableName, attributeName)})`;
+        // Find the position of "; COMMENT"
+        const commentPos = definition.indexOf("; COMMENT");
+        const usingClause = `USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(
+          tableName,
+          attributeName
+        )})`
+        if (commentPos !== -1) {
+          // Insert the USING clause before the "; COMMENT"
+          definition =
+            definition.slice(0, commentPos) +
+            usingClause +
+            definition.slice(commentPos);
+        } else {
+          // If no COMMENT clause is found, append the USING clause at the end
+          definition += ` ${  usingClause}`;
+        }
       }
 
       if (/UNIQUE;*$/.test(definition)) {


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Fix the incorrect sql generation when using sync({alter: true}).

It's a quite straightforward bug fix. The bug is described as below:

I created a model with a field like this :

```
    droneInvestigation: {
      type: DataTypes.ENUM(
        'notInvestigated',
        'largelyUncleared',
        'scatteredUncleared',
        'cleared'
      ),
      allowNull: false,
      comment: '无人机调查情况',
    },
```

and the sql query generated is like this:

```
  sql: `ALTER TABLE "clearing_records" ALTER COLUMN "drone_investigation" SET NOT NULL;ALTER TABLE "clearing_records" ALTER COLUMN "drone_investigation" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_clearing_records_drone_investigation" AS ENUM(''notInvestigated'', ''largelyUncleared'', ''scatteredUncleared'', ''cleared''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "clearing_records" ALTER COLUMN "drone_investigation" TYPE "public"."enum_clearing_records_drone_investigation" ; COMMENT ON COLUMN "clearing_records"."drone_investigation" IS '无人机调查情况' USING ("drone_investigation"::"public"."enum_clearing_records_drone_investigation");`,
```

It's obvious that the `USING` clause should go before the `; COMMENT`. So I fixed it.

## List of Breaking Changes

None.