### PR TITLE
fix(core): ensure bulkInsert returns array of inserted IDs

### DIFF
--- a/packages/mysql/src/query.js
+++ b/packages/mysql/src/query.js
@@ -126,7 +126,18 @@ export class MySqlQuery extends AbstractQuery {
             });
           }
         } else {
-          result = data[this.getInsertIdField()];
+
+          const startId = data[this.getInsertIdField()];
+          if (data.constructor.name === "ResultSetHeader" && data.affectedRows > 1) {
+            // No model context, but still return array of IDs
+            result = [];
+            for (let i = startId; i < startId + data.affectedRows; i++) {
+              // this shouldnot be (id) key but we have no other choice here
+              result.push({ id: i });
+            }
+          } else {
+            result = startId;
+          }
         }
       }
     }


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #14325)?
- [x] Does the name of your PR follow our conventions?

## Description of Changes

This PR ensures `queryInterface.bulkInsert` consistently returns an **array of inserted IDs** across mysql dialect, instead of a single value or undefined.

- Updated `bulkInsert` implementation to return an array.

Previously:
```js
await queryInterface.bulkInsert('companies', [
  { name: 'Example Company 1' },
  { name: 'Example Company 2' },
]);
// → 1
```
now:
```js
await queryInterface.bulkInsert('companies', [
  { name: 'Example Company 1' },
  { name: 'Example Company 2' },
]);
// → [1, 2]
```

Closes #14325

## List of Breaking Changes

- None (the return type is extended, but still backward-compatible).