### PR TITLE
fix(core): apply beforeUpsert value changes to query payload

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2188,10 +2188,12 @@ ${associationOwner._getAssociationDebugList()}`);
       const beforeHookValues = cloneDeep(values);
       await this.hooks.runAsync('beforeUpsert', values, options);
 
-      const hookChangedValues = pickBy(
-        values,
-        (value, key) => !isEqual(value, beforeHookValues[key]),
-      );
+      const hookChangedValues = {};
+      for (const key of union(Object.keys(beforeHookValues), Object.keys(values))) {
+        if (!isEqual(values[key], beforeHookValues[key])) {
+          hookChangedValues[key] = values[key];
+        }
+      }
 
       instance.set(hookChangedValues);
 

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2168,6 +2168,8 @@ ${associationOwner._getAssociationDebugList()}`);
     options.instance = instance;
 
     let changed = [...instance._changed];
+    // Track whether the caller passed an explicit `fields` list so that hook-driven
+    // value changes don't widen the update payload beyond what the caller asked for.
     const fieldsSpecified = Boolean(options.fields);
     if (!options.fields) {
       options.fields = changed;

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2161,13 +2161,14 @@ ${associationOwner._getAssociationDebugList()}`);
 
     const createdAtAttr = modelDefinition.timestampAttributeNames.createdAt;
     const updatedAtAttr = modelDefinition.timestampAttributeNames.updatedAt;
-    const hasPrimary = this.primaryKeyField in values || this.primaryKeyAttribute in values;
+    let hasPrimary = this.primaryKeyField in values || this.primaryKeyAttribute in values;
     const instance = this.build(values);
 
     options.model = this;
     options.instance = instance;
 
-    const changed = [...instance._changed];
+    let changed = [...instance._changed];
+    const fieldsSpecified = Boolean(options.fields);
     if (!options.fields) {
       options.fields = changed;
     }
@@ -2181,6 +2182,24 @@ ${associationOwner._getAssociationDebugList()}`);
       options.conflictFields = options.conflictFields.map(attrName => {
         return modelDefinition.getColumnName(attrName);
       });
+    }
+
+    if (options.hooks) {
+      const beforeHookValues = cloneDeep(values);
+      await this.hooks.runAsync('beforeUpsert', values, options);
+
+      const hookChangedValues = pickBy(
+        values,
+        (value, key) => !isEqual(value, beforeHookValues[key]),
+      );
+
+      instance.set(hookChangedValues);
+
+      hasPrimary = this.primaryKeyField in values || this.primaryKeyAttribute in values;
+      changed = [...instance._changed];
+      if (!fieldsSpecified) {
+        options.fields = changed;
+      }
     }
 
     // Map field names
@@ -2225,10 +2244,6 @@ ${associationOwner._getAssociationDebugList()}`);
     ) {
       delete insertValues[this.primaryKeyField];
       delete updateValues[this.primaryKeyField];
-    }
-
-    if (options.hooks) {
-      await this.hooks.runAsync('beforeUpsert', values, options);
     }
 
     const result = await this.queryInterface.upsert(

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2199,7 +2199,11 @@ ${associationOwner._getAssociationDebugList()}`);
 
       instance.set(hookChangedValues);
 
-      hasPrimary = this.primaryKeyField in values || this.primaryKeyAttribute in values;
+      hasPrimary =
+        this.primaryKeyField in values ||
+        this.primaryKeyAttribute in values ||
+        instance._changed.has(this.primaryKeyAttribute) ||
+        instance._changed.has(this.primaryKeyField);
       changed = [...instance._changed];
       if (!fieldsSpecified) {
         options.fields = changed;

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2175,10 +2175,6 @@ ${associationOwner._getAssociationDebugList()}`);
       options.fields = changed;
     }
 
-    if (options.validate) {
-      await instance.validate(options);
-    }
-
     // Map conflict fields to column names
     if (options.conflictFields) {
       options.conflictFields = options.conflictFields.map(attrName => {
@@ -2208,6 +2204,12 @@ ${associationOwner._getAssociationDebugList()}`);
       if (!fieldsSpecified) {
         options.fields = changed;
       }
+    }
+
+    // Validate after beforeUpsert so hook-driven mutations are validated
+    // before being written to the database.
+    if (options.validate) {
+      await instance.validate(options);
     }
 
     // Map field names

--- a/packages/core/test/integration/hooks/upsert.test.js
+++ b/packages/core/test/integration/hooks/upsert.test.js
@@ -80,8 +80,48 @@ if (Support.sequelize.dialect.supports.upserts) {
             hookCalled++;
           });
 
