### PR TITLE
feat(sqlite3): add support for STRICT tables

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -58,6 +58,14 @@ export interface CreateTableQueryOptions {
   comment?: string;
   initialAutoIncrement?: number;
   /**
+   * If true, the table will be created as a STRICT table.
+   *
+   * SQLite only.
+   *
+   * @see https://www.sqlite.org/stricttables.html
+   */
+  strict?: boolean;
+  /**
    * Used for compound unique keys.
    */
   uniqueKeys?: Array<{ fields: string[] }> | { [indexName: string]: { fields: string[] } };

--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -62,6 +62,8 @@ export interface CreateTableQueryOptions {
    *
    * SQLite only.
    *
+   * Requires SQLite >= 3.37.0.
+   *
    * @see https://www.sqlite.org/stricttables.html
    */
   strict?: boolean;

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -48,6 +48,7 @@ export const CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set([
   'comment',
   'initialAutoIncrement',
   'uniqueKeys',
+  'strict',
 ]);
 export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
 

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2076,6 +2076,15 @@ export interface ModelOptions<M extends Model = Model> {
   initialAutoIncrement?: string | undefined;
 
   /**
+   * If true, the table will be created as a STRICT table.
+   *
+   * SQLite only.
+   *
+   * @see https://www.sqlite.org/stricttables.html
+   */
+  strict?: boolean | undefined;
+
+  /**
    * Add hooks to the model.
    * Hooks will be called before and after certain operations.
    *

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2080,6 +2080,8 @@ export interface ModelOptions<M extends Model = Model> {
    *
    * SQLite only.
    *
+   * Requires SQLite >= 3.37.0.
+   *
    * @see https://www.sqlite.org/stricttables.html
    */
   strict?: boolean | undefined;

--- a/packages/core/test/unit/query-generator/create-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-table-query.test.ts
@@ -649,6 +649,26 @@ describe('QueryGenerator#createTableQuery', () => {
     );
   });
 
+  it('supports the strict option', () => {
+    expectsql(
+      () => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { strict: true }),
+      {
+        default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['strict']),
+        sqlite3: 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) STRICT;',
+      },
+    );
+  });
+
+  it('produces a query without STRICT when strict option is false', () => {
+    expectsql(
+      () => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { strict: false }),
+      {
+        default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['strict']),
+        sqlite3: 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE);',
+      },
+    );
+  });
+
   describe('supports the uniqueKeys option', () => {
     // SQLITE does not respect the index name when the index is created through CREATE TABLE
     // As such, Sequelize's createTable does not add the constraint in the Sequelize Dialect.

--- a/packages/core/test/unit/query-generator/create-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-table-query.test.ts
@@ -660,10 +660,16 @@ describe('QueryGenerator#createTableQuery', () => {
   });
 
   it('produces a query without STRICT when strict option is false', () => {
+    // strict: false is treated the same as not passing the option at all,
+    // since rejectInvalidOptions filters out false values.
     expectsql(
       () => queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { strict: false }),
       {
-        default: buildInvalidOptionReceivedError('createTableQuery', dialectName, ['strict']),
+        default: 'CREATE TABLE IF NOT EXISTS [myTable] ([myColumn] DATE);',
+        'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB;',
+        mssql: `IF OBJECT_ID(N'[myTable]', 'U') IS NULL CREATE TABLE [myTable] ([myColumn] DATE);`,
+        ibmi: `BEGIN DECLARE CONTINUE HANDLER FOR SQLSTATE VALUE '42710' BEGIN END; CREATE TABLE "myTable" ("myColumn" DATE); END`,
+        oracle: `BEGIN EXECUTE IMMEDIATE 'CREATE TABLE "myTable" ("myColumn" DATE)'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;`,
         sqlite3: 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE);',
       },
     );

--- a/packages/mariadb/src/query-generator.js
+++ b/packages/mariadb/src/query-generator.js
@@ -4,6 +4,8 @@ import {
   attributeTypeToSql,
   normalizeDataType,
 } from '@sequelize/core/_non-semver-use-at-your-own-risk_/abstract-dialect/data-types-utils.js';
+import { CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '@sequelize/core/_non-semver-use-at-your-own-risk_/abstract-dialect/query-generator.js';
+import { rejectInvalidOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
 import { joinSQLFragments } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/join-sql-fragments.js';
 import { defaultValueSchemable } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/query-builder-utils.js';
 import each from 'lodash/each';
@@ -12,8 +14,28 @@ import { MariaDbQueryGeneratorTypeScript } from './query-generator-typescript.in
 
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
+const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set([
+  'collate',
+  'charset',
+  'engine',
+  'rowFormat',
+  'comment',
+  'initialAutoIncrement',
+  'uniqueKeys',
+]);
+
 export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
   createTableQuery(tableName, attributes, options) {
+    if (options) {
+      rejectInvalidOptions(
+        'createTableQuery',
+        this.dialect,
+        CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+        CREATE_TABLE_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
     options = {
       engine: 'InnoDB',
       charset: null,

--- a/packages/mysql/src/query-generator.js
+++ b/packages/mysql/src/query-generator.js
@@ -4,7 +4,10 @@ import {
   attributeTypeToSql,
   normalizeDataType,
 } from '@sequelize/core/_non-semver-use-at-your-own-risk_/abstract-dialect/data-types-utils.js';
-import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS } from '@sequelize/core/_non-semver-use-at-your-own-risk_/abstract-dialect/query-generator.js';
+import {
+  ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
+  CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/abstract-dialect/query-generator.js';
 import { BaseSqlExpression } from '@sequelize/core/_non-semver-use-at-your-own-risk_/expression-builders/base-sql-expression.js';
 import { rejectInvalidOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
 import { joinSQLFragments } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/join-sql-fragments.js';
@@ -17,8 +20,28 @@ import { MySqlQueryGeneratorTypeScript } from './query-generator-typescript.inte
 
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
+const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set([
+  'collate',
+  'charset',
+  'engine',
+  'rowFormat',
+  'comment',
+  'initialAutoIncrement',
+  'uniqueKeys',
+]);
+
 export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
   createTableQuery(tableName, attributes, options) {
+    if (options) {
+      rejectInvalidOptions(
+        'createTableQuery',
+        this.dialect,
+        CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
+        CREATE_TABLE_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
     options = {
       engine: 'InnoDB',
       charset: null,

--- a/packages/sqlite3/src/query-generator.js
+++ b/packages/sqlite3/src/query-generator.js
@@ -15,6 +15,8 @@ import each from 'lodash/each';
 import isObject from 'lodash/isObject';
 import { SqliteQueryGeneratorTypeScript } from './query-generator-typescript.internal.js';
 
+const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['strict']);
+
 export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
   createTableQuery(tableName, attributes, options) {
     // TODO: add support for 'uniqueKeys' by improving the createTableQuery implementation so it also generates a CREATE UNIQUE INDEX query
@@ -23,7 +25,7 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
         'createTableQuery',
         this.dialect,
         CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-        EMPTY_SET,
+        CREATE_TABLE_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }
@@ -96,7 +98,8 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
       attrStr += `, PRIMARY KEY (${pkString})`;
     }
 
-    const sql = `CREATE TABLE IF NOT EXISTS ${table} (${attrStr});`;
+    const strict = options.strict ? ' STRICT' : '';
+    const sql = `CREATE TABLE IF NOT EXISTS ${table} (${attrStr})${strict};`;
 
     return this.replaceBooleanDefaults(sql);
   }


### PR DESCRIPTION
## Summary
- Adds a `strict` option to `CreateTableQueryOptions` that appends the `STRICT` keyword to `CREATE TABLE` statements for the SQLite dialect
- Adds `strict` to `ModelOptions` so it can be set via `sequelize.define()` or `Model.init()`
- Includes unit tests verifying the option produces correct SQL for SQLite and is rejected for other dialects

Closes #15715

## Details

SQLite [STRICT tables](https://www.sqlite.org/stricttables.html) enforce column type constraints at the database level. Without STRICT, SQLite allows storing any type in any column. This change lets users opt into strict type enforcement by setting `strict: true` in their model or table options.

### Usage

```js
const Vegetable = sequelize.define('Vegetable', {
  name: DataTypes.STRING,
}, {
  strict: true,
});

await sequelize.sync();
// Generates: CREATE TABLE IF NOT EXISTS `Vegetables` (...) STRICT;
```

## Test plan
- [x] Added unit tests for `createTableQuery` with `strict: true` (produces `STRICT` suffix for SQLite)
- [x] Added unit tests for `createTableQuery` with `strict: false` (no `STRICT` suffix)
- [x] Verified non-SQLite dialects reject the `strict` option with an appropriate error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SQLite STRICT tables via an optional "strict" table-creation option. The option is dialect-aware and will be ignored or reported as invalid on non‑SQLite dialects to prevent accidental misuse.

* **Tests**
  * Added tests covering the strict option’s behavior and validation across different dialects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->