### PR TITLE
fix(postgres): populate fields, value and reltype in ForeignKeyConstraintError

### DIFF
--- a/packages/core/test/integration/error.test.ts
+++ b/packages/core/test/integration/error.test.ts
@@ -746,7 +746,8 @@ describe(getTestDialectTeaser('Sequelize Errors'), () => {
 
           case 'postgres':
             expect(error.table).to.equal('Users');
-            expect(error.fields).to.be.null;
+            expect(error.fields).to.deep.equal(['id']);
+            expect(error.reltype).to.equal('parent');
             expect(error.cause.message).to.equal(
               'update or delete on table "Users" violates foreign key constraint "Tasks_userId_Users_fk" on table "Tasks"',
             );
@@ -829,7 +830,8 @@ describe(getTestDialectTeaser('Sequelize Errors'), () => {
 
           case 'postgres':
             expect(error.table).to.equal('Tasks');
-            expect(error.fields).to.be.null;
+            expect(error.fields).to.deep.equal(['userId']);
+            expect(error.reltype).to.equal('child');
             expect(error.cause.message).to.equal(
               'insert or update on table "Tasks" violates foreign key constraint "Tasks_userId_Users_fk"',
             );

--- a/packages/postgres/src/query.js
+++ b/packages/postgres/src/query.js
@@ -338,19 +338,35 @@ export class PostgresQuery extends AbstractQuery {
     const errDetail = err.detail || err.messageDetail;
 
     switch (code) {
-      case '23503':
+      case '23503': {
         index = errMessage.match(/violates foreign key constraint "(.+?)"/);
         index = index ? index[1] : undefined;
         table = errMessage.match(/on table "(.+?)"/);
         table = table ? table[1] : undefined;
 
+        // errDetail format: Key (field)=(value) is not present in table "x".
+        //                or: Key (field)=(value) is still referenced from table "x".
+        const fkMatch = errDetail
+          ? errDetail.replaceAll('"', '').match(/Key \((.+?)\)=\((.+?)\)/)
+          : null;
+        const fkFields = fkMatch ? fkMatch[1].split(', ') : undefined;
+        const fkValues = fkMatch ? fkMatch[2].split(', ') : undefined;
+
+        // "insert or update on table" = child referencing missing parent
+        // "update or delete on table" = parent still referenced by children
+        const reltype = errMessage.includes('insert or update') ? 'child' : 'parent';
+
         return new ForeignKeyConstraintError({
           message: errMessage,
-          fields: null,
+          fields: fkFields,
+          value: fkValues,
           index,
           table,
+          reltype,
           cause: err,
         });
+      }
+
       case '23505':
         // there are multiple different formats of error messages for this error code
         // this regex should check at least two


### PR DESCRIPTION
## Summary

Closes #7826

The PostgreSQL dialect was hardcoding `fields: null` when constructing `ForeignKeyConstraintError`, even though `err.detail` contains the offending field names and values. This made it impossible for developers to build user-friendly error messages from FK constraint violations — a long-standing complaint on the issue.

**Before:**
```js
{ table: 'users', fields: null, value: undefined, reltype: undefined }
```

**After:**
```js
{ table: 'users', fields: ['user_id'], value: ['42'], reltype: 'child' }
```

## Changes

- `packages/postgres/src/query.js` — parse `err.detail` to extract FK field names and values via the `Key (field)=(value)` pattern already used for unique constraint errors (23505). Determine `reltype` from the error message (`insert or update` → child, `update or delete` → parent).
- `packages/core/test/integration/error.test.ts` — update postgres assertions to expect populated `fields` and `reltype`

## Test plan

- [ ] Integration tests for FK constraint errors (need a running PG instance, verified via CI)
- [x] ESLint passes
- [x] Prettier passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL foreign key constraint errors now provide enhanced diagnostics with richer error metadata. When constraint violations occur, error messages explicitly report the specific affected field names and constraint relationship type (parent or child relationships), providing clearer diagnostics to help identify and troubleshoot database integrity issues more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->