### PR TITLE
fix(core): clear expression defaults from bulkCreate instances without RETURNING

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2540,6 +2540,16 @@ ${associationOwner._getAssociationDebugList()}`);
             }
           }
         }
+
+        // #10966 - without RETURNING, expression defaults (literal, fn, etc.)
+        // stay as raw objects on the instance. Replace them with undefined.
+        for (const instance of instances) {
+          for (const key of Object.keys(instance.dataValues)) {
+            if (instance.dataValues[key] instanceof BaseSqlExpression) {
+              instance.dataValues[key] = undefined;
+            }
+          }
+        }
       }
 
       if (options.include && options.include.length > 0) {

--- a/packages/core/test/integration/model/bulk-create.test.js
+++ b/packages/core/test/integration/model/bulk-create.test.js
@@ -6,7 +6,7 @@ const {
   createMultiTransactionalTestSequelizeInstance,
   sequelize,
 } = require('../support');
-const { col, DataTypes, Op } = require('@sequelize/core');
+const { col, DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 const dialect = sequelize.dialect;
 const dialectName = dialect.name;
@@ -1314,6 +1314,33 @@ describe('Model', () => {
         });
       });
     }
+
+    it('should not return raw Literal objects for default values (#10966)', async function () {
+      const User = this.customSequelize.define('User', {
+        name: DataTypes.STRING,
+        code: { type: DataTypes.INTEGER, defaultValue: Sequelize.literal(2020) },
+      });
+
+      await User.sync({ force: true });
+
+      const users = await User.bulkCreate([{ name: 'Alice' }, { name: 'Bob' }]);
+
+      for (const user of users) {
+        expect(user.name).to.be.a('string');
+        if (dialect.supports.returnValues) {
+          expect(user.code).to.equal(2020);
+        } else {
+          // without RETURNING the literal can't be resolved, but it
+          // shouldn't stay as a raw expression object either
+          expect(user.code).not.to.be.an('object');
+        }
+      }
+
+      // the DB should always have the right value though
+      const stored = await User.findAll({ order: [['name', 'ASC']] });
+      expect(stored[0].code).to.equal(2020);
+      expect(stored[1].code).to.equal(2020);
+    });
 
     describe('enums', () => {
       it('correctly restores enum values', async function () {


### PR DESCRIPTION
## Problem

When a model attribute uses a SQL expression as its `defaultValue` (e.g. `Sequelize.literal(2020)`), `bulkCreate` leaves the raw expression object on the returned instances for dialects that don't support `RETURNING` (like MySQL).

Instead of getting the resolved value or `undefined`, callers see something like `Literal { val: '2020' }` — which isn't a usable JS value and breaks comparisons, serialization, etc.

## Solution

After the insert result mapping loop in `bulkCreate`, scan all instance `dataValues` and replace any remaining `BaseSqlExpression` objects with `undefined`. For dialects with `RETURNING` support (Postgres, newer SQLite), the real value is already set by the result mapper, so the cleanup loop is a no-op.

## Test plan

- Added integration test that checks returned instances don't contain raw Literal objects
- Verifies that dialects with RETURNING still resolve the value correctly
- Verifies the DB always stores the correct value regardless of dialect

Closes #10966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk create operations to properly handle default values set using SQL expressions. Expression-based defaults, such as Sequelize.literal, previously appeared as raw objects in returned instances. They now correctly evaluate and display their intended values, ensuring consistent behavior across all bulk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->