### PR TITLE
fix: fix subclass validation errors caused by multiple instances

### DIFF
--- a/src/associations/mixin.js
+++ b/src/associations/mixin.js
@@ -6,15 +6,15 @@ const HasMany = require('./has-many');
 const BelongsToMany = require('./belongs-to-many');
 const BelongsTo = require('./belongs-to');
 
-function isModel(model, sequelize) {
+function isModel(model, source) {
   return model
     && model.prototype
-    && model.prototype instanceof sequelize.Sequelize.Model;
+    && model.prototype instanceof source.__proto__;
 }
 
 const Mixin = {
   hasMany(target, options = {}) {
-    if (!isModel(target, this.sequelize)) {
+    if (!isModel(target, this)) {
       throw new Error(`${this.name}.hasMany called with something that's not a subclass of Sequelize.Model`);
     }
 
@@ -45,7 +45,7 @@ const Mixin = {
   },
 
   belongsToMany(target, options = {}) {
-    if (!isModel(target, this.sequelize)) {
+    if (!isModel(target, this)) {
       throw new Error(`${this.name}.belongsToMany called with something that's not a subclass of Sequelize.Model`);
     }
 
@@ -89,7 +89,7 @@ function singleLinked(Type) {
   return function(target, options = {}) {
     // eslint-disable-next-line no-invalid-this
     const source = this;
-    if (!isModel(target, source.sequelize)) {
+    if (!isModel(target, source)) {
       throw new Error(`${source.name}.${_.lowerFirst(Type.name)} called with something that's not a subclass of Sequelize.Model`);
     }
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->
In a monorepo setup where models are defined and consumed in different packages, having mismatched resolved sequelize versions (e.g., 6.28.0_mysql2@2.3.3 vs. 6.28.0_mysql2@3.11.3) will cause the subclass validation for model associations to fail.

To fix this, we simply modified the validation logic to check whether the target and source share the same base Model class.

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
