### PR TITLE
meta: remove bug/feature labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: 🐛 Bug report
 about: Create a bug report to help us improve
 title: ''
-labels: ['type: bug', 'pending-approval']
+labels: ['pending-approval']
 type: Bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: 🚀 Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ['type: feature', 'pending-approval']
+labels: ['pending-approval']
 type: Feature
 assignees: ''
 ---


### PR DESCRIPTION
## Description of Changes

This PR is a follow-up on https://github.com/sequelize/sequelize/pull/17753, now that issue types have been tested with success:

- https://github.com/sequelize/sequelize/issues/17755
- https://github.com/sequelize/sequelize/issues/17754

We'll still need to replace all existing bug/feature labels with issue types, on older PRs.

I don't know if there is an automated way to do this yet