### PR TITLE
test: add regression for nullable hasMany onDelete behavior

### DIFF
--- a/packages/core/test/unit/associations/has-many.test.ts
+++ b/packages/core/test/unit/associations/has-many.test.ts
@@ -421,5 +421,35 @@ describe(getTestDialectTeaser('hasMany'), () => {
         expect(afterAssociate).to.not.have.been.called;
       });
     });
+
+    it('uses SET NULL by default for nullable foreign keys', () => {
+      class User extends Model<InferAttributes<User>> {}
+
+      class Foo extends Model<InferAttributes<Foo>> {
+        declare userId: ForeignKey<number | null>;
+      }
+
+      User.init({
+        name: DataTypes.TEXT,
+      }, { sequelize });
+
+      Foo.init({
+        name: DataTypes.TEXT,
+        userId: {
+          type: DataTypes.INTEGER,
+          // allowNull is omitted on purpose; this should be treated as nullable.
+          references: {
+            model: User,
+            key: 'id',
+          },
+        },
+      }, { sequelize });
+
+      User.hasMany(Foo, { foreignKey: 'userId' });
+
+      const attribute = Foo.getAttributes().userId;
+      expect(attribute.allowNull).to.not.equal(false);
+      expect(attribute.onDelete).to.equal('SET NULL');
+    });
   });
 });


### PR DESCRIPTION
This PR addresses sequelize/sequelize#18172 for the v7 codebase.

In v7, the behavior for a nullable foreign key created via [hasMany](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is already correct: when the FK column is nullable (i.e. [allowNull](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is not explicitly set to false), the generated constraint defaults to ON DELETE SET NULL.

This change adds a regression test to lock in that behavior:

packages/core/test/unit/associations/has-many.test.ts
Verifies that when [Foo.userId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is defined without [allowNull: false](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [User.hasMany(Foo, { foreignKey: 'userId' })](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is used, [Foo.getAttributes().userId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) has:
[allowNull](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) not forced to false
[onDelete === 'SET NULL'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
No runtime code changes were necessary; this is a test-only change to prevent regressions and to document the intended behavior for nullable 1:n associations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case verifying default cascade delete behavior for nullable foreign key relationships in multi-table associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->