### PR TITLE
feat: allow passing raw attribute objects into set/add association me…

### DIFF
--- a/packages/core/src/associations/belongs-to-many.ts
+++ b/packages/core/src/associations/belongs-to-many.ts
@@ -1,7 +1,8 @@
 import type { AllowIterable, RequiredBy } from '@sequelize/utils';
-import { EMPTY_ARRAY, EMPTY_OBJECT } from '@sequelize/utils';
+import { EMPTY_ARRAY, EMPTY_OBJECT, isIterable, isPlainObject } from '@sequelize/utils';
 import each from 'lodash/each';
 import isEqual from 'lodash/isEqual';
+import isObject from 'lodash/isObject';
 import omit from 'lodash/omit';
 import upperFirst from 'lodash/upperFirst';
 import type { WhereOptions } from '../abstract-dialect/where-sql-builder-types.js';
@@ -492,6 +493,7 @@ Add your own primary key to the through model, on different attributes than the 
         'remove',
         'removeMultiple',
         'create',
+        'createMany',
       ],
       {
         hasSingle: 'has',
@@ -641,16 +643,18 @@ Add your own primary key to the through model, on different attributes than the 
   }
 
   /**
-   * Set the associated models by passing an array of instances or their primary keys.
-   * Everything that it not in the passed array will be un-associated.
+   * Set the associated models by passing an array of instances, their primary keys, or raw
+   * attribute objects (which will be created automatically).
+   * Everything that is not in the passed array will be un-associated.
    *
    * @param sourceInstance source instance to associate new instances with
-   * @param newInstancesOrPrimaryKeys A single instance or primary key, or a mixed array of persisted instances or primary keys
+   * @param newInstancesOrPrimaryKeys A single instance, primary key, raw attribute object, or a
+   *   mixed array thereof
    * @param options Options passed to `through.findAll`, `bulkCreate`, `update` and `destroy`
    */
   async set(
     sourceInstance: SourceModel,
-    newInstancesOrPrimaryKeys: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
+    newInstancesOrPrimaryKeys: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]> | CreationAttributes<TargetModel>>,
     options: BelongsToManySetAssociationsMixinOptions<TargetModel> = {},
   ): Promise<void> {
     const sourceKey = this.sourceKey;
@@ -658,7 +662,33 @@ Add your own primary key to the through model, on different attributes than the 
     const foreignKey = this.foreignKey;
     const otherKey = this.otherKey;
 
-    const newInstances = this.toInstanceArray(newInstancesOrPrimaryKeys);
+    // Separate raw attribute objects from instances/PKs and create them first
+    const inputArray = isIterable(newInstancesOrPrimaryKeys) && isObject(newInstancesOrPrimaryKeys)
+      ? [...(newInstancesOrPrimaryKeys as Iterable<any>)]
+      : [newInstancesOrPrimaryKeys];
+    const rawObjects: CreationAttributes<TargetModel>[] = [];
+    const persistedOrPk: Array<TargetModel | Exclude<TargetModel[TargetKey], any[]>> = [];
+    for (const item of inputArray) {
+      if (isPlainObject(item) && !(item instanceof this.target)) {
+        rawObjects.push(item as CreationAttributes<TargetModel>);
+      } else {
+        persistedOrPk.push(item as TargetModel | Exclude<TargetModel[TargetKey], any[]>);
+      }
+    }
+
+    let createdInstances: TargetModel[] = [];
+    if (rawObjects.length > 0) {
+      if (this.scope) {
+        for (const raw of rawObjects) {
+          Object.assign(raw, this.scope);
+        }
+      }
+
+      createdInstances = await this.target.bulkCreate(rawObjects, options);
+    }
+
+    const mergedInput = [...createdInstances, ...persistedOrPk];
+    const newInstances = this.toInstanceArray(mergedInput);
 
     const where: WhereOptions = {
       [foreignKey]: sourceInstance.get(sourceKey),
@@ -674,12 +704,12 @@ Add your own primary key to the through model, on different attributes than the 
       rejectOnEmpty: false,
       include: this.scope
         ? [
-            {
-              association: this.fromThroughToTarget,
-              where: this.scope,
-              required: true,
-            },
-          ]
+          {
+            association: this.fromThroughToTarget,
+            where: this.scope,
+            required: true,
+          },
+        ]
         : EMPTY_ARRAY,
     });
 