-          await this.User.upsert(valuesOriginal);
+          const [user] = await this.User.upsert(valuesOriginal);
+          const persistedUser = await this.User.findOne({ where: { username: 'leafninja' } });
+
           expect(valuesOriginal.mood).to.equal('happy');
+          expect(user.mood).to.equal('happy');
+          expect(persistedUser.mood).to.equal('happy');
+          expect(hookCalled).to.equal(1);
+        });
+
+        it('beforeUpsert on update', async function () {
+          let hookCalled = 0;
+
+          this.User.beforeUpsert(values => {
+            values.mood = 'happy';
+            hookCalled++;
+          });
+
+          await this.User.create({ mood: 'sad', username: 'leafninja' });
+          const [user] = await this.User.upsert({ mood: 'neutral', username: 'leafninja' });
+          const persistedUser = await this.User.findOne({ where: { username: 'leafninja' } });
+
+          expect(user.mood).to.equal('happy');
+          expect(persistedUser.mood).to.equal('happy');
+          expect(hookCalled).to.equal(1);
+        });
+
+        it('beforeUpsert keeps explicit fields limited on update', async function () {
+          let hookCalled = 0;
+
+          this.User.beforeUpsert(values => {
+            values.mood = 'happy';
+            hookCalled++;
+          });
+
+          await this.User.create({ mood: 'sad', username: 'leafninja' });
+          await this.User.upsert(
+            { mood: 'neutral', username: 'leafninja' },
+            { fields: ['username'] },
+          );
+          const persistedUser = await this.User.findOne({ where: { username: 'leafninja' } });
+
+          expect(persistedUser.mood).to.equal('sad');
           expect(hookCalled).to.equal(1);
         });
       });

--- a/packages/core/test/integration/hooks/upsert.test.js
+++ b/packages/core/test/integration/hooks/upsert.test.js
@@ -80,11 +80,10 @@ if (Support.sequelize.dialect.supports.upserts) {
             hookCalled++;
           });
 
-          const [user] = await this.User.upsert(valuesOriginal);
+          await this.User.upsert(valuesOriginal);
           const persistedUser = await this.User.findOne({ where: { username: 'leafninja' } });
 
           expect(valuesOriginal.mood).to.equal('happy');
-          expect(user.mood).to.equal('happy');
           expect(persistedUser.mood).to.equal('happy');
           expect(hookCalled).to.equal(1);
         });
@@ -98,10 +97,9 @@ if (Support.sequelize.dialect.supports.upserts) {
           });
 
           await this.User.create({ mood: 'sad', username: 'leafninja' });
-          const [user] = await this.User.upsert({ mood: 'neutral', username: 'leafninja' });
+          await this.User.upsert({ mood: 'neutral', username: 'leafninja' });
           const persistedUser = await this.User.findOne({ where: { username: 'leafninja' } });
 
-          expect(user.mood).to.equal('happy');
           expect(persistedUser.mood).to.equal('happy');
           expect(hookCalled).to.equal(1);
         });

--- a/packages/core/test/unit/model/upsert.test.js
+++ b/packages/core/test/unit/model/upsert.test.js
@@ -100,6 +100,56 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           'updatedAt',
         ]);
       });
+
+      it('uses beforeUpsert changes in insert and update values', async function () {
+        const unhook = this.User.hooks.addListener('beforeUpsert', values => {
+          values.name = 'Hooked Cat';
+          values.virtualValue = '222';
+        });
+
+        try {
+          await this.User.upsert({
+            name: 'Old Cat',
+            secretValue: 1,
+          });
+        } finally {
+          unhook();
+        }
+
+        const [, insertValues, updateValues] = this.stub.getCall(0).args;
+        expect(insertValues.name).to.equal('Hooked Cat');
+        expect(insertValues.value).to.equal('222');
+        expect(updateValues.name).to.equal('Hooked Cat');
+        expect(updateValues.value).to.equal('222');
+      });
+
+      it('does not add beforeUpsert changes to explicitly configured update fields', async function () {
+        const unhook = this.User.hooks.addListener('beforeUpsert', values => {
+          values.name = 'Hooked Cat';
+          values.virtualValue = '222';
+        });
+
+        try {
+          await this.User.upsert(
+            {
+              name: 'Old Cat',
+              secretValue: 1,
+            },
+            {
+              fields: ['secretValue'],
+            },
+          );
+        } finally {
+          unhook();
+        }
+
+        const [, insertValues, updateValues] = this.stub.getCall(0).args;
+        expect(insertValues.name).to.equal('Hooked Cat');
+        expect(insertValues.value).to.equal('222');
+        expect(updateValues).not.to.have.property('name');
+        expect(updateValues).not.to.have.property('value');
+        expect(updateValues.secretValue).to.equal(1);
+      });
     });
   }
 });

