### PR TITLE
feat(sqlite): add support for STRICT tables

### DIFF
--- a/packages/core/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/packages/core/test/integration/dialects/sqlite/dao-factory.test.js
@@ -119,6 +119,83 @@ describe('[SQLITE Specific] DAOFactory', () => {
     });
   });
 
+  describe('STRICT tables', () => {
+    it('should enforce type constraints when strict mode is enabled', async () => {
+      const sequelize = createSequelizeInstance({
+        storage: dbFile,
+        dialectOptions: {
+          strictTables: true, // Enable strict mode
+        },
+      });
+
+      const StrictUser = sequelize.define('StrictUser', {
+        age: DataTypes.INTEGER,
+        name: DataTypes.STRING,
+      });
+
+      console.log('Creating StrictUser table with strict mode enabled');
+
+      await StrictUser.sync({ force: true });
+
+      // Valid data should work
+      await StrictUser.create({ age: 21, name: 'John' });
+
+      // Invalid data should fail
+      try {
+        await StrictUser.create({ age: 'twenty-one', name: 'John' });
+        throw new Error('Should have thrown an error');
+      } catch (error) {
+        expect(error.name).to.equal('SequelizeDatabaseError');
+        expect(error.message).to.match(/cannot store TEXT value in INTEGER column/);
+      }
+
+      await sequelize.close();
+    });
+
+    it('should allow non-strict behavior when disabled', async () => {
+      const sequelize = createSequelizeInstance({
+        storage: dbFile,
+        dialectOptions: {
+          strictTables: false, // Explicitly disable
+        },
+      });
+
+      const LooseUser = sequelize.define('LooseUser', {
+        age: DataTypes.INTEGER,
+        name: DataTypes.STRING,
+      });
+
+      await LooseUser.sync({ force: true });
+
+      // Should allow type conversion
+      const user = await LooseUser.create({ age: '21', name: 'John' });
+      expect(user.age).to.equal(21); // Note the type conversion
+
+      await sequelize.close();
+    });
+
+    it('should include STRICT in CREATE TABLE statement', async () => {
+      const sequelize = createSequelizeInstance({
+        storage: dbFile,
+        dialectOptions: {
+          strictTables: true,
+        },
+        logging: sql => {
+          if (sql.includes('CREATE TABLE')) {
+            expect(sql).to.include('STRICT');
+          }
+        },
+      });
+
+      const User = sequelize.define('User', {
+        name: DataTypes.STRING,
+      });
+
+      await User.sync({ force: true });
+      await sequelize.close();
+    });
+  });
+
   describe('.findOne', () => {
     beforeEach(async () => {
       const { User } = vars;

--- a/packages/sqlite3/src/dialect.ts
+++ b/packages/sqlite3/src/dialect.ts
@@ -26,11 +26,21 @@ export interface SqliteDialectOptions {
    * as the Sequelize team cannot guarantee its compatibility.
    */
   sqlite3Module?: Sqlite3Module;
+
+  /**
+   * Enable STRICT mode for all tables by default.
+   * When enabled, tables will be created with STRICT keyword,
+   * enforcing strict typing at the database level.
+   *
+   * @default false
+   */
+  strictTables?: boolean;
 }
 
 const DIALECT_OPTION_NAMES = getSynchronizedTypeKeys<SqliteDialectOptions>({
   foreignKeys: undefined,
   sqlite3Module: undefined,
+  strictTables: undefined,
 });
 
 const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<SqliteConnectionOptions>({

--- a/packages/sqlite3/src/query-generator.js
+++ b/packages/sqlite3/src/query-generator.js
@@ -94,7 +94,13 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
       attrStr += `, PRIMARY KEY (${pkString})`;
     }
 
-    const sql = `CREATE TABLE IF NOT EXISTS ${table} (${attrStr});`;
+    let sql = `CREATE TABLE IF NOT EXISTS ${table} (${attrStr})`;
+
+    if (this.dialect.options.strictTables) {
+      sql += ' STRICT';
+    }
+
+    sql += ';';
 
     return this.replaceBooleanDefaults(sql);
   }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This PR adds support for SQLite STRICT tables, which enforce type constraints at the database level.

Key changes:
- Added `strictTables` dialect option
- Modified query generator to include STRICT keyword
- Added tests

issue: [#15715](https://github.com/sequelize/sequelize/issues/15715)

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