@@ -713,19 +743,45 @@ Add your own primary key to the through model, on different attributes than the 
   }
 
   /**
-   * Associate one or several rows with source instance. It will not un-associate any already associated instance
-   * that may be missing from `newInstances`.
+   * Associate one or several rows with source instance. It will not un-associate any already
+   * associated instance that may be missing from `newInstances`.
    *
    * @param sourceInstance source instance to associate new instances with
-   * @param newInstancesOrPrimaryKeys A single instance or primary key, or a mixed array of persisted instances or primary keys
+   * @param newInstancesOrPrimaryKeys A single instance, primary key, raw attribute object, or a
+   *   mixed array thereof
    * @param options Options passed to `through.findAll`, `bulkCreate` and `update`
    */
   async add(
     sourceInstance: SourceModel,
-    newInstancesOrPrimaryKeys: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
+    newInstancesOrPrimaryKeys: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]> | CreationAttributes<TargetModel>>,
     options?: BelongsToManyAddAssociationsMixinOptions<TargetModel>,
   ): Promise<void> {
-    const newInstances = this.toInstanceArray(newInstancesOrPrimaryKeys);
+    // Separate raw attribute objects from instances/PKs and create them first
+    const inputArray = isIterable(newInstancesOrPrimaryKeys) && isObject(newInstancesOrPrimaryKeys)
+      ? [...(newInstancesOrPrimaryKeys as Iterable<any>)]
+      : [newInstancesOrPrimaryKeys];
+    const rawObjects: CreationAttributes<TargetModel>[] = [];
+    const persistedOrPk: Array<TargetModel | Exclude<TargetModel[TargetKey], any[]>> = [];
+    for (const item of inputArray) {
+      if (isPlainObject(item) && !(item instanceof this.target)) {
+        rawObjects.push(item as CreationAttributes<TargetModel>);
+      } else {
+        persistedOrPk.push(item as TargetModel | Exclude<TargetModel[TargetKey], any[]>);
+      }
+    }
+
+    let createdInstances: TargetModel[] = [];
+    if (rawObjects.length > 0) {
+      if (this.scope) {
+        for (const raw of rawObjects) {
+          Object.assign(raw, this.scope);
+        }
+      }
+
+      createdInstances = await this.target.bulkCreate(rawObjects, options);
+    }
+
+    const newInstances = this.toInstanceArray([...createdInstances, ...persistedOrPk]);
     if (newInstances.length === 0) {
       return;
     }
@@ -907,6 +963,42 @@ Add your own primary key to the through model, on different attributes than the 
     await this.add(sourceInstance, newAssociatedObject, omit(options, ['fields']));
 
     return newAssociatedObject;
+  }
+
+  /**
+   * Create multiple new instances of the associated model and associate them with this.
+   *
+   * @param sourceInstance source instance
+   * @param records array of attribute objects for the new target model instances
+   * @param options Options passed to bulkCreate and add
+   */
+  async createMany(
+    sourceInstance: SourceModel,
+    // @ts-expect-error -- {} is not always assignable to 'values', but Target.bulkCreate will enforce this, not us.
+    records: CreationAttributes<TargetModel>[],
+    options?: BelongsToManyCreateAssociationsMixinOptions<TargetModel>,
+  ): Promise<TargetModel[]> {
+    if (!Array.isArray(records) || records.length === 0) {
+      return [];
+    }
+
+    if (this.scope) {
+      for (const record of records) {
+        Object.assign(record, this.scope);
+        if ((options as { fields?: string[] })?.fields) {
+          (options as { fields?: string[] }).fields = [
+            ...((options as { fields?: string[] }).fields ?? []),
+            ...Object.keys(this.scope),
+          ];
+        }
+      }
+    }
+
+    const newAssociatedObjects = await this.target.bulkCreate(records, options);
+
+    await this.add(sourceInstance, newAssociatedObjects, omit(options ?? {}, ['fields']));
+
+    return newAssociatedObjects;
   }
 }
 
@@ -1091,13 +1183,13 @@ export interface BelongsToManyOptions<
    * The name of the inverse association, or an object for further association setup.
    */
   inverse?:
-    | string
-    | undefined
-    | {
-        as?: AssociationOptions<string>['as'];
-        scope?: MultiAssociationOptions<string>['scope'];
-        foreignKeyConstraints?: AssociationOptions<string>['foreignKeyConstraints'];
-      };
+  | string
+  | undefined
+  | {
+    as?: AssociationOptions<string>['as'];
+    scope?: MultiAssociationOptions<string>['scope'];
+    foreignKeyConstraints?: AssociationOptions<string>['foreignKeyConstraints'];
+  };
 
   // this is also present in AssociationOptions, but they have different JSDoc, keep both!
   /**
@@ -1224,9 +1316,9 @@ export type BelongsToManyGetAssociationsMixin<T extends Model> = (
  */
 export interface BelongsToManySetAssociationsMixinOptions<TargetModel extends Model>
   extends FindOptions<Attributes<TargetModel>>,
