### PR TITLE
meta: use issue types instead of labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,7 @@ name: 🐛 Bug report
 about: Create a bug report to help us improve
 title: ''
 labels: ['type: bug', 'pending-approval']
+type: Bug
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,6 +3,7 @@ name: 🚀 Feature request
 about: Suggest an idea for this project
 title: ''
 labels: ['type: feature', 'pending-approval']
+type: Feature
 assignees: ''
 ---
 


### PR DESCRIPTION
## Description of Changes

The goal of this PR is to start using the new issue types instead of labels in our repository

I have not yet removed the labels from the issue templates, because I cannot find any documentation for non-form issue templates that talk about issue types. This is a test PR to see if it even works

If it works, we'll be able to replace our labels with issue types

![image](https://github.com/user-attachments/assets/72d44521-52a2-4fb1-9b93-43d35242628f)
