### PR TITLE
fix(snowflake): update describeTableQuery to use Snowflake's DESCRIBE TABLE

### DIFF
--- a/packages/snowflake/src/query-generator-typescript.internal.ts
+++ b/packages/snowflake/src/query-generator-typescript.internal.ts
@@ -81,7 +81,8 @@ export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
   }
 
   describeTableQuery(tableName: TableOrModel) {
-    return `SHOW FULL COLUMNS FROM ${this.quoteTable(tableName)};`;
+    const table = this.extractTableDetails(tableName);
+    return `DESCRIBE TABLE ${this.quoteIdentifier(table.schema)}.${this.quoteIdentifier(table.tableName)}`;
   }
 
   listTablesQuery(options?: ListTablesQueryOptions) {

--- a/packages/snowflake/src/query.js
+++ b/packages/snowflake/src/query.js
@@ -152,19 +152,17 @@ export class SnowflakeQuery extends AbstractQuery {
 
     if (this.isDescribeQuery()) {
       result = {};
-
+      
       for (const _result of data) {
-        result[_result.Field] = {
-          type: _result.Type.toUpperCase(),
-          allowNull: _result.Null === 'YES',
-          defaultValue: _result.Default,
-          primaryKey: _result.Key === 'PRI',
-          autoIncrement:
-            Object.hasOwn(_result, 'Extra') && _result.Extra.toLowerCase() === 'auto_increment',
-          comment: _result.Comment ? _result.Comment : null,
+        result[_result.name] = {
+          type: _result.type.toUpperCase(),
+          allowNull: _result['null?'].includes("Y"),
+          defaultValue: _result.default,
+          primaryKey: _result['primary key'].includes("Y"),
+          autoIncrement: _result.default !== null && _result.default.includes("_id_seq"),
+          comment: _result.comment ? _result.comment : null
         };
       }
-
       return result;
     }
 

--- a/packages/snowflake/src/query.js
+++ b/packages/snowflake/src/query.js
@@ -159,7 +159,7 @@ export class SnowflakeQuery extends AbstractQuery {
           allowNull: _result['null?'].includes("Y"),
           defaultValue: _result.default,
           primaryKey: _result['primary key'].includes("Y"),
-          autoIncrement: _result.default !== null && _result.default.includes("_id_seq"),
+          autoIncrement: _result.default !== null && _result.default.includes(".NEXTVAL"),
           comment: _result.comment ? _result.comment : null
         };
       }


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

Updates Query generation for Snowflake to use `DESCRIBE TABLE` as `SHOW FULL COLUMNS FROM` is unsupported by Snowflake. Also updates the result parsing logic to align with the column names and formats returned by Snowflake.

Closes #[15525]

Improvements to Snowflake query generation:

* [`packages/snowflake/src/query-generator-typescript.internal.ts`](diffhunk://#diff-4b67b98cb05cc52bfc720b82e06d534d7142c81c3f1a5032644606c9885a520eL84-R85): Modified the `describeTableQuery` method to use the `DESCRIBE TABLE` command and properly handle table schema extraction.

Enhancements to query result parsing:

* [`packages/snowflake/src/query.js`](diffhunk://#diff-873efc93541661559f616264c7edbd731ee32fe09e04df7a412368e1ec4a2046L157-L167): Updated the result parsing logic in the `SnowflakeQuery` class to align with the new column names and formats returned by Snowflake, ensuring accurate mapping of field properties.

## List of Breaking Changes



