### PR TITLE
docs: fix typo in comment and test title

### DIFF
--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -291,7 +291,7 @@ Use Sequelize#query if you wish to use replacements.`);
 
         sql = mappedResult.sql;
 
-        // used by dialects that support "INOUT" parameters to map the OUT parameters back the the name the dev used.
+        // used by dialects that support "INOUT" parameters to map the OUT parameters back to the name the dev used.
         options.bindParameterOrder = mappedResult.bindOrder;
         if (mappedResult.bindOrder == null) {
           bindParameters = options.bind;

--- a/packages/core/test/integration/model/destroy.test.ts
+++ b/packages/core/test/integration/model/destroy.test.ts
@@ -190,7 +190,7 @@ describe('destroy', () => {
       expect(await Log.findAll()).to.have.lengthOf(0);
     });
 
-    it('maps the the column name', async () => {
+    it('maps the column name', async () => {
       const UserProject = sequelize.define('UserProject', {
         userId: {
           type: DataTypes.INTEGER,


### PR DESCRIPTION
Fix typos: `the the` → `the` / `to the`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal documentation and test description corrections for code clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->