### PR TITLE
fix-postgres-alter-default-references

### DIFF
--- a/packages/core/src/abstract-dialect/query-interface.js
+++ b/packages/core/src/abstract-dialect/query-interface.js
@@ -207,16 +207,18 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   async changeColumn(tableName, attributeName, dataTypeOrOptions, options) {
     options ||= {};
 
+    const normalizedAttributes = {
+      [attributeName]: this.normalizeAttribute(dataTypeOrOptions),
+    };
+
     const query = this.queryGenerator.attributesToSQL(
-      {
-        [attributeName]: this.normalizeAttribute(dataTypeOrOptions),
-      },
+      normalizedAttributes,
       {
         context: 'changeColumn',
         table: tableName,
       },
     );
-    const sql = this.queryGenerator.changeColumnQuery(tableName, query);
+    const sql = this.queryGenerator.changeColumnQuery(tableName, query, normalizedAttributes);
 
     return this.sequelize.queryRaw(sql, options);
   }

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -925,16 +925,17 @@ ${associationOwner._getAssociationDebugList()}`);
             continue;
           }
 
-          if (currentAttribute.primaryKey) {
+          const attributeForChange = cloneDeep(currentAttribute);
+          if (attributeForChange.primaryKey) {
             continue;
           }
 
           // Check foreign keys. If it's a foreign key, it should remove constraint first.
-          const references = currentAttribute.references;
-          if (currentAttribute.references) {
+          const references = attributeForChange.references;
+          if (references) {
             const schema = tableName.schema;
             const database = this.sequelize.options.replication.write.database;
-            const foreignReferenceSchema = currentAttribute.references.table.schema;
+            const foreignReferenceSchema = references.table.schema;
             const foreignReferenceTableName =
               typeof references.table === 'object' ? references.table.tableName : references.table;
             // Find existed foreign keys
@@ -961,7 +962,7 @@ ${associationOwner._getAssociationDebugList()}`);
             }
           }
 
-          await this.queryInterface.changeColumn(tableName, columnName, currentAttribute, options);
+          await this.queryInterface.changeColumn(tableName, columnName, attributeForChange, options);
         }
       }
     }

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -171,6 +171,16 @@ if (dialect.startsWith('postgres')) {
           ],
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
+        {
+          arguments: [
+            'myTable',
+            {
+              col_1: 'INTEGER NOT NULL DEFAULT 1 REFERENCES "other" ("id") ON DELETE SET NULL ON UPDATE CASCADE',
+            },
+          ],
+          expectation:
+            'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" SET DEFAULT 1;ALTER TABLE "myTable"  ADD FOREIGN KEY ("col_1") REFERENCES "other" ("id") ON DELETE SET NULL ON UPDATE CASCADE;',
+        },
       ],
 
       selectQuery: [


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

issue #11048.
Fix Postgres changeColumn SQL generation when a column has both DEFAULT and REFERENCES. The previous parsing would include the REFERENCES clause in the SET DEFAULT fragment, producing invalid SQL like SET DEFAULT 1 REFERENCES ....
This change splits DEFAULT and REFERENCES into separate valid ALTER TABLE statements and adds a regression test for the combined case.
## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
