### PR TITLE
feat(mysql): support all geometry types

### DIFF
--- a/src/dialects/mysql/data-types.js
+++ b/src/dialects/mysql/data-types.js
@@ -90,7 +90,7 @@ module.exports = BaseTypes => {
     }
   }
 
-  const SUPPORTED_GEOMETRY_TYPES = ['POINT', 'LINESTRING', 'POLYGON'];
+  const SUPPORTED_GEOMETRY_TYPES = ['POINT', 'LINESTRING', 'POLYGON', 'MULTIPOINT', 'MULTILINESTRING', 'MULTIPOLYGON', 'GEOMETRYCOLLECTION'];
 
   class GEOMETRY extends BaseTypes.GEOMETRY {
     constructor(type, srid) {

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -1679,6 +1679,30 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           mariadb: 'POINT',
           mysql: 'POINT'
         });
+
+        testsql('GEOMETRY(\'MULTIPOINT\')', DataTypes.GEOMETRY('MULTIPOINT'), {
+          postgres: 'GEOMETRY(MULTIPOINT)',
+          mariadb: 'MULTIPOINT',
+          mysql: 'MULTIPOINT'
+        });
+
+        testsql('GEOMETRY(\'MULTILINESTRING\')', DataTypes.GEOMETRY('MULTILINESTRING'), {
+          postgres: 'GEOMETRY(MULTILINESTRING)',
+          mariadb: 'MULTILINESTRING',
+          mysql: 'MULTILINESTRING'
+        });
+
+        testsql('GEOMETRY(\'MULTIPOLYGON\')', DataTypes.GEOMETRY('MULTIPOLYGON'), {
+          postgres: 'GEOMETRY(MULTIPOLYGON)',
+          mariadb: 'MULTIPOLYGON',
+          mysql: 'MULTIPOLYGON'
+        });
+
+        testsql('GEOMETRY(\'GEOMETRYCOLLECTION\')', DataTypes.GEOMETRY('GEOMETRYCOLLECTION'), {
+          postgres: 'GEOMETRY(GEOMETRYCOLLECTION)',
+          mariadb: 'GEOMETRYCOLLECTION',
+          mysql: 'GEOMETRYCOLLECTION'
+        });
       });
     }
   });


### PR DESCRIPTION
## Problem

MySQL dialect only supports POINT, LINESTRING, and POLYGON geometry types, while MySQL database itself supports all geometry types including MULTIPOINT, MULTILINESTRING, MULTIPOLYGON, and GEOMETRYCOLLECTION.

This causes unnecessary errors when users try to use these valid MySQL geometry types:

```
Error: Supported geometry types are: POINT, LINESTRING, POLYGON
```

## Solution

Expand `SUPPORTED_GEOMETRY_TYPES` array to include all MySQL-supported geometry types, aligning with MariaDB dialect behavior which has no such restriction.

## Changes

- Added MULTIPOINT, MULTILINESTRING, MULTIPOLYGON, GEOMETRYCOLLECTION to `SUPPORTED_GEOMETRY_TYPES` in `src/dialects/mysql/data-types.js`
- Added unit tests for new geometry types

## References

- MySQL Spatial Data Types: https://dev.mysql.com/doc/refman/8.0/en/spatial-type-overview.html
- MariaDB dialect implementation: `src/dialects/mariadb/data-types.js` (no restriction on geometry types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)