### PR TITLE
fix(core): rename useMaster to usePrimary in replication config

### DIFF
--- a/packages/core/src/abstract-dialect/connection-manager.ts
+++ b/packages/core/src/abstract-dialect/connection-manager.ts
@@ -10,6 +10,11 @@ export interface GetConnectionOptions {
    * Force the query to use the primary (write) pool, regardless of the query type.
    */
   usePrimary?: boolean;
+
+  /**
+   * @deprecated Use {@link usePrimary} instead.
+   */
+  useMaster?: boolean;
 }
 
 export interface AbstractConnection {

--- a/packages/core/src/abstract-dialect/connection-manager.ts
+++ b/packages/core/src/abstract-dialect/connection-manager.ts
@@ -7,9 +7,9 @@ export interface GetConnectionOptions {
   type: 'read' | 'write';
 
   /**
-   * Force master or write replica to get connection from
+   * Force the query to use the primary (write) pool, regardless of the query type.
    */
-  useMaster?: boolean;
+  usePrimary?: boolean;
 }
 
 export interface AbstractConnection {

--- a/packages/core/src/abstract-dialect/connection-manager.ts
+++ b/packages/core/src/abstract-dialect/connection-manager.ts
@@ -12,7 +12,7 @@ export interface GetConnectionOptions {
   usePrimary?: boolean;
 
   /**
-   * @deprecated Use {@link usePrimary} instead.
+   * @deprecated Use {@link GetConnectionOptions.usePrimary} instead.
    */
   useMaster?: boolean;
 }

--- a/packages/core/src/abstract-dialect/replication-pool.ts
+++ b/packages/core/src/abstract-dialect/replication-pool.ts
@@ -46,9 +46,9 @@ export interface AcquireConnectionOptions {
   type?: 'read' | 'write';
 
   /**
-   * Force master or write replica to get connection from
+   * Force the query to use the primary (write) pool, regardless of the query type.
    */
-  useMaster?: boolean;
+  usePrimary?: boolean;
 }
 
 interface ReplicationPoolConfig<Connection extends object, ConnectionOptions extends object> {
@@ -160,13 +160,13 @@ export class ReplicationPool<Connection extends object, ConnectionOptions extend
     await this.#beforeAcquire?.(options);
     Object.freeze(options);
 
-    const { useMaster = false, type = 'write' } = options;
+    const { usePrimary = false, type = 'write' } = options;
 
     if (type !== 'read' && type !== 'write') {
       throw new Error(`Expected queryType to be either read or write. Received ${type}`);
     }
 
-    const pool = this.read != null && type === 'read' && !useMaster ? this.read : this.write;
+    const pool = this.read != null && type === 'read' && !usePrimary ? this.read : this.write;
 
     let connection;
     try {

--- a/packages/core/src/abstract-dialect/replication-pool.ts
+++ b/packages/core/src/abstract-dialect/replication-pool.ts
@@ -52,7 +52,7 @@ export interface AcquireConnectionOptions {
   usePrimary?: boolean;
 
   /**
-   * @deprecated Use {@link usePrimary} instead.
+   * @deprecated Use {@link AcquireConnectionOptions.usePrimary} instead.
    */
   useMaster?: boolean;
 }

--- a/packages/core/src/abstract-dialect/replication-pool.ts
+++ b/packages/core/src/abstract-dialect/replication-pool.ts
@@ -1,8 +1,8 @@
 import { pojo, shallowClonePojo } from '@sequelize/utils';
 import { Pool, TimeoutError } from 'sequelize-pool';
 import type { Class } from 'type-fest';
-import { logger } from '../utils/logger.js';
 import { useMasterToUsePrimary } from '../utils/deprecations.js';
+import { logger } from '../utils/logger.js';
 
 const debug = logger.debugContext('pool');
 

--- a/packages/core/src/abstract-dialect/replication-pool.ts
+++ b/packages/core/src/abstract-dialect/replication-pool.ts
@@ -2,6 +2,7 @@ import { pojo, shallowClonePojo } from '@sequelize/utils';
 import { Pool, TimeoutError } from 'sequelize-pool';
 import type { Class } from 'type-fest';
 import { logger } from '../utils/logger.js';
+import { useMasterToUsePrimary } from '../utils/deprecations.js';
 
 const debug = logger.debugContext('pool');
 
@@ -49,6 +50,11 @@ export interface AcquireConnectionOptions {
    * Force the query to use the primary (write) pool, regardless of the query type.
    */
   usePrimary?: boolean;
+
+  /**
+   * @deprecated Use {@link usePrimary} instead.
+   */
+  useMaster?: boolean;
 }
 
 interface ReplicationPoolConfig<Connection extends object, ConnectionOptions extends object> {
@@ -157,6 +163,17 @@ export class ReplicationPool<Connection extends object, ConnectionOptions extend
 
   async acquire(options?: AcquireConnectionOptions | undefined) {
     options = options ? shallowClonePojo(options) : pojo();
+
+    // Deprecation bridge: useMaster -> usePrimary
+    if ('useMaster' in options) {
+      useMasterToUsePrimary();
+      if (options.usePrimary === undefined) {
+        options.usePrimary = options.useMaster;
+      }
+
+      delete options.useMaster;
+    }
+
     await this.#beforeAcquire?.(options);
     Object.freeze(options);
 

--- a/packages/core/src/abstract-dialect/replication-pool.ts
+++ b/packages/core/src/abstract-dialect/replication-pool.ts
@@ -164,7 +164,6 @@ export class ReplicationPool<Connection extends object, ConnectionOptions extend
   async acquire(options?: AcquireConnectionOptions | undefined) {
     options = options ? shallowClonePojo(options) : pojo();
 
-    // Deprecation bridge: useMaster -> usePrimary
     if ('useMaster' in options) {
       useMasterToUsePrimary();
       if (options.usePrimary === undefined) {

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -60,7 +60,7 @@ export interface Poolable {
   usePrimary?: boolean;
 
   /**
-   * @deprecated Use {@link usePrimary} instead.
+   * @deprecated Use {@link Poolable.usePrimary} instead.
    */
   useMaster?: boolean;
 }

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -58,6 +58,11 @@ export interface Poolable {
    * @default false
    */
   usePrimary?: boolean;
+
+  /**
+   * @deprecated Use {@link usePrimary} instead.
+   */
+  useMaster?: boolean;
 }
 
 export interface Transactionable {

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -53,11 +53,11 @@ export interface Logging {
 
 export interface Poolable {
   /**
-   * Force the query to use the write pool, regardless of the query type.
+   * Force the query to use the primary (write) pool, regardless of the query type.
    *
    * @default false
    */
-  useMaster?: boolean;
+  usePrimary?: boolean;
 }
 
 export interface Transactionable {

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -201,7 +201,7 @@ export class Sequelize extends SequelizeTypeScript {
    * @param {boolean}         [options.plain=false] Sets the query type to `SELECT` and return a single row
    * @param {object|Array}    [options.replacements] Either an object of named parameter replacements in the format `:param` or an array of unnamed replacements to replace `?` in your SQL.
    * @param {object|Array}    [options.bind] Either an object of named bind parameter in the format `_param` or an array of unnamed bind parameter to replace `$1, $2, ...` in your SQL.
-   * @param {boolean}         [options.useMaster=false] Force the query to use the write pool, regardless of the query type.
+   * @param {boolean}         [options.usePrimary=false] Force the query to use the primary (write) pool, regardless of the query type.
    * @param {Function}        [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {Model}           [options.instance] A sequelize model instance whose Model is to be used to build the query result
    * @param {ModelStatic<Model>}    [options.model] A sequelize model used to build the returned model instances
@@ -373,7 +373,7 @@ Use Sequelize#query if you wish to use replacements.`);
         : options.connection
           ? options.connection
           : await this.pool.acquire({
-              useMaster: options.useMaster,
+              usePrimary: options.usePrimary,
               type: options.type === 'SELECT' ? 'read' : 'write',
             });
 

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -366,9 +366,13 @@ Use Sequelize#query if you wish to use replacements.`);
 
     setTransactionFromCls(options, this);
 
-    // Emit deprecation warning for useMaster before entering the retry loop.
     if (Object.hasOwn(options, 'useMaster')) {
       useMasterToUsePrimary();
+      if (options.usePrimary === undefined) {
+        options.usePrimary = options.useMaster;
+      }
+
+      delete options.useMaster;
     }
 
     const retryOptions = { ...this.options.retry, ...options.retry };
@@ -381,7 +385,7 @@ Use Sequelize#query if you wish to use replacements.`);
         : options.connection
           ? options.connection
           : await this.pool.acquire({
-              usePrimary: options.usePrimary ?? (Object.hasOwn(options, 'useMaster') ? options.useMaster : undefined),
+              usePrimary: options.usePrimary,
               type: options.type === 'SELECT' ? 'read' : 'write',
             });
 

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -366,14 +366,9 @@ Use Sequelize#query if you wish to use replacements.`);
 
     setTransactionFromCls(options, this);
 
-    // Deprecation bridge: useMaster -> usePrimary
+    // Emit deprecation warning for useMaster before entering the retry loop.
     if (Object.hasOwn(options, 'useMaster')) {
       useMasterToUsePrimary();
-      if (options.usePrimary === undefined) {
-        options.usePrimary = options.useMaster;
-      }
-
-      delete options.useMaster;
     }
 
     const retryOptions = { ...this.options.retry, ...options.retry };
@@ -386,7 +381,7 @@ Use Sequelize#query if you wish to use replacements.`);
         : options.connection
           ? options.connection
           : await this.pool.acquire({
-              usePrimary: options.usePrimary,
+              usePrimary: options.usePrimary ?? (Object.hasOwn(options, 'useMaster') ? options.useMaster : undefined),
               type: options.type === 'SELECT' ? 'read' : 'write',
             });
 

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -202,6 +202,7 @@ export class Sequelize extends SequelizeTypeScript {
    * @param {object|Array}    [options.replacements] Either an object of named parameter replacements in the format `:param` or an array of unnamed replacements to replace `?` in your SQL.
    * @param {object|Array}    [options.bind] Either an object of named bind parameter in the format `_param` or an array of unnamed bind parameter to replace `$1, $2, ...` in your SQL.
    * @param {boolean}         [options.usePrimary=false] Force the query to use the primary (write) pool, regardless of the query type.
+   * @param {boolean}         [options.useMaster=false] Deprecated: Use options.usePrimary instead.
    * @param {Function}        [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {Model}           [options.instance] A sequelize model instance whose Model is to be used to build the query result
    * @param {ModelStatic<Model>}    [options.model] A sequelize model used to build the returned model instances
@@ -374,6 +375,7 @@ Use Sequelize#query if you wish to use replacements.`);
           ? options.connection
           : await this.pool.acquire({
               usePrimary: options.usePrimary,
+              useMaster: options.useMaster,
               type: options.type === 'SELECT' ? 'read' : 'write',
             });
 

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -374,8 +374,9 @@ Use Sequelize#query if you wish to use replacements.`);
         : options.connection
           ? options.connection
           : await this.pool.acquire({
-              usePrimary: options.usePrimary,
-              useMaster: options.useMaster,
+              usePrimary:
+                options.usePrimary ??
+                (Object.hasOwn(options, 'useMaster') ? options.useMaster : undefined),
               type: options.type === 'SELECT' ? 'read' : 'write',
             });
 

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -56,6 +56,7 @@ import {
   noSequelizeIsDefined,
   noSequelizeModel,
   noSequelizeRandom,
+  useMasterToUsePrimary,
 } from './utils/deprecations';
 import { isModelStatic, isSameInitialModel } from './utils/model-utils';
 import { injectReplacements, mapBindParameters } from './utils/sql';
@@ -364,6 +365,17 @@ Use Sequelize#query if you wish to use replacements.`);
     };
 
     setTransactionFromCls(options, this);
+
+    // Deprecation bridge: useMaster -> usePrimary
+    if (Object.hasOwn(options, 'useMaster')) {
+      useMasterToUsePrimary();
+      if (options.usePrimary === undefined) {
+        options.usePrimary = options.useMaster;
+      }
+
+      delete options.useMaster;
+    }
+
     const retryOptions = { ...this.options.retry, ...options.retry };
 
     return await retry(async () => {
@@ -374,9 +386,7 @@ Use Sequelize#query if you wish to use replacements.`);
         : options.connection
           ? options.connection
           : await this.pool.acquire({
-              usePrimary:
-                options.usePrimary ??
-                (Object.hasOwn(options, 'useMaster') ? options.useMaster : undefined),
+              usePrimary: options.usePrimary,
               type: options.type === 'SELECT' ? 'read' : 'write',
             });
 

--- a/packages/core/src/utils/deprecations.ts
+++ b/packages/core/src/utils/deprecations.ts
@@ -148,6 +148,6 @@ export const noSequelizeRandom = deprecate(
 
 export const useMasterToUsePrimary = deprecate(
   noop,
-  'The "useMaster" option has been renamed to "usePrimary". "useMaster" is deprecated and will be removed in a future release.',
+  'The "useMaster" option has been renamed to "usePrimary".',
   'SEQUELIZE0033',
 );

--- a/packages/core/src/utils/deprecations.ts
+++ b/packages/core/src/utils/deprecations.ts
@@ -145,3 +145,9 @@ export const noSequelizeRandom = deprecate(
   'Do not use sequelize.random(). Use sql.random instead, as it can be used without needing a reference to sequelize.',
   'SEQUELIZE0032',
 );
+
+export const useMasterToUsePrimary = deprecate(
+  noop,
+  'The "useMaster" option has been renamed to "usePrimary". "useMaster" is deprecated and will be removed in a future release.',
+  'SEQUELIZE0033',
+);

--- a/packages/core/test/types/model-count.ts
+++ b/packages/core/test/types/model-count.ts
@@ -18,6 +18,6 @@ expectTypeOf(
         [Op.gte]: new Date(),
       },
     },
-    useMaster: false,
+    usePrimary: false,
   }),
 ).toEqualTypeOf<Promise<number>>();

--- a/packages/core/test/unit/pool.test.ts
+++ b/packages/core/test/unit/pool.test.ts
@@ -195,7 +195,7 @@ describe('sequelize.pool', () => {
       const getConnection = async () => {
         return sequelize3.pool.acquire({
           type: 'read',
-          useMaster: false,
+          usePrimary: false,
         });
       };
 
@@ -258,7 +258,7 @@ describe('sequelize.pool', () => {
 
       await sequelize3.pool.acquire({
         type: 'read',
-        useMaster: true,
+        usePrimary: true,
       });
 
       expect(connectStub).to.have.been.calledOnce;


### PR DESCRIPTION
## Summary

Replaces the last remaining master/slave terminology in Sequelize replication pool API with primary/replica naming.

- Renames `useMaster` option to `usePrimary` across all interfaces (`AcquireConnectionOptions`, `GetConnectionOptions`, `Poolable`), implementation, JSDoc, and tests
- Updates associated JSDoc comments from "Force master or write replica" to "Force the query to use the primary (write) pool"
- Fixes a pre-existing DB2 bug where `showConstraintsQuery` returned referenced columns from unrelated constraints

### Files changed (7)

- `packages/core/src/abstract-dialect/replication-pool.ts` - interface + acquire() logic
- `packages/core/src/abstract-dialect/connection-manager.ts` - GetConnectionOptions interface
- `packages/core/src/model.d.ts` - Poolable interface
- `packages/core/src/sequelize.js` - JSDoc + query() method
- `packages/core/test/types/model-count.ts` - type test
- `packages/core/test/unit/pool.test.ts` - pool unit tests
- `packages/db2/src/query-generator-typescript.internal.ts` - fix incomplete JOIN in showConstraintsQuery

## Motivation

The database ecosystem has broadly moved away from master/slave terminology:

- **MySQL 8.0.23+** (2021): Renamed to SOURCE/REPLICA across SQL syntax and system variables
- **PostgreSQL**: Uses primary/standby/replica terminology
- **Django**: Completed this rename in PR #2694 (2014)
- **TypeORM**: Active discussion in issue #11949

Sequelize had already done most of this work -- the replication config uses read/write pool naming, and `slave` no longer appears anywhere in the codebase. The `useMaster` option was the last holdover.

## DB2 bug fix

Also fixes a pre-existing bug in the DB2 dialect's `showConstraintsQuery` (failing on `main` and other PRs like #18132). The `LEFT JOIN SYSCAT.KEYCOLUSE fk` for referenced columns was only matching on `CONSTNAME`, without qualifying by `TABNAME` and `TABSCHEMA`. This caused cross-contamination when multiple constraints shared the same internal name, resulting in incorrect `referencedColumnNames` (e.g. `["manager", "id"]` instead of `["id"]`).

## Breaking change note

This is a **breaking change** to the public API. If a deprecation period is preferred, I can add a `useMaster` alias that maps to `usePrimary` with a deprecation warning via `process.emitWarning()`.

## Test plan

- [ ] Existing unit tests updated and passing
- [ ] Grep confirms zero remaining instances of `useMaster` in codebase
- [ ] No changes to non-replication uses of "master" (MSSQL master database, GitHub URL refs)
- [ ] DB2 `removeColumn` constraint retention test passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public option `usePrimary` to force using the primary (write) pool.

* **Deprecated**
  * `useMaster` retained for backward compatibility, now emits a deprecation warning and is mapped to `usePrimary` when used.

* **Tests**
  * Updated tests and type usages to reference `usePrimary`.

* **Docs**
  * Query/option docs updated to document `usePrimary` and note deprecation of `useMaster`.

* **Chores**
  * Added a deprecation notice entry for the rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->