-    BulkCreateOptions<Attributes<TargetModel>>,
-    InstanceUpdateOptions<Attributes<TargetModel>>,
-    InstanceDestroyOptions {
+  BulkCreateOptions<Attributes<TargetModel>>,
+  InstanceUpdateOptions<Attributes<TargetModel>>,
+  InstanceDestroyOptions {
   /**
    * Additional attributes for the join table.
    */
@@ -1248,7 +1340,7 @@ export interface BelongsToManySetAssociationsMixinOptions<TargetModel extends Mo
  * @see Model.belongsToMany
  */
 export type BelongsToManySetAssociationsMixin<TModel extends Model, TModelPrimaryKey> = (
-  newAssociations?: Iterable<TModel | TModelPrimaryKey> | null,
+  newAssociations?: Iterable<TModel | TModelPrimaryKey | CreationAttributes<TModel>> | null,
   options?: BelongsToManySetAssociationsMixinOptions<TModel>,
 ) => Promise<void>;
 
@@ -1259,9 +1351,9 @@ export type BelongsToManySetAssociationsMixin<TModel extends Model, TModelPrimar
  */
 export interface BelongsToManyAddAssociationsMixinOptions<TModel extends Model>
   extends FindOptions<Attributes<TModel>>,
-    BulkCreateOptions<Attributes<TModel>>,
-    InstanceUpdateOptions<Attributes<TModel>>,
-    InstanceDestroyOptions {
+  BulkCreateOptions<Attributes<TModel>>,
+  InstanceUpdateOptions<Attributes<TModel>>,
+  InstanceDestroyOptions {
   through?: JoinTableAttributes;
 }
 
@@ -1280,7 +1372,7 @@ export interface BelongsToManyAddAssociationsMixinOptions<TModel extends Model>
  * @see Model.belongsToMany
  */
 export type BelongsToManyAddAssociationsMixin<T extends Model, TModelPrimaryKey> = (
-  newAssociations?: Iterable<T | TModelPrimaryKey>,
+  newAssociations?: Iterable<T | TModelPrimaryKey | CreationAttributes<T>>,
   options?: BelongsToManyAddAssociationsMixinOptions<T>,
 ) => Promise<void>;
 
@@ -1291,9 +1383,9 @@ export type BelongsToManyAddAssociationsMixin<T extends Model, TModelPrimaryKey>
  */
 export interface BelongsToManyAddAssociationMixinOptions<T extends Model>
   extends FindOptions<Attributes<T>>,
-    BulkCreateOptions<Attributes<T>>,
-    InstanceUpdateOptions<Attributes<T>>,
-    InstanceDestroyOptions {
+  BulkCreateOptions<Attributes<T>>,
+  InstanceUpdateOptions<Attributes<T>>,
+  InstanceDestroyOptions {
   through?: JoinTableAttributes;
 }
 
@@ -1345,11 +1437,42 @@ export type BelongsToManyCreateAssociationMixin<T extends Model> = (
 ) => Promise<T>;
 
 /**
+ * The options for the createAssociations mixin of the belongsToMany association.
+ *
+ * @see BelongsToManyCreateAssociationsMixin
+ */
+export interface BelongsToManyCreateAssociationsMixinOptions<T extends Model>
+  extends BulkCreateOptions<Attributes<T>> {
+  through?: JoinTableAttributes;
+}
+
+/**
+ * The createAssociations mixin applied to models with belongsToMany.
+ * Allows creating multiple associated instances at once.
+ *
+ * An example of usage is as follows:
+ *
+ * ```typescript
+ * class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+ *   declare createRoles: BelongsToManyCreateAssociationsMixin<Role>;
+ * }
+ *
+ * User.belongsToMany(Role, { through: UserRole });
+ * ```
+ *
+ * @see Model.belongsToMany
+ */
+export type BelongsToManyCreateAssociationsMixin<T extends Model> = (
+  records: Array<CreationAttributes<T>>,
+  options?: BelongsToManyCreateAssociationsMixinOptions<T>,
+) => Promise<T[]>;
+
+/**
  * The options for the removeAssociation mixin of the belongsToMany association.
  *
  * @see BelongsToManyRemoveAssociationMixin
  */
-export interface BelongsToManyRemoveAssociationMixinOptions extends InstanceDestroyOptions {}
+export interface BelongsToManyRemoveAssociationMixinOptions extends InstanceDestroyOptions { }
 
 /**
  * The removeAssociation mixin applied to models with belongsToMany.
@@ -1377,7 +1500,7 @@ export type BelongsToManyRemoveAssociationMixin<TModel, TModelPrimaryKey> = (
  */
 export interface BelongsToManyRemoveAssociationsMixinOptions
   extends InstanceDestroyOptions,
-    InstanceDestroyOptions {}
+  InstanceDestroyOptions { }
 
 /**
  * The removeAssociations mixin applied to models with belongsToMany.
@@ -1404,7 +1527,7 @@ export type BelongsToManyRemoveAssociationsMixin<TModel, TModelPrimaryKey> = (
  * @see BelongsToManyHasAssociationMixin
  */
 export interface BelongsToManyHasAssociationMixinOptions<T extends Model>
-  extends BelongsToManyGetAssociationsMixinOptions<T> {}
+  extends BelongsToManyGetAssociationsMixinOptions<T> { }
 
 /**
  * The hasAssociation mixin applied to models with belongsToMany.
@@ -1431,7 +1554,7 @@ export type BelongsToManyHasAssociationMixin<TModel extends Model, TModelPrimary
  * @see BelongsToManyHasAssociationsMixin
  */
 export interface BelongsToManyHasAssociationsMixinOptions<T extends Model>
-  extends BelongsToManyGetAssociationsMixinOptions<T> {}
+  extends BelongsToManyGetAssociationsMixinOptions<T> { }
 
 /**
  * The removeAssociations mixin applied to models with belongsToMany.
@@ -1459,7 +1582,7 @@ export type BelongsToManyHasAssociationsMixin<TModel extends Model, TModelPrimar
  */
 export interface BelongsToManyCountAssociationsMixinOptions<T extends Model>
   extends Transactionable,
-    Filterable<Attributes<T>> {
+  Filterable<Attributes<T>> {
   /**
    * Apply a scope on the related model, or remove its default scope by passing false.
    */

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -1,5 +1,5 @@
 import type { AllowIterable } from '@sequelize/utils';
-import { isPlainObject } from '@sequelize/utils';
+import { isIterable, isPlainObject } from '@sequelize/utils';
 import isObject from 'lodash/isObject';
 import upperFirst from 'lodash/upperFirst';
 import type { WhereOptions } from '../abstract-dialect/where-sql-builder-types.js';
@@ -9,6 +9,7 @@ import { fn } from '../expression-builders/fn.js';
 import type {
   AttributeNames,
   Attributes,
+  BulkCreateOptions,
   CreateOptions,
   CreationAttributes,
   DestroyOptions,
@@ -228,6 +229,7 @@ export class HasManyAssociation<
         'remove',
         'removeMultiple',
         'create',
+        'createMany',
       ],
       {
         hasSingle: 'has',
@@ -402,18 +404,45 @@ export class HasManyAssociation<
   }
 
   /**
-   * Set the associated models by passing an array of persisted instances or their primary keys. Everything that is not in the passed array will be un-associated
+   * Set the associated models by passing an array of persisted instances, their primary keys,
+   * or raw attribute objects (which will be created automatically). Everything that is not in
+   * the passed array will be un-associated.
    *
    * @param sourceInstance source instance to associate new instances with
-   * @param targets An array of persisted instances or primary key of instances to associate with this. Pass `null` to remove all associations.
-   * @param options Options passed to `target.findAll` and `update`.
+   * @param targets An array of persisted instances, primary keys, or raw attribute objects to
+   *   associate with this. Pass `null` to remove all associations.
+   * @param options Options passed to `target.findAll`, `bulkCreate`, and `update`.
    */
   async set(
     sourceInstance: S,
-    targets: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]>> | null,
+    targets: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]> | CreationAttributes<T>> | null,
     options?: HasManySetAssociationsMixinOptions<T>,
   ): Promise<void> {
-    const normalizedTargets = this.toInstanceArray(targets);
+    // Separate raw attribute objects from instances/PKs and create them first
+    const inputArray = targets == null ? [] : (isIterable(targets) && isObject(targets) ? [...(targets as Iterable<any>)] : [targets]);
+    const rawObjects: CreationAttributes<T>[] = [];
+    const persistedOrPk: Array<T | Exclude<T[TargetPrimaryKey], any[]>> = [];
+    for (const item of inputArray) {
+      if (isPlainObject(item) && !(item instanceof this.target)) {
+        rawObjects.push(item as CreationAttributes<T>);
+      } else {
+        persistedOrPk.push(item as T | Exclude<T[TargetPrimaryKey], any[]>);
+      }
+    }
+
+    let createdInstances: T[] = [];
+    if (rawObjects.length > 0) {
+      const valuesWithScope = rawObjects.map(raw => ({
+        ...raw,
+        ...this.scope,
+        [this.foreignKey]: sourceInstance.get(this.sourceKey),
+      })) as CreationAttributes<T>[];
+      createdInstances = await this.target.bulkCreate(valuesWithScope, options);
+    }
+
+    // Merge created instances back with the persisted/pk items
+    const mergedInput = [...createdInstances, ...persistedOrPk];
+    const normalizedTargets = this.toInstanceArray(mergedInput.length === 0 ? null : mergedInput);
 
     const oldAssociations = await this.get(sourceInstance, { ...options, scope: false, raw: true });
     const promises: Array<Promise<any>> = [];
@@ -466,21 +495,54 @@ export class HasManyAssociation<
   }
 
   /**
-   * Associate one or more target rows with `this`. This method accepts a Model / string / number to associate a single row,
-   * or a mixed array of Model / string / numbers to associate multiple rows.
+   * Associate one or more target rows with `this`. This method accepts a Model / string / number
+   * to associate a single row, a mixed array of Model / string / numbers, or raw attribute objects
+   * (which will be created automatically).
    *
    * @param sourceInstance the source instance
-   * @param [rawTargetInstances] A single instance or primary key, or a mixed array of persisted instances or primary keys
-   * @param [options] Options passed to `target.update`.
+   * @param [rawTargetInstances] A single instance, primary key, raw attribute object, or a mixed
+   *   array of persisted instances, primary keys, and raw attribute objects
+   * @param [options] Options passed to `target.bulkCreate` and `target.update`.
    */
   async add(
     sourceInstance: S,
-    rawTargetInstances: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]>>,
+    rawTargetInstances: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]> | CreationAttributes<T>>,
     options: HasManyAddAssociationsMixinOptions<T> = {},
   ): Promise<void> {
-    const targetInstances = this.toInstanceArray(rawTargetInstances);
+    // Separate raw attribute objects from instances/PKs and create them first
+    const inputArray = isIterable(rawTargetInstances) && isObject(rawTargetInstances)
+      ? [...(rawTargetInstances as Iterable<any>)]
+      : [rawTargetInstances];
+    const rawObjects: CreationAttributes<T>[] = [];
+    const persistedOrPk: Array<T | Exclude<T[TargetPrimaryKey], any[]>> = [];
+    for (const item of inputArray) {
+      if (isPlainObject(item) && !(item instanceof this.target)) {
+        rawObjects.push(item as CreationAttributes<T>);
+      } else {
+        persistedOrPk.push(item as T | Exclude<T[TargetPrimaryKey], any[]>);
+      }
+    }
+
+    let createdInstances: T[] = [];
+    if (rawObjects.length > 0) {
+      const valuesWithScope = rawObjects.map(raw => ({
+        ...raw,
+        ...this.scope,
+        [this.foreignKey]: sourceInstance.get(this.sourceKey),
+      })) as CreationAttributes<T>[];
+      createdInstances = await this.target.bulkCreate(valuesWithScope, options);
+    }
+
+    // Merge and associate all persisted items via the usual update path
+    const targetInstances = this.toInstanceArray([...createdInstances, ...persistedOrPk]);
 
     if (targetInstances.length === 0) {
+      return;
+    }
+
+    // Only issue the FK update for items that already existed (not the newly created ones which already have the FK set)
+    const existingInstances = targetInstances.filter(inst => !createdInstances.includes(inst));
+    if (existingInstances.length === 0) {
       return;
     }
 
@@ -491,7 +553,7 @@ export class HasManyAssociation<
 
     const where = {
       // @ts-expect-error -- TODO: what if the target has no primary key?
-      [this.target.primaryKeyAttribute]: targetInstances.map(unassociatedObject => {
+      [this.target.primaryKeyAttribute]: existingInstances.map(unassociatedObject => {
         // @ts-expect-error -- TODO: what if the target has no primary key?
         return unassociatedObject.get(this.target.primaryKeyAttribute);
       }),
@@ -605,6 +667,41 @@ export class HasManyAssociation<
       options,
     );
   }
+
+  /**
+   * Create multiple new instances of the associated model and associate them with this.
+   *
+   * @param sourceInstance source instance
+   * @param records array of attribute objects for the new target model instances
+   * @param options Options passed to `target.bulkCreate`
+   */
+  async createMany(
+    sourceInstance: S,
+    // @ts-expect-error -- {} is not always assignable to 'values', but Target.bulkCreate will enforce this, not us.
+    records: CreationAttributes<T>[],
+    options?: HasManyCreateAssociationsMixinOptions<T>,
+  ): Promise<T[]> {
+    if (!Array.isArray(records) || records.length === 0) {
+      return [];
+    }
+
+    const valuesWithScope = records.map(record => {
+      const values = { ...record };
+      if (this.scope) {
+        for (const attribute of Object.keys(this.scope)) {
+          // @ts-expect-error -- TODO: fix the typing of {@link AssociationScope}
+          values[attribute] = this.scope[attribute];
+        }
+      }
+
+      return {
+        ...values,
+        [this.foreignKey]: sourceInstance.get(this.sourceKey),
+      };
+    }) as CreationAttributes<T>[];
+
+    return this.target.bulkCreate(valuesWithScope, options);
+  }
 }
 
 // workaround https://github.com/evanw/esbuild/issues/1260
@@ -634,12 +731,12 @@ export interface HasManyOptions<SourceKey extends string, TargetKey extends stri
    * The name of the inverse association, or an object for further association setup.
    */
   inverse?:
-    | string
-    | undefined
-    | {
-        as?: AssociationOptions<any>['as'];
-        scope?: AssociationOptions<any>['scope'];
-      };
+  | string
+  | undefined
+  | {
+    as?: AssociationOptions<any>['as'];
+    scope?: AssociationOptions<any>['scope'];
+  };
 }
 
 function normalizeHasManyOptions<SourceKey extends string, TargetKey extends string>(
@@ -705,7 +802,7 @@ export type HasManyGetAssociationsMixin<T extends Model> = (
  */
 export interface HasManySetAssociationsMixinOptions<T extends Model>
   extends FindOptions<Attributes<T>>,
-    InstanceUpdateOptions<Attributes<T>> {
+  InstanceUpdateOptions<Attributes<T>> {
   /**
    * Delete the previous associated model. Default to false.
    *
@@ -713,9 +810,9 @@ export interface HasManySetAssociationsMixinOptions<T extends Model>
    * the previous associated model is always deleted.
    */
   destroyPrevious?:
-    | boolean
-    | Omit<DestroyOptions<Attributes<T>>, 'where' | 'transaction' | 'logging' | 'benchmark'>
-    | undefined;
+  | boolean
+  | Omit<DestroyOptions<Attributes<T>>, 'where' | 'transaction' | 'logging' | 'benchmark'>
+  | undefined;
 }
 
 /**
@@ -733,7 +830,7 @@ export interface HasManySetAssociationsMixinOptions<T extends Model>
  * @see Model.hasMany
  */
 export type HasManySetAssociationsMixin<T extends Model, TModelPrimaryKey> = (
-  newAssociations?: Iterable<T | TModelPrimaryKey> | null,
+  newAssociations?: Iterable<T | TModelPrimaryKey | CreationAttributes<T>> | null,
   options?: HasManySetAssociationsMixinOptions<T>,
 ) => Promise<void>;
 
@@ -743,7 +840,7 @@ export type HasManySetAssociationsMixin<T extends Model, TModelPrimaryKey> = (
  * @see HasManyAddAssociationsMixin
  */
 export interface HasManyAddAssociationsMixinOptions<T extends Model>
-  extends InstanceUpdateOptions<Attributes<T>> {}
+  extends InstanceUpdateOptions<Attributes<T>> { }
 
 /**
  * The addAssociations mixin applied to models with hasMany.
@@ -760,7 +857,7 @@ export interface HasManyAddAssociationsMixinOptions<T extends Model>
  * @see Model.hasMany
  */
 export type HasManyAddAssociationsMixin<T extends Model, TModelPrimaryKey> = (
-  newAssociations?: Iterable<T | TModelPrimaryKey>,
+  newAssociations?: Iterable<T | TModelPrimaryKey | CreationAttributes<T>>,
   options?: HasManyAddAssociationsMixinOptions<T>,
 ) => Promise<void>;
 
@@ -770,7 +867,7 @@ export type HasManyAddAssociationsMixin<T extends Model, TModelPrimaryKey> = (
  * @see HasManyAddAssociationMixin
  */
 export interface HasManyAddAssociationMixinOptions<T extends Model>
-  extends HasManyAddAssociationsMixinOptions<T> {}
+  extends HasManyAddAssociationsMixinOptions<T> { }
 
 /**
  * The addAssociation mixin applied to models with hasMany.
@@ -797,7 +894,7 @@ export type HasManyAddAssociationMixin<T extends Model, TModelPrimaryKey> = (
  * @see HasManyCreateAssociationMixin
  */
 export interface HasManyCreateAssociationMixinOptions<T extends Model>
-  extends CreateOptions<Attributes<T>> {}
+  extends CreateOptions<Attributes<T>> { }
 
 /**
  * The createAssociation mixin applied to models with hasMany.
@@ -822,12 +919,44 @@ export type HasManyCreateAssociationMixin<
 ) => Promise<Target>;
 
 /**
+ * The options for the createAssociations mixin of the hasMany association.
+ *
+ * @see HasManyCreateAssociationsMixin
+ */
+export interface HasManyCreateAssociationsMixinOptions<T extends Model>
+  extends BulkCreateOptions<Attributes<T>> { }
+
+/**
+ * The createAssociations mixin applied to models with hasMany.
+ * Allows creating multiple associated instances at once.
+ *
+ * An example of usage is as follows:
+ *
+ * ```typescript
+ * class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+ *   declare createRoles: HasManyCreateAssociationsMixin<Role>;
+ * }
+ *
+ * User.hasMany(Role);
+ * ```
+ *
+ * @see Model.hasMany
+ */
+export type HasManyCreateAssociationsMixin<
+  Target extends Model,
+  ExcludedAttributes extends keyof CreationAttributes<Target> = never,
+> = (
+  records: Array<Omit<CreationAttributes<Target>, ExcludedAttributes>>,
+  options?: HasManyCreateAssociationsMixinOptions<Target>,
+) => Promise<Target[]>;
+
+/**
  * The options for the removeAssociation mixin of the hasMany association.
  *
  * @see HasManyRemoveAssociationMixin
  */
 export interface HasManyRemoveAssociationMixinOptions<T extends Model>
-  extends HasManyRemoveAssociationsMixinOptions<T> {}
+  extends HasManyRemoveAssociationsMixinOptions<T> { }
 
 /**
  * The removeAssociation mixin applied to models with hasMany.
@@ -862,9 +991,9 @@ export interface HasManyRemoveAssociationsMixinOptions<T extends Model>
    * the associated model is always deleted.
    */
   destroy?:
-    | boolean
-    | Omit<DestroyOptions<Attributes<T>>, 'where' | 'transaction' | 'logging' | 'benchmark'>
-    | undefined;
+  | boolean
+  | Omit<DestroyOptions<Attributes<T>>, 'where' | 'transaction' | 'logging' | 'benchmark'>
+  | undefined;
 }
 
 /**
@@ -892,7 +1021,7 @@ export type HasManyRemoveAssociationsMixin<T extends Model, TModelPrimaryKey> = 
  * @see HasManyHasAssociationMixin
  */
 export interface HasManyHasAssociationMixinOptions<T extends Model>
-  extends HasManyGetAssociationsMixinOptions<T> {}
+  extends HasManyGetAssociationsMixinOptions<T> { }
 
 /**
  * The hasAssociation mixin applied to models with hasMany.
@@ -919,7 +1048,7 @@ export type HasManyHasAssociationMixin<TModel extends Model, TModelPrimaryKey> =
  * @see HasManyHasAssociationsMixin
  */
 export interface HasManyHasAssociationsMixinOptions<T extends Model>
-  extends HasManyGetAssociationsMixinOptions<T> {}
+  extends HasManyGetAssociationsMixinOptions<T> { }
 
 /**
  * The removeAssociations mixin applied to models with hasMany.
@@ -950,7 +1079,7 @@ export type HasManyHasAssociationsMixin<TModel extends Model, TModelPrimaryKey> 
  */
 export interface HasManyCountAssociationsMixinOptions<T extends Model>
   extends Transactionable,
-    Filterable<Attributes<T>> {
+  Filterable<Attributes<T>> {
   /**
    * Apply a scope on the related model, or remove its default scope by passing false.
    */

--- a/packages/core/test/integration/associations/belongs-to-many-mixins.test.ts
+++ b/packages/core/test/integration/associations/belongs-to-many-mixins.test.ts
@@ -2,6 +2,7 @@ import type {
   BelongsToManyAddAssociationsMixin,
   BelongsToManyCountAssociationsMixin,
   BelongsToManyCreateAssociationMixin,
+  BelongsToManyCreateAssociationsMixin,
   BelongsToManyGetAssociationsMixin,
   BelongsToManyHasAssociationsMixin,
   BelongsToManyRemoveAssociationsMixin,
@@ -30,6 +31,7 @@ describe('belongsToMany Mixins', () => {
       declare addAuthors: BelongsToManyAddAssociationsMixin<User, User['id']>;
       declare removeAuthors: BelongsToManyRemoveAssociationsMixin<User, User['id']>;
       declare createAuthor: BelongsToManyCreateAssociationMixin<User>;
+      declare createAuthors: BelongsToManyCreateAssociationsMixin<User>;
       declare hasAuthors: BelongsToManyHasAssociationsMixin<User, User['id']>;
       declare countAuthors: BelongsToManyCountAssociationsMixin<User>;
     }
@@ -235,6 +237,63 @@ describe('belongsToMany Mixins', () => {
       await article.setAuthors([user]);
 
       expect(await article.hasAuthors([user.id])).to.be.true;
+    });
+  });
+
+  describe('setAssociations with raw objects', () => {
+    it('creates and associates raw attribute objects', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      await article.setAuthors([{}] as any);
+
+      expect(await article.getAuthors()).to.have.length(1);
+    });
+
+    it('mixes instances and raw objects', async () => {
+      const { User, Article } = vars;
+
+      const article = await Article.create();
+      const existing = await User.create();
+
+      await article.setAuthors([existing, {}] as any);
+
+      expect(await article.getAuthors()).to.have.length(2);
+    });
+  });
+
+  describe('addAssociations with raw objects', () => {
+    it('creates and associates raw attribute objects', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      await article.addAuthors([{}, {}] as any);
+
+      expect(await article.getAuthors()).to.have.length(2);
+    });
+  });
+
+  describe('createManyAssociations', () => {
+    it('creates multiple associated instances at once', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      const created = await article.createAuthors([{}, {}] as any);
+
+      expect(created).to.have.length(2);
+      expect(await article.getAuthors()).to.have.length(2);
+    });
+
+    it('returns an empty array when given an empty records list', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      const created = await article.createAuthors([] as any);
+      expect(created).to.be.an('array').that.is.empty;
     });
   });
 });

--- a/packages/core/test/integration/associations/has-many-mixins.test.ts
+++ b/packages/core/test/integration/associations/has-many-mixins.test.ts
@@ -1,6 +1,8 @@
 import type {
   CreationOptional,
   HasManyAddAssociationsMixin,
+  HasManyCreateAssociationsMixin,
+  HasManyGetAssociationsMixin,
   HasManyHasAssociationsMixin,
   HasManyRemoveAssociationsMixin,
   HasManySetAssociationsMixin,
@@ -33,6 +35,8 @@ describe('hasMany Mixins', () => {
       declare removeLabels: HasManyRemoveAssociationsMixin<Label, Label['id']>;
       declare hasLabels: HasManyHasAssociationsMixin<Label, Label['id']>;
       declare addLabels: HasManyAddAssociationsMixin<Label, Label['id']>;
+      declare getLabels: HasManyGetAssociationsMixin<Label>;
+      declare createLabels: HasManyCreateAssociationsMixin<Label>;
 
       @HasMany(() => NonNullLabel, 'articleId')
       declare nonNullLabels?: NonNullLabel[];
@@ -302,7 +306,82 @@ describe('hasMany Mixins', () => {
       expect(await article.hasLabels([label.id])).to.equal(true);
     });
   });
+
+  describe('setAssociations with raw objects', () => {
+    it('creates and associates raw attribute objects', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      await article.setLabels([{}, {}] as any);
+
+      const labels = await article.getLabels!();
+      expect(labels).to.have.length(2);
+      for (const label of labels) {
+        expect(label.articleId).to.equal(article.id);
+      }
+    });
+
+    it('mixes instances and raw objects', async () => {
+      const { Label, Article } = vars;
+
+      const article = await Article.create();
+      const existing = await Label.create();
+
+      await article.setLabels([existing, {}] as any);
+
+      const labels = await article.getLabels!();
+      expect(labels).to.have.length(2);
+      for (const label of labels) {
+        expect(label.articleId).to.equal(article.id);
+      }
+    });
+  });
+
+  describe('addAssociations with raw objects', () => {
+    it('creates and associates raw attribute objects', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      await article.addLabels([{}, {}] as any);
+
+      const labels = await article.getLabels!();
+      expect(labels).to.have.length(2);
+      for (const label of labels) {
+        expect(label.articleId).to.equal(article.id);
+      }
+    });
+  });
+
+  describe('createManyAssociations', () => {
+    it('creates multiple associated instances at once', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      const created = await article.createLabels!([{}, {}] as any);
+
+      expect(created).to.have.length(2);
+      for (const label of created) {
+        expect(label.articleId).to.equal(article.id);
+      }
+
+      const fetched = await article.getLabels!();
+      expect(fetched).to.have.length(2);
+    });
+
+    it('returns an empty array when given an empty records list', async () => {
+      const { Article } = vars;
+
+      const article = await Article.create();
+
+      const created = await article.createLabels!([] as any);
+      expect(created).to.be.an('array').that.is.empty;
+    });
+  });
 });
