### PR TITLE
fix(core): Update return types for set and setAttributes methods

### DIFF
--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -3003,8 +3003,8 @@ export abstract class Model<
     key: K,
     value: TModelAttributes[K],
     options?: SetOptions,
-  ): Model<TModelAttributes, TCreationAttribues>;
-  set(keys: Partial<TModelAttributes>, options?: SetOptions): Model<TModelAttributes, TCreationAttribues>;
+  ): Model<TModelAttributes, TCreationAttributes>;
+  set(keys: Partial<TModelAttributes>, options?: SetOptions): Model<TModelAttributes, TCreationAttributes>;
 
   /**
    * Alias for {@link Model.set}.
@@ -3013,8 +3013,8 @@ export abstract class Model<
     key: K,
     value: TModelAttributes[K],
     options?: SetOptions,
-  ): Model<TModelAttributes, TCreationAttribues>;
-  setAttributes(keys: Partial<TModelAttributes>, options?: SetOptions): Model<TModelAttributes, TCreationAttribues>;
+  ): Model<TModelAttributes, TCreationAttributes>;
+  setAttributes(keys: Partial<TModelAttributes>, options?: SetOptions): Model<TModelAttributes, TCreationAttributes>;
 
   /**
    * If changed is called with a string it will return a boolean indicating whether the value of that key in


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This should fix #16594 

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Type definitions updated for Model methods: `set()` and `setAttributes()` now return a Model instance type instead of the previous this-type, which may affect existing TypeScript method-chaining patterns and require minor call-site adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->