### PR TITLE
feat(core): rejectOnEmpty added to ModelOptions

### DIFF
--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2120,6 +2120,15 @@ export interface ModelOptions<M extends Model = Model> {
    * @default false
    */
   version?: boolean | string | undefined;
+
+  /**
+   * Throws an error if the query would return 0 results.
+   * This option is used as the default for all find operations on this model.
+   * Can be overridden in individual find operations.
+   *
+   * @default false
+   */
+  rejectOnEmpty?: boolean | Error | undefined;
 }
 
 /**

--- a/packages/core/test/integration/model/findOne.test.js
+++ b/packages/core/test/integration/model/findOne.test.js
@@ -1078,6 +1078,44 @@ The following associations are defined on "Worker": "ToDos"`);
         ).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
 
+      it('throws error when record not found by findByPk with model-level rejectOnEmpty', async function () {
+        const Model = current.define(
+          'Test',
+          {
+            username: DataTypes.STRING(100),
+          },
+          {
+            rejectOnEmpty: true,
+          },
+        );
+
+        await Model.sync({ force: true });
+
+        await expect(
+          Model.findByPk(1),
+        ).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+      });
+
+      it('override model-level rejectOnEmpty in findByPk', async function () {
+        const Model = current.define(
+          'Test',
+          {
+            username: DataTypes.STRING(100),
+          },
+          {
+            rejectOnEmpty: true,
+          },
+        );
+
+        await Model.sync({ force: true });
+
+        await expect(
+          Model.findByPk(1, {
+            rejectOnEmpty: false,
+          }),
+        ).to.eventually.be.deep.equal(null);
+      });
+
       it('throws error when record not found by find', async function () {
         await expect(
           this.User.findOne({

--- a/packages/core/test/types/typescript-docs/define-reject-on-empty.ts
+++ b/packages/core/test/types/typescript-docs/define-reject-on-empty.ts
@@ -1,0 +1,54 @@
+import type {
+    CreationOptional,
+    InferAttributes,
+    InferCreationAttributes,
+    Model,
+} from '@sequelize/core';
+import { DataTypes, Sequelize } from '@sequelize/core';
+import { MySqlDialect } from '@sequelize/mysql';
+
+const sequelize = new Sequelize({
+    dialect: MySqlDialect,
+    url: 'mysql://root:asd123@localhost:3306/mydb',
+});
+
+// We recommend you declare an interface for the attributes, for stricter typechecking
+
+interface IUserModel
+    extends Model<InferAttributes<IUserModel>, InferCreationAttributes<IUserModel>> {
+    // Some fields are optional when calling UserModel.create() or UserModel.build()
+    id: CreationOptional<number>;
+    name: string;
+}
+
+// Define a model with rejectOnEmpty: true at the model level
+const UserModel = sequelize.define<IUserModel>('User', {
+    id: {
+        primaryKey: true,
+        type: DataTypes.INTEGER.UNSIGNED,
+    },
+    name: {
+        type: DataTypes.STRING,
+    },
+}, {
+    // This will make all find operations throw an error if no record is found
+    rejectOnEmpty: true,
+});
+
+async function doStuff() {
+    // Since the model has rejectOnEmpty: true, this will throw an error if no record is found
+    const instance = await UserModel.findByPk(1);
+
+    // The return type is guaranteed to be non-null because of model-level rejectOnEmpty
+    console.log(instance.id); // TypeScript knows this is not null
+
+    // You can still override the model-level setting for individual queries
+    const maybeInstance = await UserModel.findByPk(1, {
+        rejectOnEmpty: false,
+    });
+
+    // Now TypeScript knows this could be null
+    if (maybeInstance) {
+        console.log(maybeInstance.id);
+    }
+} 


### PR DESCRIPTION
## Pull Request Checklist

Issue: https://github.com/sequelize/sequelize/issues/17936

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?


## Description of Changes
Added `rejectOnEmpty` to ModelOptions so this can be set at model definition and not on each `findByPK()` query

Before:
```ts
const user = await User.findByPk(userID, {
    rejectOnEmpty: true
})
```

After:
```ts 
const User = sequelize.define<UserModel>('User', {
    id: {
        type: DataTypes.UUID,
        defaultValue: DataTypes.UUIDV4,
        primaryKey: true,
        allowNull: false,
        unique: true
    },
    ...
}, {
    tableName: 'Users',
    rejectOnEmpty: true
});


try {
    const model = await User.findByPk(modelID)
} catch (error) {
    console.error(error)
}

const model = await User.findByPk(modelID, {
    rejectOnEmpty: false
})

console.log(model) // null
```

## List of Breaking Changes
None
