### PR TITLE
fix(sqlite3): Map regexp and notRegexp to REGEXP and NOT REGEXP in sqlite3 TypeScript instead of "~"

### DIFF
--- a/packages/sqlite3/src/query-generator-typescript.internal.ts
+++ b/packages/sqlite3/src/query-generator-typescript.internal.ts
@@ -43,6 +43,9 @@ export class SqliteQueryGeneratorTypeScript extends AbstractQueryGenerator {
   ) {
     super(dialect, internals);
 
+    internals.whereSqlBuilder.setOperatorKeyword(Op.regexp, 'REGEXP');
+    internals.whereSqlBuilder.setOperatorKeyword(Op.notRegexp, 'NOT REGEXP');
+
     this.#internals = internals;
   }
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Description of Changes

By [default](https://github.com/sequelize/sequelize/blob/9f5a25b5ec8eb487e4fe3e15f959509ddd277de8/packages/core/src/abstract-dialect/where-sql-builder.ts#L93), the REGEXP operator maps to the "~" operator but this is not the correct operator for sqlite. Sqlite uses "REGEXP", the same as [what MySQL uses](https://github.com/sequelize/sequelize/blob/9f5a25b5ec8eb487e4fe3e15f959509ddd277de8/packages/mysql/src/query-generator-typescript.internal.ts#L36).

This PR updates the behavior for the TypeScript version of Sqlite to properly map the REGEXP operators.

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added regex filtering support for SQLite queries. You can now use REGEXP and NOT REGEXP in WHERE clauses for more flexible pattern matching.
  * Enables constructing queries with regexp/notRegexp conditions in the SQLite dialect.
  * Improves expressiveness of filters without breaking existing queries.
  * Applicable across features that rely on pattern-based search within SQLite-backed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->