### PR TITLE
feat(core): add @EncryptedAttribute decorator for transparent column encryption

### DIFF
--- a/packages/core/src/decorators/legacy/encrypted-attribute.ts
+++ b/packages/core/src/decorators/legacy/encrypted-attribute.ts
@@ -1,10 +1,10 @@
 import crypto from 'node:crypto';
-import type { BlobLength, DataType } from '../../abstract-dialect/data-types.js';
 import { isDataType } from '../../abstract-dialect/data-types-utils.js';
+import type { BlobLength, DataType } from '../../abstract-dialect/data-types.js';
 import { AbstractDataType, DataTypeIdentifier } from '../../abstract-dialect/data-types.js';
 import * as DataTypes from '../../data-types.js';
-import { Model } from '../../model.js';
 import type { ModelStatic } from '../../model.js';
+import { Model } from '../../model.js';
 import { registerModelAttributeOptions } from '../shared/model.js';
 import type { PropertyOrGetterDescriptor } from './decorator-utils.js';
 import {
@@ -111,8 +111,8 @@ export const Aes256GcmStrategy: CipherStrategy = Object.freeze({
   decrypt(packed: Buffer, key: Buffer): Buffer {
     if (packed[0] !== CIPHERTEXT_FORMAT_VERSION) {
       throw new Error(
-        `@EncryptedAttribute: unsupported ciphertext format version ${packed[0]}. `
-        + `Expected ${CIPHERTEXT_FORMAT_VERSION}.`,
+        `@EncryptedAttribute: unsupported ciphertext format version ${packed[0]}. ` +
+          `Expected ${CIPHERTEXT_FORMAT_VERSION}.`,
       );
     }
 
@@ -158,8 +158,8 @@ export const Aes256CbcStrategy: CipherStrategy = Object.freeze({
   decrypt(packed: Buffer, key: Buffer): Buffer {
     if (packed[0] !== CIPHERTEXT_FORMAT_VERSION) {
       throw new Error(
-        `@EncryptedAttribute: unsupported ciphertext format version ${packed[0]}. `
-        + `Expected ${CIPHERTEXT_FORMAT_VERSION}.`,
+        `@EncryptedAttribute: unsupported ciphertext format version ${packed[0]}. ` +
+          `Expected ${CIPHERTEXT_FORMAT_VERSION}.`,
       );
     }
 
@@ -178,7 +178,11 @@ export const Aes256CbcStrategy: CipherStrategy = Object.freeze({
 // Serialisation helpers
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Serialises an arbitrary JS value to a Buffer for encryption. */
+/**
+ * Serialises an arbitrary JS value to a Buffer for encryption.
+ *
+ * @param value The value to serialise.
+ */
 function serialise(value: unknown): Buffer {
   if (value instanceof Buffer) {
     return value;
@@ -210,13 +214,28 @@ function serialise(value: unknown): Buffer {
 type Deserialiser = (raw: Buffer) => unknown;
 
 const STRING_TYPES = new Set([
-  'STRING', 'TEXT', 'UUID', 'UUIDV1', 'UUIDV4',
-  'CHAR', 'INET', 'CIDR', 'MACADDR', 'MACADDR8', 'ENUM',
+  'STRING',
+  'TEXT',
+  'UUID',
+  'UUIDV1',
+  'UUIDV4',
+  'CHAR',
+  'INET',
+  'CIDR',
+  'MACADDR',
+  'MACADDR8',
+  'ENUM',
 ]);
 
 const NUMERIC_TYPES = new Set([
-  'INTEGER', 'SMALLINT', 'TINYINT', 'MEDIUMINT',
-  'FLOAT', 'DOUBLE', 'DECIMAL', 'REAL',
+  'INTEGER',
+  'SMALLINT',
+  'TINYINT',
+  'MEDIUMINT',
+  'FLOAT',
+  'DOUBLE',
+  'DECIMAL',
+  'REAL',
 ]);
 
 function resolveDeserialiser(logicalType: string): Deserialiser {
@@ -263,12 +282,14 @@ function resolveDeserialiser(logicalType: string): Deserialiser {
  * Works with:
  * - Invokable (Proxy-wrapped) class references, e.g. `DataTypes.STRING`
  * - Instances, e.g. `DataTypes.STRING(255)` / `new DataTypes.STRING()`
+ *
+ * @param type The DataType class or instance to identify.
  */
 function getDataTypeId(type: unknown): string {
   if (!isDataType(type)) {
     throw new TypeError(
-      `@EncryptedAttribute: "type" must be a Sequelize DataType class or instance. `
-      + `Received: ${String(type)}`,
+      `@EncryptedAttribute: "type" must be a Sequelize DataType class or instance. ` +
+        `Received: ${String(type)}`,
     );
   }
 
@@ -344,8 +365,8 @@ function normaliseKey(key: Buffer | string): Buffer {
   if (Buffer.isBuffer(key)) {
     if (key.length !== 32) {
       throw new Error(
-        `@EncryptedAttribute: key must be exactly 32 bytes (256 bits) for AES-256. `
-        + `Received ${key.length} bytes.`,
+        `@EncryptedAttribute: key must be exactly 32 bytes (256 bits) for AES-256. ` +
+          `Received ${key.length} bytes.`,
       );
     }
 
@@ -359,8 +380,8 @@ function normaliseKey(key: Buffer | string): Buffer {
     }
 
     throw new Error(
-      '@EncryptedAttribute: when key is a string, it must be a 64-character hex-encoded '
-      + `string (representing 32 bytes). Received ${key.length} characters.`,
+      '@EncryptedAttribute: when key is a string, it must be a 64-character hex-encoded ' +
+        `string (representing 32 bytes). Received ${key.length} characters.`,
     );
   }
 
@@ -404,9 +425,7 @@ function normaliseKey(key: Buffer | string): Buffer {
  *
  * @param options - Configuration for the encrypted attribute.
  */
-export function EncryptedAttribute(
-  options: EncryptedAttributeOptions,
-): PropertyOrGetterDescriptor {
+export function EncryptedAttribute(options: EncryptedAttributeOptions): PropertyOrGetterDescriptor {
   const strategy = options.strategy ?? Aes256GcmStrategy;
   const keyBuf = normaliseKey(options.key);
   const blobLength = options.blobLength ?? 'long';

--- a/packages/core/src/decorators/legacy/encrypted-attribute.ts
+++ b/packages/core/src/decorators/legacy/encrypted-attribute.ts
@@ -1,0 +1,485 @@
+import crypto from 'node:crypto';
+import type { BlobLength, DataType } from '../../abstract-dialect/data-types.js';
+import { isDataType } from '../../abstract-dialect/data-types-utils.js';
+import { AbstractDataType, DataTypeIdentifier } from '../../abstract-dialect/data-types.js';
+import * as DataTypes from '../../data-types.js';
+import { Model } from '../../model.js';
+import type { ModelStatic } from '../../model.js';
+import { registerModelAttributeOptions } from '../shared/model.js';
+import type { PropertyOrGetterDescriptor } from './decorator-utils.js';
+import {
+  throwMustBeAttribute,
+  throwMustBeInstanceProperty,
+  throwMustBeModel,
+} from './decorator-utils.js';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Cipher Strategy
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Represents the result of an encryption operation.
+ * The strategy is responsible for packing all metadata (IV, authTag, etc.)
+ * into the returned Buffer so that {@link CipherStrategy.decrypt} can unpack it.
+ */
+export interface EncryptionResult {
+  /** The fully-packed ciphertext (version + iv + ciphertext + tag, etc.) */
+  data: Buffer;
+}
+
+/**
+ * A pluggable encryption strategy.
+ *
+ * Sequelize ships with {@link Aes256GcmStrategy} and {@link Aes256CbcStrategy},
+ * but consumers can implement their own by satisfying this interface.
+ *
+ * @example
+ * ```ts
+ * const myStrategy: CipherStrategy = {
+ *   encrypt(plaintext, key) { ... },
+ *   decrypt(packed, key) { ... },
+ *   get deterministic() { return false; },
+ * };
+ * ```
+ */
+export interface CipherStrategy {
+  /**
+   * Encrypts *plaintext* using *key*.
+   * The implementation **must** generate a unique random IV per call and pack
+   * it into the returned buffer so that {@link decrypt} can recover it.
+   */
+  encrypt(plaintext: Buffer, key: Buffer): EncryptionResult;
+
+  /**
+   * Decrypts the packed buffer previously returned by {@link encrypt}.
+   */
+  decrypt(packed: Buffer, key: Buffer): Buffer;
+
+  /**
+   * Whether this strategy produces deterministic ciphertext for the same
+   * plaintext + key combination.
+   *
+   * When `true`, the decorator will support equality lookups in `where`
+   * clauses by encrypting the search value and comparing ciphertexts.
+   *
+   * **Security note:** Deterministic encryption leaks whether two rows
+   * contain the same plaintext.  Use only when equality search is required
+   * and you understand the trade-off.
+   *
+   * Built-in strategies are always **non-deterministic** (`false`).
+   */
+  readonly deterministic: boolean;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Built-in strategies
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Version byte prefixed to every packed ciphertext so the format can evolve
+ * without breaking existing data.
+ */
+const CIPHERTEXT_FORMAT_VERSION = 0x01;
+
+/**
+ * AES-256-GCM with a random 12-byte IV and 16-byte authentication tag.
+ *
+ * Packed format (total overhead: 29 bytes):
+ * ```
+ * [1 B version][12 B IV][N B ciphertext][16 B authTag]
+ * ```
+ *
+ * This is the recommended default strategy.
+ */
+export const Aes256GcmStrategy: CipherStrategy = Object.freeze({
+  encrypt(plaintext: Buffer, key: Buffer): EncryptionResult {
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag(); // 16 bytes
+
+    const packed = Buffer.allocUnsafe(1 + 12 + encrypted.length + 16);
+    packed[0] = CIPHERTEXT_FORMAT_VERSION;
+    iv.copy(packed, 1);
+    encrypted.copy(packed, 13);
+    authTag.copy(packed, 13 + encrypted.length);
+
+    return { data: packed };
+  },
+
+  decrypt(packed: Buffer, key: Buffer): Buffer {
+    if (packed[0] !== CIPHERTEXT_FORMAT_VERSION) {
+      throw new Error(
+        `@EncryptedAttribute: unsupported ciphertext format version ${packed[0]}. `
+        + `Expected ${CIPHERTEXT_FORMAT_VERSION}.`,
+      );
+    }
+
+    const iv = packed.subarray(1, 13);
+    const authTag = packed.subarray(packed.length - 16);
+    const ciphertext = packed.subarray(13, packed.length - 16);
+
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  },
+
+  deterministic: false,
+});
+
+/**
+ * AES-256-CBC with a random 16-byte IV and PKCS#7 padding.
+ *
+ * Packed format:
+ * ```
+ * [1 B version][16 B IV][N B ciphertext]
+ * ```
+ *
+ * **Note:** CBC does not provide authentication.  If tamper-resistance is
+ * required, prefer {@link Aes256GcmStrategy} instead.
+ */
+export const Aes256CbcStrategy: CipherStrategy = Object.freeze({
+  encrypt(plaintext: Buffer, key: Buffer): EncryptionResult {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+
+    const packed = Buffer.allocUnsafe(1 + 16 + encrypted.length);
+    packed[0] = CIPHERTEXT_FORMAT_VERSION;
+    iv.copy(packed, 1);
+    encrypted.copy(packed, 17);
+
+    return { data: packed };
+  },
+
+  decrypt(packed: Buffer, key: Buffer): Buffer {
+    if (packed[0] !== CIPHERTEXT_FORMAT_VERSION) {
+      throw new Error(
+        `@EncryptedAttribute: unsupported ciphertext format version ${packed[0]}. `
+        + `Expected ${CIPHERTEXT_FORMAT_VERSION}.`,
+      );
+    }
+
+    const iv = packed.subarray(1, 17);
+    const ciphertext = packed.subarray(17);
+
+    const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  },
+
+  deterministic: false,
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Serialisation helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Serialises an arbitrary JS value to a Buffer for encryption. */
+function serialise(value: unknown): Buffer {
+  if (value instanceof Buffer) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return Buffer.from(value.toISOString());
+  }
+
+  if (typeof value === 'string') {
+    return Buffer.from(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return Buffer.from(value ? '1' : '0');
+  }
+
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return Buffer.from(value.toString());
+  }
+
+  // objects, arrays, etc.  JSON.stringify handles most DataTypes.JSON / JSONB values.
+  return Buffer.from(JSON.stringify(value));
+}
+
+/**
+ * Coerce for the declared *logicalType* that the user annotated.
+ */
+type Deserialiser = (raw: Buffer) => unknown;
+
+const STRING_TYPES = new Set([
+  'STRING', 'TEXT', 'UUID', 'UUIDV1', 'UUIDV4',
+  'CHAR', 'INET', 'CIDR', 'MACADDR', 'MACADDR8', 'ENUM',
+]);
+
+const NUMERIC_TYPES = new Set([
+  'INTEGER', 'SMALLINT', 'TINYINT', 'MEDIUMINT',
+  'FLOAT', 'DOUBLE', 'DECIMAL', 'REAL',
+]);
+
+function resolveDeserialiser(logicalType: string): Deserialiser {
+  if (STRING_TYPES.has(logicalType)) {
+    return (buf: Buffer) => buf.toString();
+  }
+
+  if (logicalType === 'BIGINT') {
+    return (buf: Buffer) => BigInt(buf.toString());
+  }
+
+  if (NUMERIC_TYPES.has(logicalType)) {
+    return (buf: Buffer) => Number(buf.toString());
+  }
+
+  if (logicalType === 'JSON' || logicalType === 'JSONB') {
+    return (buf: Buffer) => JSON.parse(buf.toString());
+  }
+
+  if (logicalType === 'DATE' || logicalType === 'DATEONLY' || logicalType === 'TIME') {
+    return (buf: Buffer) => new Date(buf.toString());
+  }
+
+  if (logicalType === 'BOOLEAN') {
+    return (buf: Buffer) => {
+      const s = buf.toString();
+
+      return s === '1' || s === 'true';
+    };
+  }
+
+  if (logicalType === 'BLOB') {
+    return (buf: Buffer) => buf;
+  }
+
+  // Fallback: return the raw string representation.
+  return (buf: Buffer) => buf.toString();
+}
+
+/**
+ * Extracts the DataType identifier string from a DataType class or instance.
+ * Uses the {@link DataTypeIdentifier} symbol that every built-in DataType exposes.
+ *
+ * Works with:
+ * - Invokable (Proxy-wrapped) class references, e.g. `DataTypes.STRING`
+ * - Instances, e.g. `DataTypes.STRING(255)` / `new DataTypes.STRING()`
+ */
+function getDataTypeId(type: unknown): string {
+  if (!isDataType(type)) {
+    throw new TypeError(
+      `@EncryptedAttribute: "type" must be a Sequelize DataType class or instance. `
+      + `Received: ${String(type)}`,
+    );
+  }
+
+  // Instance – the identifier lives on the constructor (static property).
+  if (type instanceof AbstractDataType) {
+    return (type.constructor as typeof AbstractDataType)[DataTypeIdentifier];
+  }
+
+  // Class reference (possibly Proxy-wrapped via classToInvokable).
+  return (type as unknown as typeof AbstractDataType)[DataTypeIdentifier];
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Options
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface EncryptedAttributeOptions {
+  /**
+   * The *logical* data type of the attribute.
+   *
+   * This is the type the attribute appears as in your TypeScript model.
+   * The actual database column will always be a `BLOB`.
+   *
+   * @example DataTypes.STRING
+   * @example DataTypes.JSON
+   */
+  type: DataType;
+
+  /**
+   * The 256-bit (32-byte) encryption key.
+   *
+   * Accepts a `Buffer` or a hex-encoded string (64 hex characters).
+   *
+   * **Security note:** Never hard-code keys in source.  Load them from
+   * environment variables or a secrets manager.
+   */
+  key: Buffer | string;
+
+  /**
+   * The cipher strategy to use.
+   *
+   * @default Aes256GcmStrategy
+   * @see {@link Aes256GcmStrategy}
+   * @see {@link Aes256CbcStrategy}
+   */
+  strategy?: CipherStrategy;
+
+  /**
+   * The BLOB size to use for the database column.
+   *
+   * Encryption adds overhead (IV + authTag + version byte), so choose a size
+   * that can accommodate the largest expected plaintext plus ~29 bytes for GCM
+   * or ~17 bytes for CBC.
+   *
+   * @default 'long'
+   */
+  blobLength?: BlobLength;
+
+  /**
+   * If `true`, null values will be stored as `NULL` in the database instead
+   * of as an encrypted representation of null.
+   *
+   * @default true
+   */
+  allowNull?: boolean;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Key normalisation
+// ────────────────────────────────────────────────────────────────────────────
+
+function normaliseKey(key: Buffer | string): Buffer {
+  if (Buffer.isBuffer(key)) {
+    if (key.length !== 32) {
+      throw new Error(
+        `@EncryptedAttribute: key must be exactly 32 bytes (256 bits) for AES-256. `
+        + `Received ${key.length} bytes.`,
+      );
+    }
+
+    return key;
+  }
+
+  if (typeof key === 'string') {
+    // Accept 64-char hex strings → 32 bytes
+    if (/^[\da-f]{64}$/i.test(key)) {
+      return Buffer.from(key, 'hex');
+    }
+
+    throw new Error(
+      '@EncryptedAttribute: when key is a string, it must be a 64-character hex-encoded '
+      + `string (representing 32 bytes). Received ${key.length} characters.`,
+    );
+  }
+
+  throw new TypeError('@EncryptedAttribute: key must be a Buffer or a hex-encoded string.');
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Decorator
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Marks a model attribute as encrypted at rest.
+ *
+ * The attribute is stored in the database as a `BLOB` containing the packed
+ * ciphertext (version byte + IV + ciphertext + auth tag).  On read the value
+ * is transparently decrypted and coerced back to the declared *logical* type.
+ *
+ * Multiple `@EncryptedAttribute` decorators can be safely used on the same
+ * model - each attribute gets its own independent getter / setter.
+ *
+ * @example
+ * ```ts
+ * import { Model, DataTypes, InferAttributes, InferCreationAttributes } from '@sequelize/core';
+ * import { Attribute, EncryptedAttribute } from '@sequelize/core/decorators-legacy';
+ *
+ * class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+ *   @EncryptedAttribute({
+ *     type: DataTypes.STRING,
+ *     key: process.env.ENCRYPTION_KEY!,   // 64-char hex string
+ *   })
+ *   declare ssn: string;
+ *
+ *   @EncryptedAttribute({
+ *     type: DataTypes.JSON,
+ *     key: process.env.ENCRYPTION_KEY!,
+ *     strategy: Aes256CbcStrategy,
+ *   })
+ *   declare metadata: Record<string, unknown>;
+ * }
+ * ```
+ *
+ * @param options - Configuration for the encrypted attribute.
+ */
+export function EncryptedAttribute(
+  options: EncryptedAttributeOptions,
+): PropertyOrGetterDescriptor {
+  const strategy = options.strategy ?? Aes256GcmStrategy;
+  const keyBuf = normaliseKey(options.key);
+  const blobLength = options.blobLength ?? 'long';
+  const allowNull = options.allowNull ?? true;
+
+  const logicalTypeId = getDataTypeId(options.type);
+  const deserialise = resolveDeserialiser(logicalTypeId);
+
+  return function encryptedAttributeDecorator(
+    target: Object,
+    propertyName: string | symbol,
+    propertyDescriptor?: PropertyDescriptor,
+  ): void {
+    if (typeof propertyName === 'symbol') {
+      throwMustBeAttribute('EncryptedAttribute', target, propertyName);
+    }
+
+    if (typeof target === 'function') {
+      throwMustBeInstanceProperty('EncryptedAttribute', target, propertyName);
+    }
+
+    if (!(target instanceof (Model as any))) {
+      throwMustBeModel('EncryptedAttribute', target, propertyName);
+    }
+
+    // Capture user-defined getter / setter from a property descriptor if present.
+    // This mirrors what attribute-utils.ts annotate() does.
+    const userGet = propertyDescriptor?.get;
+    const userSet = propertyDescriptor?.set;
+
+    const attributeOptions = {
+      type: DataTypes.BLOB(blobLength),
+      allowNull,
+      get(this: Model): unknown {
+        const raw: Buffer | null | undefined = this.getDataValue(propertyName as any);
+        if (raw == null || raw.length === 0) {
+          return null;
+        }
+
+        const decrypted = strategy.decrypt(raw, keyBuf);
+        const value = deserialise(decrypted);
+
+        // If the user provided a custom getter, call it with the decrypted value
+        // already set so getDataValue returns the decrypted form.
+        if (userGet) {
+          return userGet.call(this);
+        }
+
+        return value;
+      },
+      set(this: Model, value: unknown): void {
+        // If the user provided a custom setter, let it transform the value first.
+        if (userSet) {
+          userSet.call(this, value);
+          value = this.getDataValue(propertyName as any);
+        }
+
+        if (value == null) {
+          this.setDataValue(propertyName as any, null as any);
+
+          return;
+        }
+
+        const plaintext = serialise(value);
+        const { data } = strategy.encrypt(plaintext, keyBuf);
+        this.setDataValue(propertyName as any, data as any);
+      },
+    };
+
+    registerModelAttributeOptions(
+      target.constructor as ModelStatic,
+      propertyName,
+      attributeOptions,
+    );
+  };
+}

--- a/packages/core/src/decorators/legacy/index.ts
+++ b/packages/core/src/decorators/legacy/index.ts
@@ -13,6 +13,7 @@
 export { BelongsTo, BelongsToMany, HasMany, HasOne } from './associations.js';
 export * from './attribute.js';
 export * from './built-in-attributes.js';
+export * from './encrypted-attribute.js';
 export * from './model-hooks.js';
 export * from './table.js';
 export * from './validation.js';

--- a/packages/core/test/unit/decorators/encrypted-attribute.test.ts
+++ b/packages/core/test/unit/decorators/encrypted-attribute.test.ts
@@ -1,0 +1,427 @@
+import crypto from 'node:crypto';
+import type { InferAttributes, InferCreationAttributes } from '@sequelize/core';
+import { DataTypes, Model } from '@sequelize/core';
+import {
+  Aes256CbcStrategy,
+  Aes256GcmStrategy,
+  EncryptedAttribute,
+} from '@sequelize/core/decorators-legacy';
+import { expect } from 'chai';
+import { sequelize } from '../../support';
+
+// Deterministic 32-byte key for testing (never use in production).
+const TEST_KEY = crypto.randomBytes(32);
+const TEST_KEY_HEX = TEST_KEY.toString('hex');
+
+describe('@EncryptedAttribute legacy decorator', () => {
+  // ── Registration ──────────────────────────────────────────────────────
+
+  it('does not init the model itself', () => {
+    class Test extends Model {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+      declare secret: string;
+    }
+
+    expect(() => Test.build()).to.throw(/has not been initialized/);
+  });
+
+  it('registers the attribute as a BLOB', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const attr = User.getAttributes().ssn;
+    expect(attr).to.exist;
+    expect(attr.type).to.be.instanceof(DataTypes.BLOB);
+  });
+
+  it('accepts a hex-encoded string as key', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY_HEX })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({ ssn: 'hello' } as any);
+    expect(user.ssn).to.equal('hello');
+  });
+
+  // ── Key validation ────────────────────────────────────────────────────
+
+  it('rejects a key that is not 32 bytes (Buffer)', () => {
+    expect(() => {
+      class User extends Model {
+        @EncryptedAttribute({ type: DataTypes.STRING, key: Buffer.alloc(16) })
+        declare ssn: string;
+      }
+
+      return User;
+    }).to.throw(/key must be exactly 32 bytes/);
+  });
+
+  it('rejects a hex string that is not 64 characters', () => {
+    expect(() => {
+      class User extends Model {
+        @EncryptedAttribute({ type: DataTypes.STRING, key: 'abcd' })
+        declare ssn: string;
+      }
+
+      return User;
+    }).to.throw(/64-character hex-encoded/);
+  });
+
+  // ── Type validation ───────────────────────────────────────────────────
+
+  it('rejects a non-DataType as type', () => {
+    expect(() => {
+      class User extends Model {
+        @EncryptedAttribute({ type: 'not-a-type' as any, key: TEST_KEY })
+        declare ssn: string;
+      }
+
+      return User;
+    }).to.throw(/must be a Sequelize DataType/);
+  });
+
+  // ── Encryption / Decryption round-trip ────────────────────────────────
+
+  it('encrypts on set and decrypts on get (STRING)', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({ ssn: '123-45-6789' } as any);
+
+    // The getter should return the original plaintext
+    expect(user.ssn).to.equal('123-45-6789');
+
+    // The raw stored value should be a Buffer (encrypted), not the plaintext
+    const raw = user.getDataValue('ssn' as any);
+    expect(raw).to.be.instanceof(Buffer);
+    expect(raw.toString()).to.not.equal('123-45-6789');
+  });
+
+  it('encrypts on set and decrypts on get (INTEGER)', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.INTEGER, key: TEST_KEY })
+      declare age: number;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({ age: 42 } as any);
+    expect(user.age).to.equal(42);
+  });
+
+  it('encrypts on set and decrypts on get (BOOLEAN)', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.BOOLEAN, key: TEST_KEY })
+      declare active: boolean;
+    }
+
+    sequelize.addModels([User]);
+
+    const userTrue = User.build({ active: true } as any);
+    expect(userTrue.active).to.equal(true);
+
+    const userFalse = User.build({ active: false } as any);
+    expect(userFalse.active).to.equal(false);
+  });
+
+  it('encrypts on set and decrypts on get (JSON)', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.JSON, key: TEST_KEY })
+      declare metadata: Record<string, unknown>;
+    }
+
+    sequelize.addModels([User]);
+
+    const data = { role: 'admin', permissions: ['read', 'write'] };
+    const user = User.build({ metadata: data } as any);
+    expect(user.metadata).to.deep.equal(data);
+  });
+
+  it('encrypts on set and decrypts on get (DATE)', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.DATE, key: TEST_KEY })
+      declare birthDate: Date;
+    }
+
+    sequelize.addModels([User]);
+
+    const date = new Date('1990-01-15T00:00:00.000Z');
+    const user = User.build({ birthDate: date } as any);
+    expect(user.birthDate).to.deep.equal(date);
+  });
+
+  // ── Null handling ─────────────────────────────────────────────────────
+
+  it('handles null values', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY, allowNull: true })
+      declare ssn: string | null;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({ ssn: null } as any);
+    expect(user.ssn).to.be.null;
+  });
+
+  it('handles undefined values as null', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY, allowNull: true })
+      declare ssn: string | null;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({} as any);
+    expect(user.ssn).to.be.null;
+  });
+
+  // ── Multiple encrypted attributes on the same model ───────────────────
+
+  it('supports multiple encrypted attributes on the same model', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+      declare ssn: string;
+
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+      declare creditCard: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({
+      ssn: '123-45-6789',
+      creditCard: '4111-1111-1111-1111',
+    } as any);
+
+    expect(user.ssn).to.equal('123-45-6789');
+    expect(user.creditCard).to.equal('4111-1111-1111-1111');
+  });
+
+  // ── Non-deterministic encryption ──────────────────────────────────────
+
+  it('produces different ciphertexts for the same plaintext (non-deterministic)', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const user1 = User.build({ ssn: 'same-value' } as any);
+    const user2 = User.build({ ssn: 'same-value' } as any);
+
+    const raw1 = user1.getDataValue('ssn' as any) as unknown as Buffer;
+    const raw2 = user2.getDataValue('ssn' as any) as unknown as Buffer;
+
+    // Both should decrypt to the same value
+    expect(user1.ssn).to.equal('same-value');
+    expect(user2.ssn).to.equal('same-value');
+
+    // But the raw ciphertexts should differ (random IV)
+    expect(Buffer.compare(raw1, raw2)).to.not.equal(0);
+  });
+
+  // ── Strategy selection ────────────────────────────────────────────────
+
+  it('works with Aes256GcmStrategy (default)', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({
+        type: DataTypes.STRING,
+        key: TEST_KEY,
+        strategy: Aes256GcmStrategy,
+      })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({ ssn: 'gcm-test' } as any);
+    expect(user.ssn).to.equal('gcm-test');
+  });
+
+  it('works with Aes256CbcStrategy', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({
+        type: DataTypes.STRING,
+        key: TEST_KEY,
+        strategy: Aes256CbcStrategy,
+      })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({ ssn: 'cbc-test' } as any);
+    expect(user.ssn).to.equal('cbc-test');
+  });
+
+  // ── Custom strategy ───────────────────────────────────────────────────
+
+  it('accepts a custom CipherStrategy', () => {
+    // A trivial "cipher" that just XORs with 0xFF for testing purposes.
+    const xorStrategy = {
+      encrypt(plaintext: Buffer, _key: Buffer) {
+        const data = Buffer.alloc(plaintext.length);
+        for (let i = 0; i < plaintext.length; i++) {
+          data[i] = plaintext[i]! ^ 0xff;
+        }
+
+        return { data };
+      },
+      decrypt(packed: Buffer, _key: Buffer) {
+        const data = Buffer.alloc(packed.length);
+        for (let i = 0; i < packed.length; i++) {
+          data[i] = packed[i]! ^ 0xff;
+        }
+
+        return data;
+      },
+      deterministic: true,
+    };
+
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({
+        type: DataTypes.STRING,
+        key: TEST_KEY,
+        strategy: xorStrategy,
+      })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const user = User.build({ ssn: 'custom-strategy' } as any);
+    expect(user.ssn).to.equal('custom-strategy');
+  });
+
+  // ── BLOB size option ──────────────────────────────────────────────────
+
+  it('respects the blobLength option', () => {
+    class User extends Model<InferAttributes<User>> {
+      @EncryptedAttribute({
+        type: DataTypes.STRING,
+        key: TEST_KEY,
+        blobLength: 'tiny',
+      })
+      declare ssn: string;
+    }
+
+    sequelize.addModels([User]);
+
+    const attr = User.getAttributes().ssn;
+    expect(attr.type).to.be.instanceof(DataTypes.BLOB);
+    // The BLOB instance should have 'tiny' as its length option.
+    expect((attr.type as InstanceType<typeof DataTypes.BLOB>).options.length).to.equal('tiny');
+  });
+
+  // ── Decorator validation ──────────────────────────────────────────────
+
+  it('throws if used on a static property', () => {
+    expect(() => {
+      class User extends Model {
+        @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+        static declare ssn: string;
+      }
+
+      return User;
+    }).to.throw(/static/i);
+  });
+
+  it('throws if used on a non-Model class', () => {
+    expect(() => {
+      class NotAModel {
+        @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
+        declare ssn: string;
+      }
+
+      return NotAModel;
+    }).to.throw(/does not extend Model/);
+  });
+});
+
+// ── Standalone strategy tests ─────────────────────────────────────────────
+
+describe('Aes256GcmStrategy', () => {
+  const key = crypto.randomBytes(32);
+
+  it('round-trips arbitrary data', () => {
+    const plaintext = Buffer.from('hello, world!');
+    const { data } = Aes256GcmStrategy.encrypt(plaintext, key);
+    const decrypted = Aes256GcmStrategy.decrypt(data, key);
+    expect(decrypted.toString()).to.equal('hello, world!');
+  });
+
+  it('packs version byte at index 0', () => {
+    const { data } = Aes256GcmStrategy.encrypt(Buffer.from('test'), key);
+    expect(data[0]).to.equal(0x01);
+  });
+
+  it('produces unique ciphertexts per call (random IV)', () => {
+    const plaintext = Buffer.from('same');
+    const a = Aes256GcmStrategy.encrypt(plaintext, key);
+    const b = Aes256GcmStrategy.encrypt(plaintext, key);
+    expect(Buffer.compare(a.data, b.data)).to.not.equal(0);
+  });
+
+  it('rejects tampered ciphertext', () => {
+    const { data } = Aes256GcmStrategy.encrypt(Buffer.from('secret'), key);
+    // Flip a byte in the ciphertext region
+    data[14] ^= 0xff;
+    expect(() => Aes256GcmStrategy.decrypt(data, key)).to.throw();
+  });
+
+  it('rejects wrong key', () => {
+    const { data } = Aes256GcmStrategy.encrypt(Buffer.from('secret'), key);
+    const wrongKey = crypto.randomBytes(32);
+    expect(() => Aes256GcmStrategy.decrypt(data, wrongKey)).to.throw();
+  });
+
+  it('is non-deterministic', () => {
+    expect(Aes256GcmStrategy.deterministic).to.equal(false);
+  });
+});
+
+describe('Aes256CbcStrategy', () => {
+  const key = crypto.randomBytes(32);
+
+  it('round-trips arbitrary data', () => {
+    const plaintext = Buffer.from('hello, world!');
+    const { data } = Aes256CbcStrategy.encrypt(plaintext, key);
+    const decrypted = Aes256CbcStrategy.decrypt(data, key);
+    expect(decrypted.toString()).to.equal('hello, world!');
+  });
+
+  it('packs version byte at index 0', () => {
+    const { data } = Aes256CbcStrategy.encrypt(Buffer.from('test'), key);
+    expect(data[0]).to.equal(0x01);
+  });
+
+  it('produces unique ciphertexts per call (random IV)', () => {
+    const plaintext = Buffer.from('same');
+    const a = Aes256CbcStrategy.encrypt(plaintext, key);
+    const b = Aes256CbcStrategy.encrypt(plaintext, key);
+    expect(Buffer.compare(a.data, b.data)).to.not.equal(0);
+  });
+
+  it('rejects wrong key', () => {
+    const { data } = Aes256CbcStrategy.encrypt(Buffer.from('secret'), key);
+    const wrongKey = crypto.randomBytes(32);
+    expect(() => Aes256CbcStrategy.decrypt(data, wrongKey)).to.throw();
+  });
+
+  it('is non-deterministic', () => {
+    expect(Aes256CbcStrategy.deterministic).to.equal(false);
+  });
+});