--- a/packages/core/test/unit/model/upsert.test.js
+++ b/packages/core/test/unit/model/upsert.test.js
@@ -151,7 +151,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(updateValues.secretValue).to.equal(1);
       });
 
-      it('uses beforeUpsert deleted values in insert and update values', async function () {
+      it('removes properties deleted in beforeUpsert from insert and update values', async function () {
         const unhook = this.User.hooks.addListener('beforeUpsert', values => {
           delete values.name;
         });

--- a/packages/core/test/unit/model/upsert.test.js
+++ b/packages/core/test/unit/model/upsert.test.js
@@ -151,6 +151,35 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(updateValues.secretValue).to.equal(1);
       });
 
+      it('preserves primary key set on options.instance in beforeUpsert', async function () {
+        const Item = current.define('Item', {
+          id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+          },
+          name: DataTypes.STRING,
+        });
+
+        const stub = sinon
+          .stub(current.queryInterface, 'upsert')
+          .resolves([Item.build(), true]);
+
+        const unhook = Item.hooks.addListener('beforeUpsert', (values, options) => {
+          options.instance.set('id', 42);
+        });
+
+        try {
+          await Item.upsert({ name: 'Whiskers' });
+        } finally {
+          unhook();
+          stub.restore();
+        }
+
+        const [, insertValues, updateValues] = stub.getCall(0).args;
+        expect(insertValues.id).to.equal(42);
+        expect(updateValues.id).to.equal(42);
+      });
+
       it('removes properties deleted in beforeUpsert from insert and update values', async function () {
         const unhook = this.User.hooks.addListener('beforeUpsert', values => {
           delete values.name;

--- a/packages/core/test/unit/model/upsert.test.js
+++ b/packages/core/test/unit/model/upsert.test.js
@@ -150,6 +150,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(updateValues).not.to.have.property('value');
         expect(updateValues.secretValue).to.equal(1);
       });
+
+      it('uses beforeUpsert deleted values in insert and update values', async function () {
+        const unhook = this.User.hooks.addListener('beforeUpsert', values => {
+          delete values.name;
+        });
+
+        try {
+          await this.User.upsert({
+            name: 'Old Cat',
+            secretValue: 1,
+          });
+        } finally {
+          unhook();
+        }
+
+        const [, insertValues, updateValues] = this.stub.getCall(0).args;
+        expect(insertValues).not.to.have.property('name');
+        expect(updateValues).not.to.have.property('name');
+      });
     });
   }
 });

--- a/packages/core/test/unit/model/upsert.test.js
+++ b/packages/core/test/unit/model/upsert.test.js
@@ -160,9 +160,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           name: DataTypes.STRING,
         });
 
-        const stub = sinon
-          .stub(current.queryInterface, 'upsert')
-          .resolves([Item.build(), true]);
+        this.stub.resolves([Item.build(), true]);
 
         const unhook = Item.hooks.addListener('beforeUpsert', (values, options) => {
           options.instance.set('id', 42);
@@ -172,10 +170,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           await Item.upsert({ name: 'Whiskers' });
         } finally {
           unhook();
-          stub.restore();
         }
 
-        const [, insertValues, updateValues] = stub.getCall(0).args;
+        const [, insertValues, updateValues] = this.stub.getCall(0).args;
         expect(insertValues.id).to.equal(42);
         expect(updateValues.id).to.equal(42);
       });


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Fixes #8829.

`Model.upsert` ran `beforeUpsert` after `insertValues` and `updateValues` had already been derived from the built instance. As a result, mutations made by `beforeUpsert` were visible on the original values object but were not sent to the database. 

This changes `upsert` to run `beforeUpsert` before mapping the insert/update payloads, sync hook-mutated values back into the built instance, and preserve explicit `fields` behavior so hook changes do not widen the update payload when fields are user-specified.

## List of Breaking Changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upsert now applies hook-driven modifications before determining which fields to persist; insert/update payloads honor post-hook changes and deletions, while explicit field lists are respected.

* **Tests**
  * Added integration and unit tests verifying hooks run, mutated values persist as expected, and behavior with explicit upsert fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->