### PR TITLE
fix: remove redundant types export in package.json

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,8 +28,7 @@
       "import": {
         "types": "./lib/node/index.d.mts",
         "default": "./lib/node/index.mjs"
-      },
-      "types": "./lib/node/index.d.ts"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

The build process notes that the types export is redundant, node export only for require and import options.

