### PR TITLE
feat(core): add DataTypes.VARBINARY for variable-length binary columns

### DIFF
--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -1773,7 +1773,107 @@ export interface BlobOptions {
  *
  * @category DataTypes
  */
+export interface VarBinaryOptions {
+  /**
+   * The maximum number of bytes to store. Must be a positive integer between 1 and 65535.
+   */
+  length: number;
+}
+
+/**
+ * A variable-length binary string with a maximum byte length.
+ *
+ * Unlike {@link BLOB}, `VARBINARY` has a fixed maximum length and can be efficiently indexed.
+ * This makes it well-suited for storing binary identifiers (e.g. hashes, UUIDs as bytes) that
+ * need to participate in indexes or unique constraints.
+ *
+ * __Fallback policy:__
+ * If this type is not supported by the dialect, an error will be raised.
+ *
+ * @example
+ * ```ts
+ * // Store a SHA-256 hash (32 bytes) as binary
+ * DataTypes.VARBINARY(32)
+ *
+ * // Store an arbitrary binary value up to 255 bytes
+ * DataTypes.VARBINARY(255)
+ * ```
+ *
+ * @category DataTypes
+ */
 // TODO: add FIXED_BINARY & VAR_BINARY data types. They are not the same as CHAR BINARY / VARCHAR BINARY.
+export class VARBINARY extends AbstractDataType<AcceptedBlob> {
+  /** @hidden */
+  static readonly [DataTypeIdentifier]: string = 'VARBINARY';
+  readonly options: VarBinaryOptions;
+
+  /**
+   * @param lengthOrOptions The maximum number of bytes to store, or an options object.
+   */
+  constructor(lengthOrOptions: number | VarBinaryOptions) {
+    super();
+
+    const length = typeof lengthOrOptions === 'object' ? lengthOrOptions.length : lengthOrOptions;
+
+    if (!Number.isInteger(length) || length < 1 || length > 65_535) {
+      throw new TypeError(
+        'The "length" option of VARBINARY must be a positive integer between 1 and 65535.',
+      );
+    }
+
+    this.options = { length };
+  }
+
+  protected _checkOptionSupport(dialect: AbstractDialect) {
+    if (!dialect.supports.dataTypes.VARBINARY) {
+      throwUnsupportedDataType(dialect, 'VARBINARY');
+    }
+  }
+
+  toSql(): string {
+    return `VARBINARY(${this.options.length})`;
+  }
+
+  validate(value: any) {
+    if (
+      Buffer.isBuffer(value) ||
+      typeof value === 'string' ||
+      value instanceof Uint8Array ||
+      value instanceof ArrayBuffer
+    ) {
+      return;
+    }
+
+    rejectBlobs(value);
+
+    ValidationErrorItem.throwDataTypeValidationError(
+      `${util.inspect(value)} is not a valid binary value: Only strings, Buffer, Uint8Array and ArrayBuffer are supported.`,
+    );
+  }
+
+  sanitize(value: unknown): unknown {
+    if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+      return makeBufferFromTypedArray(value);
+    }
+
+    if (typeof value === 'string') {
+      return Buffer.from(value);
+    }
+
+    return value;
+  }
+
+  escape(value: string | Buffer) {
+    const buf = typeof value === 'string' ? Buffer.from(value, 'binary') : value;
+
+    return this._getDialect().escapeBuffer(buf);
+  }
+
+  getBindParamSql(value: AcceptedBlob, options: BindParamOptions) {
+    return options.bindParam(value);
+  }
+}
+
 export class BLOB extends AbstractDataType<AcceptedBlob> {
   /** @hidden */
   static readonly [DataTypeIdentifier]: string = 'BLOB';

--- a/packages/core/src/abstract-dialect/dialect.ts
+++ b/packages/core/src/abstract-dialect/dialect.ts
@@ -204,6 +204,8 @@ export type DialectSupports = {
     INET: boolean;
     MACADDR: boolean;
     MACADDR8: boolean;
+    /** Whether this dialect supports VARBINARY(n) — a variable-length binary string with a fixed max length */
+    VARBINARY: boolean;
     DATETIME: {
       /** Whether "infinity" is a valid value in this dialect's DATETIME data type */
       infinity: boolean;
@@ -461,6 +463,7 @@ export abstract class AbstractDialect<
       GEOGRAPHY: false,
       HSTORE: false,
       TSVECTOR: false,
+      VARBINARY: false,
       DATETIME: {
         infinity: false,
       },

--- a/packages/core/src/data-types.ts
+++ b/packages/core/src/data-types.ts
@@ -47,6 +47,8 @@ export const NOW = classToInvokable(DataTypes.NOW);
 /** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const BLOB = classToInvokable(DataTypes.BLOB);
 /** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
+export const VARBINARY = classToInvokable(DataTypes.VARBINARY);
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const DECIMAL = classToInvokable(DataTypes.DECIMAL);
 /** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const UUID = classToInvokable(DataTypes.UUID);

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -29,6 +29,7 @@ export type {
   RangeOptions,
   TextOptions,
   TimeOptions,
+  VarBinaryOptions,
   VirtualOptions,
 } from './abstract-dialect/data-types.js';
 export {

--- a/packages/core/test/unit/data-types/binary-types.test.ts
+++ b/packages/core/test/unit/data-types/binary-types.test.ts
@@ -1,6 +1,9 @@
 import { DataTypes, ValidationErrorItem } from '@sequelize/core';
 import { expect } from 'chai';
+import { sequelize } from '../../support';
 import { testDataTypeSql } from './_utils';
+
+const dialectName = sequelize.dialect.name;
 
 describe('DataTypes.BLOB', () => {
   testDataTypeSql('BLOB', DataTypes.BLOB, {
@@ -67,6 +70,60 @@ describe('DataTypes.BLOB', () => {
 
       expect(() => type.validate('foobar')).not.to.throw();
       expect(() => type.validate(Buffer.from('foobar'))).not.to.throw();
+    });
+  });
+});
+
+describe('DataTypes.VARBINARY', () => {
+  const varbinaryUnsupportedError = new Error(
+    `${dialectName} does not support the VARBINARY data type.\nSee https://sequelize.org/docs/v7/models/data-types/ for a list of supported data types.`,
+  );
+
+  describe('toSql', () => {
+    testDataTypeSql('VARBINARY(32)', DataTypes.VARBINARY(32), {
+      default: varbinaryUnsupportedError,
+      'mysql mariadb mssql': 'VARBINARY(32)',
+    });
+
+    testDataTypeSql('VARBINARY({ length: 255 })', DataTypes.VARBINARY({ length: 255 }), {
+      default: varbinaryUnsupportedError,
+      'mysql mariadb mssql': 'VARBINARY(255)',
+    });
+  });
+
+  describe('constructor validation', () => {
+    it('should throw if length is not a positive integer', () => {
+      expect(() => DataTypes.VARBINARY(0)).to.throw(TypeError, '"length"');
+      expect(() => DataTypes.VARBINARY(-1)).to.throw(TypeError, '"length"');
+      expect(() => DataTypes.VARBINARY(65_536)).to.throw(TypeError, '"length"');
+      expect(() => DataTypes.VARBINARY(1.5)).to.throw(TypeError, '"length"');
+    });
+
+    it('should not throw for valid lengths', () => {
+      expect(() => DataTypes.VARBINARY(1)).not.to.throw();
+      expect(() => DataTypes.VARBINARY(255)).not.to.throw();
+      expect(() => DataTypes.VARBINARY(65_535)).not.to.throw();
+    });
+  });
+
+  describe('validate', () => {
+    it('should throw an error if `value` is invalid', () => {
+      const type = DataTypes.VARBINARY(32);
+
+      expect(() => {
+        type.validate(12_345);
+      }).to.throw(
+        ValidationErrorItem,
+        '12345 is not a valid binary value: Only strings, Buffer, Uint8Array and ArrayBuffer are supported.',
+      );
+    });
+
+    it('should not throw if `value` is a valid binary value', () => {
+      const type = DataTypes.VARBINARY(32);
+
+      expect(() => type.validate('foobar')).not.to.throw();
+      expect(() => type.validate(Buffer.from('foobar'))).not.to.throw();
+      expect(() => type.validate(new Uint8Array(4))).not.to.throw();
     });
   });
 });

--- a/packages/mariadb/src/dialect.ts
+++ b/packages/mariadb/src/dialect.ts
@@ -78,6 +78,7 @@ export class MariaDbDialect extends AbstractDialect<
     indexHints: true,
     dataTypes: {
       COLLATE_BINARY: true,
+      VARBINARY: true,
       GEOMETRY: true,
       INTS: numericOptions,
       FLOAT: { ...numericOptions, scaleAndPrecision: true },

--- a/packages/mssql/src/dialect.ts
+++ b/packages/mssql/src/dialect.ts
@@ -69,6 +69,7 @@ export class MsSqlDialect extends AbstractDialect<MsSqlDialectOptions, MsSqlConn
     tmpTableTrigger: true,
     dataTypes: {
       JSON: true,
+      VARBINARY: true,
       // TODO: https://learn.microsoft.com/en-us/sql/t-sql/spatial-geography/spatial-types-geography?view=sql-server-ver16
       GEOGRAPHY: false,
       // TODO: https://learn.microsoft.com/en-us/sql/t-sql/spatial-geometry/spatial-types-geometry-transact-sql?view=sql-server-ver16

--- a/packages/mysql/src/dialect.ts
+++ b/packages/mysql/src/dialect.ts
@@ -74,6 +74,7 @@ export class MySqlDialect extends AbstractDialect<MySqlDialectOptions, MySqlConn
     indexHints: true,
     dataTypes: {
       COLLATE_BINARY: true,
+      VARBINARY: true,
       GEOMETRY: true,
       INTS: numericOptions,
       FLOAT: { ...numericOptions, scaleAndPrecision: true },

--- a/test/esm-named-exports.test.js
+++ b/test/esm-named-exports.test.js
@@ -56,6 +56,7 @@ const ignoredCjsKeysMap = {
     'UUID',
     'UUIDV1',
     'UUIDV4',
+    'VARBINARY',
     'VIRTUAL',
   ],
   '@sequelize/core/decorators-legacy': ['__esModule'],


### PR DESCRIPTION
## What

Adds `DataTypes.VARBINARY(n)` — a variable-length binary data type with a fixed maximum byte length.

Closes #5981

## Why

Sequelize currently lacks a native `VARBINARY` type. Users who need efficient binary indexes (e.g. SHA-256 hashes, UUIDs stored as bytes, binary foreign account IDs) are forced to use `BLOB` or raw SQL types. `BLOB` cannot be directly indexed in MySQL, making `VARBINARY` the correct choice for indexable binary columns.

There is also a `// TODO: add FIXED_BINARY & VAR_BINARY data types` comment in the codebase right above the `BLOB` class — this PR addresses that TODO for the variable-length case.

## How

- New `VARBINARY` class in `packages/core/src/abstract-dialect/data-types.ts`
- `toSql()` returns `VARBINARY(n)`
- Accepts `Buffer`, `string`, `Uint8Array`, and `ArrayBuffer` values (same as BLOB)
- Validates that `length` is a positive integer between 1 and 65535
- `supports.dataTypes.VARBINARY` support flag added to the dialect interface
  - Enabled for: **MySQL**, **MariaDB**, **MSSQL**
  - All other dialects throw a clear `UnsupportedDataTypeError` at model definition time
- Exported as `DataTypes.VARBINARY` and `VarBinaryOptions` type

## Tests

Added to `test/unit/data-types/binary-types.test.ts`:
- SQL output for mysql/mariadb/mssql (`VARBINARY(n)`)
- Unsupported dialect error for sqlite3/postgres/etc.
- Constructor validation (rejects invalid lengths)
- `validate()` method (accepts Buffer, string, Uint8Array; rejects numbers)

All 1741 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VARBINARY data type for variable-length binary data (length 1–65535); accepts strings, Buffer, Uint8Array and ArrayBuffer inputs.
  * VARBINARY is available on MySQL, MariaDB and MSSQL dialects.

* **Tests**
  * Added unit tests for VARBINARY behavior and updated ESM export test to account for the new export.

* **Chores**
  * Exposed the VARBINARY options type in public exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->