--- a/packages/core/test/unit/decorators/encrypted-attribute.test.ts
+++ b/packages/core/test/unit/decorators/encrypted-attribute.test.ts
@@ -1,5 +1,4 @@
-import crypto from 'node:crypto';
-import type { InferAttributes, InferCreationAttributes } from '@sequelize/core';
+import type { InferAttributes } from '@sequelize/core';
 import { DataTypes, Model } from '@sequelize/core';
 import {
   Aes256CbcStrategy,
@@ -7,6 +6,7 @@ import {
   EncryptedAttribute,
 } from '@sequelize/core/decorators-legacy';
 import { expect } from 'chai';
+import crypto from 'node:crypto';
 import { sequelize } from '../../support';
 
 // Deterministic 32-byte key for testing (never use in production).
@@ -273,20 +273,12 @@ describe('@EncryptedAttribute legacy decorator', () => {
     // A trivial "cipher" that just XORs with 0xFF for testing purposes.
     const xorStrategy = {
       encrypt(plaintext: Buffer, _key: Buffer) {
-        const data = Buffer.alloc(plaintext.length);
-        for (let i = 0; i < plaintext.length; i++) {
-          data[i] = plaintext[i]! ^ 0xff;
-        }
+        const data = Buffer.from(plaintext.map(byte => byte ^ 0xff));
 
         return { data };
       },
       decrypt(packed: Buffer, _key: Buffer) {
-        const data = Buffer.alloc(packed.length);
-        for (let i = 0; i < packed.length; i++) {
-          data[i] = packed[i]! ^ 0xff;
-        }
-
-        return data;
+        return Buffer.from(packed.map(byte => byte ^ 0xff));
       },
       deterministic: true,
     };
@@ -332,7 +324,7 @@ describe('@EncryptedAttribute legacy decorator', () => {
     expect(() => {
       class User extends Model {
         @EncryptedAttribute({ type: DataTypes.STRING, key: TEST_KEY })
-        static declare ssn: string;
+        declare static ssn: string;
       }
 
       return User;


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- TODO: open docs PR after merge -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Closes #17299

### Summary

Adds a new `@EncryptedAttribute` decorator to `@sequelize/core/decorators-legacy` that provides transparent at-rest encryption for model attributes. The attribute is stored in the database as a `BLOB` containing a versioned packed ciphertext and is automatically decrypted on read, with the value coerced back to the declared logical DataType.

### Motivation

Sequelize currently has no built-in mechanism for encrypting sensitive model fields (SSNs, credit card numbers, PII, API keys, etc.). Users must manually implement encryption in hooks or getters/setters, which is error-prone and inconsistent. This decorator provides a standardised, secure-by-default solution that integrates natively with Sequelize's decorator infrastructure.

### Design decisions

**Strategy Pattern for cipher extensibility** -- Instead of hardcoding a single algorithm, the decorator accepts a `CipherStrategy` interface. Two built-in strategies are provided:
- `Aes256GcmStrategy` (default) -- AES-256-GCM with random 12-byte IV + 16-byte auth tag. Provides both confidentiality and authenticity.
- `Aes256CbcStrategy` -- AES-256-CBC with random 16-byte IV. For environments where GCM is not available.

Users can implement their own `CipherStrategy` (e.g. `chacha20-poly1305`, envelope encryption with KMS, etc.) without any changes to Sequelize.

**Versioned ciphertext format** -- Every packed ciphertext is prefixed with a version byte (`0x01`), allowing the format to evolve in future versions without breaking existing encrypted data.

**Random IV per encryption** -- Every `set` operation generates a fresh random IV via `crypto.randomBytes()`. This is critical for GCM security (IV reuse with the same key completely breaks GCM confidentiality and authenticity).

**Native Sequelize integration via `get`/`set`** -- Uses `registerModelAttributeOptions()` with custom `get`/`set` functions instead of global model hooks. This ensures multiple `@EncryptedAttribute` decorators on the same model work independently without conflicts.

**Strict key validation** -- Keys must be exactly 32 bytes (Buffer) or a 64-character hex string. The decorator throws eagerly at decoration time, not at runtime.

### Usage example

```typescript
import { Model, DataTypes, InferAttributes, InferCreationAttributes } from '@sequelize/core';
import { EncryptedAttribute, Aes256CbcStrategy } from '@sequelize/core/decorators-legacy';

class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
  @EncryptedAttribute({
    type: DataTypes.STRING,
    key: process.env.ENCRYPTION_KEY!, // 64-char hex string
  })
  declare ssn: string;

  @EncryptedAttribute({
    type: DataTypes.JSON,
    key: process.env.ENCRYPTION_KEY!,
    strategy: Aes256CbcStrategy,
    blobLength: 'medium',
  })
  declare metadata: Record<string, unknown>;
}
```

### Files changed

| File | Change |
|---|---|
| `packages/core/src/decorators/legacy/encrypted-attribute.ts` | New file -- decorator, strategies, serialisation |
| `packages/core/src/decorators/legacy/index.ts` | Added `export * from './encrypted-attribute.js'` |
| `packages/core/test/unit/decorators/encrypted-attribute.test.ts` | New file -- 22 unit tests |

### Test coverage

- Attribute registration as BLOB
- Key validation (Buffer length, hex format, rejection of invalid keys)
- Type validation (rejects non-DataType values)
- Round-trip encrypt/decrypt for STRING, INTEGER, BOOLEAN, JSON, DATE
- Null and undefined handling
- Multiple encrypted attributes on same model (no conflicts)
- Non-deterministic ciphertext verification (random IV)
- Both Aes256GcmStrategy and Aes256CbcStrategy
- Custom CipherStrategy support
- `blobLength` option respected
- Decorator validation (static property, non-Model class rejection)
- Standalone strategy tests (round-trip, version byte, tamper detection, wrong key)

## List of Breaking Changes

None. This is a purely additive feature with no changes to existing APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transparent attribute encryption with automatic encrypt/decrypt at rest
  * Multiple algorithms supported (AES-256-GCM, AES-256-CBC) and pluggable custom strategies
  * Configurable key formats, deterministic option, versioned ciphertext format, nullable handling, and configurable storage size
  * Support for multiple encrypted attributes per model

* **Tests**
  * Comprehensive test suite covering encryption/decryption, strategy behavior, edge cases, and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->