+
 
 describe('hasMany Mixins + transaction', () => {
   if (!dialect.supports.transactions) {


### PR DESCRIPTION
# feat: allow passing raw attribute objects into set/add association methods (#10397)

## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Closes #10397

Previously, `set` and `add` association mixins on `HasMany` and `BelongsToMany` only accepted persisted model instances or primary key values. If you had a raw array of attribute objects (e.g. from a POST body), you had to loop manually and call `createXxx()` on each item.

This PR allows raw attribute objects (plain JS objects that are not model instances) to be passed directly into `set`, `add`, and a new `createMany` mixin — Sequelize handles the loop and bulk insertion automatically.

### Changes

#### `HasMany`

- **`set(sourceInstance, targets, options?)`** — now also accepts `CreationAttributes<T>` objects in the iterable. Plain objects are detected via `isPlainObject`, bulk-created with the FK and scope pre-applied via `bulkCreate`, then merged with any persisted instances/PKs before the standard diff-and-update flow.
- **`add(sourceInstance, targets, options?)`** — same raw-object detection. Newly created instances already have their FK set, so the subsequent FK `UPDATE` is skipped for them (only issued for pre-existing persisted instances).
- **`createMany(sourceInstance, records, options?)`** — new method. Accepts `CreationAttributes<T>[]`, applies scope + FK to each record, and calls `target.bulkCreate(...)`. Returns `Promise<T[]>`.

#### `BelongsToMany`

- **`set()`** and **`add()`** — same raw-object support. Plain objects are `bulkCreate`d on the target model; resulting instances go through `#updateAssociations` to wire up the junction table.
- **`createMany(sourceInstance, records, options?)`** — new method. Bulk-creates target rows, then calls `this.add(sourceInstance, newInstances)` to create the junction table rows. Returns `Promise<T[]>`.

#### TypeScript

New exported types:

| Type | Description |
|------|-------------|
| `HasManyCreateAssociationsMixin<T, ExcludedAttrs?>` | Mixin type for `createMany` on HasMany |
| `HasManyCreateAssociationsMixinOptions<T>` | Options type (extends `BulkCreateOptions`) |
| `BelongsToManyCreateAssociationsMixin<T>` | Mixin type for `createMany` on BelongsToMany |
| `BelongsToManyCreateAssociationsMixinOptions<T>` | Options type (extends `BulkCreateOptions`) |

Updated type signatures to accept `CreationAttributes<T>` in the input union:
- `HasManySetAssociationsMixin`
- `HasManyAddAssociationsMixin`
- `BelongsToManySetAssociationsMixin`
- `BelongsToManyAddAssociationsMixin`

### Usage

```typescript
// Instead of:
for (const img of req.body.ProductImages) {
  await product.createProductImage(img);
}

// Now you can do:
await product.setProductImages(req.body.ProductImages);  // replaces all
await product.addProductImages(req.body.ProductImages);  // appends
const images = await product.createProductImages(req.body.ProductImages); // bulk create + associate
```

Works the same for `BelongsToMany`:

```typescript
await article.setAuthors([{ name: 'Alice' }, { name: 'Bob' }]);
await article.addAuthors([{ name: 'Carol' }]);
const authors = await article.createAuthors([{ name: 'Dave' }, { name: 'Eve' }]);
```

Mixed arrays (instances + PKs + raw objects) are also supported:

```typescript
await product.setProductImages([existingImage, existingImage.id, { image: 'new.jpg' }]);
```

### Tests

Integration tests added to:
- `packages/core/test/integration/associations/has-many-mixins.test.ts`
- `packages/core/test/integration/associations/belongs-to-many-mixins.test.ts`

Covering:
- `setAssociations` with raw attribute objects
- `setAssociations` with mixed instances + raw objects
- `addAssociations` with raw attribute objects
- `createManyAssociations` — bulk create and verify FK association
- `createManyAssociations` — empty array early exit

## List of Breaking Changes

None. All changes are fully backwards compatible:
- Existing calls using instances or primary keys work exactly as before.
- New plain-object detection only triggers when `isPlainObject(item) && !(item instanceof TargetModel)` — i.e. strictly for raw attribute objects.
