### PR TITLE
fix(core): replace incorrect QueryRawOptions usage in dropSchema typing

### DIFF
--- a/packages/core/src/abstract-dialect/query-interface-typescript.ts
+++ b/packages/core/src/abstract-dialect/query-interface-typescript.ts
@@ -163,7 +163,7 @@ export class AbstractQueryInterfaceTypeScript<Dialect extends AbstractDialect = 
    */
   async dropSchema(schema: string, options?: DropSchemaOptions): Promise<void> {
     const sql = this.queryGenerator.dropSchemaQuery(schema, options);
-    await this.sequelize.queryRaw(sql, options);
+    await this.sequelize.queryRaw(sql, options as QueryRawOptions);
   }
 
   /**

--- a/packages/core/src/sequelize-typescript.ts
+++ b/packages/core/src/sequelize-typescript.ts
@@ -37,7 +37,10 @@ import { normalizeDataType, validateDataType } from './abstract-dialect/data-typ
 import type { AbstractDataType } from './abstract-dialect/data-types.js';
 import type { AbstractDialect, ConnectionOptions } from './abstract-dialect/dialect.js';
 import type { EscapeOptions } from './abstract-dialect/query-generator-typescript.js';
-import type { QiDropAllSchemasOptions } from './abstract-dialect/query-interface.types.js';
+import type {
+  DropSchemaOptions,
+  QiDropAllSchemasOptions,
+} from './abstract-dialect/query-interface.types.js';
 import type { AbstractQuery } from './abstract-dialect/query.js';
 import type { AcquireConnectionOptions } from './abstract-dialect/replication-pool.js';
 import { ReplicationPool } from './abstract-dialect/replication-pool.js';
@@ -1117,7 +1120,7 @@ Connection options can be used at the root of the option bag, in the "replicatio
    * @param schema
    * @param options
    */
-  async dropSchema(schema: string, options?: QueryRawOptions) {
+  async dropSchema(schema: string, options?: DropSchemaOptions) {
     return this.queryInterface.dropSchema(schema, options);
   }
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #17935) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

This PR fixes a TypeScript typing inconsistency in `sequelize.dropSchema`.

Previously, `dropSchema` incorrectly used `QueryRawOptions` as its option type, which caused TypeScript errors when using valid options like `{ cascade: true }`.

Changes:
* Replaced incorrect `QueryRawOptions` type with `DropSchemaOptions` in `sequelize-typescript.ts`
* Adjusted internal casting in `query-interface-typescript.ts` to ensure compatibility with `queryRaw`
* Ensured type safety while preserving runtime behavior

This resolves TypeScript compilation errors reported when using `dropSchema` with `cascade` option.

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for schema operations to ensure better type consistency and correctness across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->