### PR TITLE
docs: fix typo in index comment

### DIFF
--- a/packages/core/src/abstract-dialect/query-interface.d.ts
+++ b/packages/core/src/abstract-dialect/query-interface.d.ts
@@ -121,7 +121,7 @@ export interface IndexOptions {
   type?: IndexType | undefined;
 
   /**
-   * Should the index by unique? Can also be triggered by setting type to `UNIQUE`
+   * Should the index be unique? Can also be triggered by setting type to `UNIQUE`
    *
    * @default false
    */


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions? No
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository] (https://github.com/sequelize/website/)? No
- [ ] Did you update the typescript typings accordingly (if applicable)? No
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? No
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)? Yes

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Fixed a small typo in the comment describing the option `index`.

## List of Breaking Changes
