### PR TITLE
fix: pass options object instead of boolean true to isJSON validator

### DIFF
--- a/packages/core/src/instance-validator.js
+++ b/packages/core/src/instance-validator.js
@@ -383,6 +383,9 @@ export class InstanceValidator {
         validatorArgs = [validatorArgs, field, this.modelInstance];
       } else if (isLocalizedValidator || validatorType === 'isIP') {
         validatorArgs = [];
+      } else if (validatorType === 'isJSON' && validatorArgs === true) {
+        // validator.js v13+ expects an options object for isJSON, not a boolean
+        validatorArgs = [{}];
       } else {
         validatorArgs = [validatorArgs];
       }

--- a/packages/core/src/instance-validator.js
+++ b/packages/core/src/instance-validator.js
@@ -384,7 +384,10 @@ export class InstanceValidator {
       } else if (isLocalizedValidator || validatorType === 'isIP') {
         validatorArgs = [];
       } else if (validatorType === 'isJSON' && validatorArgs === true) {
-        // validator.js v13+ expects an options object for isJSON, not a boolean
+        // validator.js v13+ expects an options object for isJSON, not a boolean.
+        // Passing `{}` uses validator.js defaults: both objects ({}) and arrays ([])
+        // are accepted as valid JSON. Primitives (strings, numbers, null) are rejected
+        // unless allow_primitives is explicitly set to true in the options object.
         validatorArgs = [{}];
       } else {
         validatorArgs = [validatorArgs];

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -163,7 +163,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     let JsonUser;
 
     beforeEach(() => {
-      JsonUser = Support.sequelize.define(`JsonUser${Math.random().toString(36).slice(2)}`, {
+      JsonUser = Support.sequelize.define('JsonUser', {
         data: {
           type: DataTypes.STRING,
           validate: {
@@ -186,6 +186,14 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     it('accepts a non-empty JSON array string when isJSON is true', async () => {
       const instance = JsonUser.build({ data: '[1,2,3]' });
       await expect(instance.validate()).not.to.be.rejected;
+    });
+
+    it('rejects JSON primitive values when isJSON is true with default options', async () => {
+      const instance = JsonUser.build({ data: '123' });
+      await expect(instance.validate()).to.be.rejectedWith(
+        SequelizeValidationError,
+        /isJSON/,
+      );
     });
 
     it('rejects an invalid JSON string when isJSON is true', async () => {

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -1,26 +1,29 @@
-'use strict';
+"use strict";
 
-const chai = require('chai');
+const chai = require("chai");
 
 const expect = chai.expect;
-const Support = require('../support');
+const Support = require("../support");
 const {
   InstanceValidator,
-} = require('@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator.js');
-const sinon = require('sinon');
-const { DataTypes, ValidationError: SequelizeValidationError } = require('@sequelize/core');
+} = require("@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator.js");
+const sinon = require("sinon");
+const {
+  DataTypes,
+  ValidationError: SequelizeValidationError,
+} = require("@sequelize/core");
 
 const ValidationError = SequelizeValidationError;
 
-describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
+describe(Support.getTestDialectTeaser("InstanceValidator"), () => {
   beforeEach(function () {
-    this.User = Support.sequelize.define('user', {
+    this.User = Support.sequelize.define("user", {
       fails: {
         type: DataTypes.BOOLEAN,
         validate: {
           isNotTrue(value) {
             if (value) {
-              throw new Error('Manual model validation failure');
+              throw new Error("Manual model validation failure");
             }
           },
         },
@@ -28,16 +31,21 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     });
   });
 
-  it('configures itself to run hooks by default', () => {
+  it("configures itself to run hooks by default", () => {
     const instanceValidator = new InstanceValidator();
     expect(instanceValidator.options.hooks).to.equal(true);
   });
 
-  describe('validate', () => {
-    it('runs the validation sequence and hooks when the hooks option is true', function () {
-      const instanceValidator = new InstanceValidator(this.User.build(), { hooks: true });
-      const _validate = sinon.spy(instanceValidator, '_validate');
-      const _validateAndRunHooks = sinon.spy(instanceValidator, '_validateAndRunHooks');
+  describe("validate", () => {
+    it("runs the validation sequence and hooks when the hooks option is true", function () {
+      const instanceValidator = new InstanceValidator(this.User.build(), {
+        hooks: true,
+      });
+      const _validate = sinon.spy(instanceValidator, "_validate");
+      const _validateAndRunHooks = sinon.spy(
+        instanceValidator,
+        "_validateAndRunHooks",
+      );
 
       instanceValidator.validate();
 
@@ -45,10 +53,15 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       expect(_validate).to.not.have.been.called;
     });
 
-    it('runs the validation sequence but skips hooks if the hooks option is false', function () {
-      const instanceValidator = new InstanceValidator(this.User.build(), { hooks: false });
-      const _validate = sinon.spy(instanceValidator, '_validate');
-      const _validateAndRunHooks = sinon.spy(instanceValidator, '_validateAndRunHooks');
+    it("runs the validation sequence but skips hooks if the hooks option is false", function () {
+      const instanceValidator = new InstanceValidator(this.User.build(), {
+        hooks: false,
+      });
+      const _validate = sinon.spy(instanceValidator, "_validate");
+      const _validateAndRunHooks = sinon.spy(
+        instanceValidator,
+        "_validateAndRunHooks",
+      );
 
       instanceValidator.validate();
 
@@ -56,22 +69,24 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       expect(_validateAndRunHooks).to.not.have.been.called;
     });
 
-    it('fulfills when validation is successful', async function () {
+    it("fulfills when validation is successful", async function () {
       const instanceValidator = new InstanceValidator(this.User.build());
       const result = instanceValidator.validate();
 
       await expect(result).to.be.fulfilled;
     });
 
-    it('rejects with a validation error when validation fails', async function () {
-      const instanceValidator = new InstanceValidator(this.User.build({ fails: true }));
+    it("rejects with a validation error when validation fails", async function () {
+      const instanceValidator = new InstanceValidator(
+        this.User.build({ fails: true }),
+      );
       const result = instanceValidator.validate();
 
       await expect(result).to.be.rejectedWith(SequelizeValidationError);
     });
 
-    it('has a useful default error message for not null validation failures', async () => {
-      const User = Support.sequelize.define('user', {
+    it("has a useful default error message for not null validation failures", async () => {
+      const User = Support.sequelize.define("user", {
         name: {
           type: DataTypes.STRING,
           allowNull: false,
@@ -88,118 +103,142 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     });
   });
 
-  describe('_validateAndRunHooks', () => {
+  describe("_validateAndRunHooks", () => {
     beforeEach(function () {
-      this.successfulInstanceValidator = new InstanceValidator(this.User.build());
-      sinon.stub(this.successfulInstanceValidator, '_validate').resolves();
+      this.successfulInstanceValidator = new InstanceValidator(
+        this.User.build(),
+      );
+      sinon.stub(this.successfulInstanceValidator, "_validate").resolves();
     });
 
-    it('should run beforeValidate and afterValidate hooks when _validate is successful', async function () {
+    it("should run beforeValidate and afterValidate hooks when _validate is successful", async function () {
       const beforeValidate = sinon.spy();
       const afterValidate = sinon.spy();
       this.User.beforeValidate(beforeValidate);
       this.User.afterValidate(afterValidate);
 
-      await expect(this.successfulInstanceValidator._validateAndRunHooks()).to.be.fulfilled;
+      await expect(this.successfulInstanceValidator._validateAndRunHooks()).to
+        .be.fulfilled;
       expect(beforeValidate).to.have.been.calledOnce;
       expect(afterValidate).to.have.been.calledOnce;
     });
 
-    it('should run beforeValidate hook but not afterValidate hook when _validate is unsuccessful', async function () {
+    it("should run beforeValidate hook but not afterValidate hook when _validate is unsuccessful", async function () {
       const failingInstanceValidator = new InstanceValidator(this.User.build());
-      sinon.stub(failingInstanceValidator, '_validate').rejects(new Error());
+      sinon.stub(failingInstanceValidator, "_validate").rejects(new Error());
       const beforeValidate = sinon.spy();
       const afterValidate = sinon.spy();
       this.User.beforeValidate(beforeValidate);
       this.User.afterValidate(afterValidate);
 
-      await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
+      await expect(failingInstanceValidator._validateAndRunHooks()).to.be
+        .rejected;
       expect(beforeValidate).to.have.been.calledOnce;
       expect(afterValidate).to.not.have.been.called;
     });
 
-    it('should emit an error from after hook when afterValidate fails', async function () {
+    it("should emit an error from after hook when afterValidate fails", async function () {
       this.User.afterValidate(() => {
-        throw new Error('after validation error');
+        throw new Error("after validation error");
       });
 
-      await expect(this.successfulInstanceValidator._validateAndRunHooks()).to.be.rejectedWith(
-        'after validation error',
-      );
+      await expect(
+        this.successfulInstanceValidator._validateAndRunHooks(),
+      ).to.be.rejectedWith("after validation error");
     });
 
-    describe('validatedFailed hook', () => {
-      it('should call validationFailed hook when validation fails', async function () {
-        const failingInstanceValidator = new InstanceValidator(this.User.build());
-        sinon.stub(failingInstanceValidator, '_validate').rejects(new Error());
+    describe("validatedFailed hook", () => {
+      it("should call validationFailed hook when validation fails", async function () {
+        const failingInstanceValidator = new InstanceValidator(
+          this.User.build(),
+        );
+        sinon.stub(failingInstanceValidator, "_validate").rejects(new Error());
         const validationFailedHook = sinon.spy();
         this.User.validationFailed(validationFailedHook);
 
-        await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
+        await expect(failingInstanceValidator._validateAndRunHooks()).to.be
+          .rejected;
         expect(validationFailedHook).to.have.been.calledOnce;
       });
 
-      it('should not replace the validation error in validationFailed hook by default', async function () {
-        const failingInstanceValidator = new InstanceValidator(this.User.build());
-        sinon.stub(failingInstanceValidator, '_validate').rejects(new SequelizeValidationError());
+      it("should not replace the validation error in validationFailed hook by default", async function () {
+        const failingInstanceValidator = new InstanceValidator(
+          this.User.build(),
+        );
+        sinon
+          .stub(failingInstanceValidator, "_validate")
+          .rejects(new SequelizeValidationError());
         const validationFailedHook = sinon.stub().resolves();
         this.User.validationFailed(validationFailedHook);
 
-        const err = await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
-        expect(err.name).to.equal('SequelizeValidationError');
+        const err = await expect(
+          failingInstanceValidator._validateAndRunHooks(),
+        ).to.be.rejected;
+        expect(err.name).to.equal("SequelizeValidationError");
       });
 
-      it('should replace the validation error if validationFailed hook creates a new error', async function () {
-        const failingInstanceValidator = new InstanceValidator(this.User.build());
-        sinon.stub(failingInstanceValidator, '_validate').rejects(new SequelizeValidationError());
-        const validationFailedHook = sinon.stub().throws(new Error('validation failed hook error'));
+      it("should replace the validation error if validationFailed hook creates a new error", async function () {
+        const failingInstanceValidator = new InstanceValidator(
+          this.User.build(),
+        );
+        sinon
+          .stub(failingInstanceValidator, "_validate")
+          .rejects(new SequelizeValidationError());
+        const validationFailedHook = sinon
+          .stub()
+          .throws(new Error("validation failed hook error"));
         this.User.validationFailed(validationFailedHook);
 
-        const err = await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
-        expect(err.message).to.equal('validation failed hook error');
+        const err = await expect(
+          failingInstanceValidator._validateAndRunHooks(),
+        ).to.be.rejected;
+        expect(err.message).to.equal("validation failed hook error");
       });
     });
   });
 
-  describe('isJSON validator regression (validator.js v13+)', () => {
+  describe("isJSON validator regression (validator.js v13+)", () => {
     let JsonUser;
 
     beforeEach(() => {
-      JsonUser = Support.sequelize.define(`JsonUser${Math.random().toString(36).slice(2)}`, {
-        data: {
-          type: DataTypes.STRING,
-          validate: {
-            isJSON: true,
+      JsonUser = Support.sequelize.define(
+        `JsonUser${Math.random().toString(36).slice(2)}`,
+        {
+          data: {
+            type: DataTypes.STRING,
+            validate: {
+              isJSON: true,
+            },
           },
         },
-      });
+      );
     });
 
-    it('accepts a valid JSON object string when isJSON is true', async () => {
+    it("accepts a valid JSON object string when isJSON is true", async () => {
       const instance = JsonUser.build({ data: '{"key":"value"}' });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it('accepts a valid JSON array string when isJSON is true', async () => {
+    it("accepts a valid JSON array string when isJSON is true", async () => {
       // Empty arrays are valid JSON and must not be rejected
-      const instance = JsonUser.build({ data: '[]' });
+      const instance = JsonUser.build({ data: "[]" });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it('accepts a non-empty JSON array string when isJSON is true', async () => {
-      const instance = JsonUser.build({ data: '[1,2,3]' });
+    it("accepts a non-empty JSON array string when isJSON is true", async () => {
+      const instance = JsonUser.build({ data: "[1,2,3]" });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it('rejects an invalid JSON string when isJSON is true', async () => {
-      const instance = JsonUser.build({ data: 'not-json' });
+    it("rejects an invalid JSON string when isJSON is true", async () => {
+      const instance = JsonUser.build({ data: "not-json" });
       await expect(instance.validate()).to.be.rejectedWith(
         ValidationError,
         /isJSON/,
       );
     });
 
-    it('does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)', async () => {
+    it("does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)", async () => {
       const instance = JsonUser.build({ data: '{"valid":true}' });
       await expect(instance.validate()).not.to.be.rejected;
     });

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -9,6 +9,7 @@ const {
 } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator.js');
 const sinon = require('sinon');
 const { DataTypes, ValidationError: SequelizeValidationError } = require('@sequelize/core');
+const ValidationError = SequelizeValidationError;
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   beforeEach(function () {
@@ -156,6 +157,64 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         const err = await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
         expect(err.message).to.equal('validation failed hook error');
       });
+    });
+  });
+
+  describe('isJSON validator regression (validator.js v13+)', () => {
+    let JsonUser;
+
+    beforeEach(function () {
+      JsonUser = Support.sequelize.define(`JsonUser${Math.random().toString(36).slice(2)}`, {
+        data: {
+          type: DataTypes.STRING,
+          validate: {
+            isJSON: true,
+          },
+        },
+      });
+    });
+
+    it('accepts a valid JSON object string when isJSON is true', async function () {
+      const instance = JsonUser.build({ data: '{"key":"value"}' });
+      await expect(instance.validate()).not.to.be.rejectedWith(
+        Error,
+        /TypeError/,
+      );
+    });
+
+    it('accepts a valid JSON array string when isJSON is true', async function () {
+      // Empty arrays are valid JSON and must not be rejected
+      const instance = JsonUser.build({ data: '[]' });
+      await expect(instance.validate()).not.to.be.rejected;
+    });
+
+    it('accepts a non-empty JSON array string when isJSON is true', async function () {
+      const instance = JsonUser.build({ data: '[1,2,3]' });
+      await expect(instance.validate()).not.to.be.rejected;
+    });
+
+    it('rejects an invalid JSON string when isJSON is true', async function () {
+      const instance = JsonUser.build({ data: 'not-json' });
+      await expect(instance.validate()).to.be.rejectedWith(
+        ValidationError,
+        /isJSON/,
+      );
+    });
+
+    it('does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)', async function () {
+      // Before the fix, passing `true` directly to validator.js isJSON caused a TypeError
+      // because v13+ expects an options object, not a boolean.
+      const instance = JsonUser.build({ data: '{"valid":true}' });
+      let caughtError = null;
+      try {
+        await instance.validate();
+      } catch (error) {
+        caughtError = error;
+      }
+
+      if (caughtError) {
+        expect(caughtError).not.to.be.instanceOf(TypeError);
+      }
     });
   });
 });

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -191,7 +191,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     it('rejects an invalid JSON string when isJSON is true', async () => {
       const instance = JsonUser.build({ data: 'not-json' });
       await expect(instance.validate()).to.be.rejectedWith(
-        ValidationError,
+        SequelizeValidationError,
         /isJSON/,
       );
     });

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -1,29 +1,24 @@
-"use strict";
+'use strict';
 
-const chai = require("chai");
+const chai = require('chai');
 
 const expect = chai.expect;
-const Support = require("../support");
+const Support = require('../support');
 const {
   InstanceValidator,
-} = require("@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator.js");
-const sinon = require("sinon");
-const {
-  DataTypes,
-  ValidationError: SequelizeValidationError,
-} = require("@sequelize/core");
+} = require('@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator.js');
+const sinon = require('sinon');
+const { DataTypes, ValidationError: SequelizeValidationError } = require('@sequelize/core');
 
-const ValidationError = SequelizeValidationError;
-
-describe(Support.getTestDialectTeaser("InstanceValidator"), () => {
+describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   beforeEach(function () {
-    this.User = Support.sequelize.define("user", {
+    this.User = Support.sequelize.define('user', {
       fails: {
         type: DataTypes.BOOLEAN,
         validate: {
           isNotTrue(value) {
             if (value) {
-              throw new Error("Manual model validation failure");
+              throw new Error('Manual model validation failure');
             }
           },
         },
@@ -31,21 +26,16 @@ describe(Support.getTestDialectTeaser("InstanceValidator"), () => {
     });
   });
 
-  it("configures itself to run hooks by default", () => {
+  it('configures itself to run hooks by default', () => {
     const instanceValidator = new InstanceValidator();
     expect(instanceValidator.options.hooks).to.equal(true);
   });
 
-  describe("validate", () => {
-    it("runs the validation sequence and hooks when the hooks option is true", function () {
-      const instanceValidator = new InstanceValidator(this.User.build(), {
-        hooks: true,
-      });
-      const _validate = sinon.spy(instanceValidator, "_validate");
-      const _validateAndRunHooks = sinon.spy(
-        instanceValidator,
-        "_validateAndRunHooks",
-      );
+  describe('validate', () => {
+    it('runs the validation sequence and hooks when the hooks option is true', function () {
+      const instanceValidator = new InstanceValidator(this.User.build(), { hooks: true });
+      const _validate = sinon.spy(instanceValidator, '_validate');
+      const _validateAndRunHooks = sinon.spy(instanceValidator, '_validateAndRunHooks');
 
       instanceValidator.validate();
 
@@ -53,15 +43,10 @@ describe(Support.getTestDialectTeaser("InstanceValidator"), () => {
       expect(_validate).to.not.have.been.called;
     });
 
-    it("runs the validation sequence but skips hooks if the hooks option is false", function () {
-      const instanceValidator = new InstanceValidator(this.User.build(), {
-        hooks: false,
-      });
-      const _validate = sinon.spy(instanceValidator, "_validate");
-      const _validateAndRunHooks = sinon.spy(
-        instanceValidator,
-        "_validateAndRunHooks",
-      );
+    it('runs the validation sequence but skips hooks if the hooks option is false', function () {
+      const instanceValidator = new InstanceValidator(this.User.build(), { hooks: false });
+      const _validate = sinon.spy(instanceValidator, '_validate');
+      const _validateAndRunHooks = sinon.spy(instanceValidator, '_validateAndRunHooks');
 
       instanceValidator.validate();
 
@@ -69,24 +54,22 @@ describe(Support.getTestDialectTeaser("InstanceValidator"), () => {
       expect(_validateAndRunHooks).to.not.have.been.called;
     });
 
-    it("fulfills when validation is successful", async function () {
+    it('fulfills when validation is successful', async function () {
       const instanceValidator = new InstanceValidator(this.User.build());
       const result = instanceValidator.validate();
 
       await expect(result).to.be.fulfilled;
     });
 
-    it("rejects with a validation error when validation fails", async function () {
-      const instanceValidator = new InstanceValidator(
-        this.User.build({ fails: true }),
-      );
+    it('rejects with a validation error when validation fails', async function () {
+      const instanceValidator = new InstanceValidator(this.User.build({ fails: true }));
       const result = instanceValidator.validate();
 
       await expect(result).to.be.rejectedWith(SequelizeValidationError);
     });
 
-    it("has a useful default error message for not null validation failures", async () => {
-      const User = Support.sequelize.define("user", {
+    it('has a useful default error message for not null validation failures', async () => {
+      const User = Support.sequelize.define('user', {
         name: {
           type: DataTypes.STRING,
           allowNull: false,
@@ -98,147 +81,122 @@ describe(Support.getTestDialectTeaser("InstanceValidator"), () => {
 
       await expect(result).to.be.rejectedWith(
         SequelizeValidationError,
-        /user\.name cannot be null/,
+        /user\\.name cannot be null/,
       );
     });
   });
 
-  describe("_validateAndRunHooks", () => {
+  describe('_validateAndRunHooks', () => {
     beforeEach(function () {
-      this.successfulInstanceValidator = new InstanceValidator(
-        this.User.build(),
-      );
-      sinon.stub(this.successfulInstanceValidator, "_validate").resolves();
+      this.successfulInstanceValidator = new InstanceValidator(this.User.build());
+      sinon.stub(this.successfulInstanceValidator, '_validate').resolves();
     });
 
-    it("should run beforeValidate and afterValidate hooks when _validate is successful", async function () {
+    it('should run beforeValidate and afterValidate hooks when _validate is successful', async function () {
       const beforeValidate = sinon.spy();
       const afterValidate = sinon.spy();
       this.User.beforeValidate(beforeValidate);
       this.User.afterValidate(afterValidate);
 
-      await expect(this.successfulInstanceValidator._validateAndRunHooks()).to
-        .be.fulfilled;
+      await expect(this.successfulInstanceValidator._validateAndRunHooks()).to.be.fulfilled;
       expect(beforeValidate).to.have.been.calledOnce;
       expect(afterValidate).to.have.been.calledOnce;
     });
 
-    it("should run beforeValidate hook but not afterValidate hook when _validate is unsuccessful", async function () {
+    it('should run beforeValidate hook but not afterValidate hook when _validate is unsuccessful', async function () {
       const failingInstanceValidator = new InstanceValidator(this.User.build());
-      sinon.stub(failingInstanceValidator, "_validate").rejects(new Error());
+      sinon.stub(failingInstanceValidator, '_validate').rejects(new Error());
       const beforeValidate = sinon.spy();
       const afterValidate = sinon.spy();
       this.User.beforeValidate(beforeValidate);
       this.User.afterValidate(afterValidate);
 
-      await expect(failingInstanceValidator._validateAndRunHooks()).to.be
-        .rejected;
+      await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
       expect(beforeValidate).to.have.been.calledOnce;
       expect(afterValidate).to.not.have.been.called;
     });
 
-    it("should emit an error from after hook when afterValidate fails", async function () {
+    it('should emit an error from after hook when afterValidate fails', async function () {
       this.User.afterValidate(() => {
-        throw new Error("after validation error");
+        throw new Error('after validation error');
       });
 
-      await expect(
-        this.successfulInstanceValidator._validateAndRunHooks(),
-      ).to.be.rejectedWith("after validation error");
+      await expect(this.successfulInstanceValidator._validateAndRunHooks()).to.be.rejectedWith(
+        'after validation error',
+      );
     });
 
-    describe("validatedFailed hook", () => {
-      it("should call validationFailed hook when validation fails", async function () {
-        const failingInstanceValidator = new InstanceValidator(
-          this.User.build(),
-        );
-        sinon.stub(failingInstanceValidator, "_validate").rejects(new Error());
+    describe('validatedFailed hook', () => {
+      it('should call validationFailed hook when validation fails', async function () {
+        const failingInstanceValidator = new InstanceValidator(this.User.build());
+        sinon.stub(failingInstanceValidator, '_validate').rejects(new Error());
         const validationFailedHook = sinon.spy();
         this.User.validationFailed(validationFailedHook);
 
-        await expect(failingInstanceValidator._validateAndRunHooks()).to.be
-          .rejected;
+        await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
         expect(validationFailedHook).to.have.been.calledOnce;
       });
 
-      it("should not replace the validation error in validationFailed hook by default", async function () {
-        const failingInstanceValidator = new InstanceValidator(
-          this.User.build(),
-        );
-        sinon
-          .stub(failingInstanceValidator, "_validate")
-          .rejects(new SequelizeValidationError());
+      it('should not replace the validation error in validationFailed hook by default', async function () {
+        const failingInstanceValidator = new InstanceValidator(this.User.build());
+        sinon.stub(failingInstanceValidator, '_validate').rejects(new SequelizeValidationError());
         const validationFailedHook = sinon.stub().resolves();
         this.User.validationFailed(validationFailedHook);
 
-        const err = await expect(
-          failingInstanceValidator._validateAndRunHooks(),
-        ).to.be.rejected;
-        expect(err.name).to.equal("SequelizeValidationError");
+        const err = await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
+        expect(err.name).to.equal('SequelizeValidationError');
       });
 
-      it("should replace the validation error if validationFailed hook creates a new error", async function () {
-        const failingInstanceValidator = new InstanceValidator(
-          this.User.build(),
-        );
-        sinon
-          .stub(failingInstanceValidator, "_validate")
-          .rejects(new SequelizeValidationError());
-        const validationFailedHook = sinon
-          .stub()
-          .throws(new Error("validation failed hook error"));
+      it('should replace the validation error if validationFailed hook creates a new error', async function () {
+        const failingInstanceValidator = new InstanceValidator(this.User.build());
+        sinon.stub(failingInstanceValidator, '_validate').rejects(new SequelizeValidationError());
+        const validationFailedHook = sinon.stub().throws(new Error('validation failed hook error'));
         this.User.validationFailed(validationFailedHook);
 
-        const err = await expect(
-          failingInstanceValidator._validateAndRunHooks(),
-        ).to.be.rejected;
-        expect(err.message).to.equal("validation failed hook error");
+        const err = await expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected;
+        expect(err.message).to.equal('validation failed hook error');
       });
     });
   });
 
-  describe("isJSON validator regression (validator.js v13+)", () => {
+  describe('isJSON validator regression (validator.js v13+)', () => {
     let JsonUser;
 
     beforeEach(() => {
-      JsonUser = Support.sequelize.define(
-        `JsonUser${Math.random().toString(36).slice(2)}`,
-        {
-          data: {
-            type: DataTypes.STRING,
-            validate: {
-              isJSON: true,
-            },
+      JsonUser = Support.sequelize.define(`JsonUser${Math.random().toString(36).slice(2)}`, {
+        data: {
+          type: DataTypes.STRING,
+          validate: {
+            isJSON: true,
           },
         },
-      );
+      });
     });
 
-    it("accepts a valid JSON object string when isJSON is true", async () => {
+    it('accepts a valid JSON object string when isJSON is true', async () => {
       const instance = JsonUser.build({ data: '{"key":"value"}' });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it("accepts a valid JSON array string when isJSON is true", async () => {
-      // Empty arrays are valid JSON and must not be rejected
-      const instance = JsonUser.build({ data: "[]" });
+    it('accepts a valid JSON array string when isJSON is true', async () => {
+      const instance = JsonUser.build({ data: '[]' });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it("accepts a non-empty JSON array string when isJSON is true", async () => {
-      const instance = JsonUser.build({ data: "[1,2,3]" });
+    it('accepts a non-empty JSON array string when isJSON is true', async () => {
+      const instance = JsonUser.build({ data: '[1,2,3]' });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it("rejects an invalid JSON string when isJSON is true", async () => {
-      const instance = JsonUser.build({ data: "not-json" });
+    it('rejects an invalid JSON string when isJSON is true', async () => {
+      const instance = JsonUser.build({ data: 'not-json' });
       await expect(instance.validate()).to.be.rejectedWith(
         ValidationError,
         /isJSON/,
       );
     });
 
-    it("does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)", async () => {
+    it('does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)', async () => {
       const instance = JsonUser.build({ data: '{"valid":true}' });
       await expect(instance.validate()).not.to.be.rejected;
     });

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -9,6 +9,7 @@ const {
 } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator.js');
 const sinon = require('sinon');
 const { DataTypes, ValidationError: SequelizeValidationError } = require('@sequelize/core');
+
 const ValidationError = SequelizeValidationError;
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
@@ -163,7 +164,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   describe('isJSON validator regression (validator.js v13+)', () => {
     let JsonUser;
 
-    beforeEach(function () {
+    beforeEach(() => {
       JsonUser = Support.sequelize.define(`JsonUser${Math.random().toString(36).slice(2)}`, {
         data: {
           type: DataTypes.STRING,
@@ -174,23 +175,23 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       });
     });
 
-    it('accepts a valid JSON object string when isJSON is true', async function () {
+    it('accepts a valid JSON object string when isJSON is true', async () => {
       const instance = JsonUser.build({ data: '{"key":"value"}' });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it('accepts a valid JSON array string when isJSON is true', async function () {
+    it('accepts a valid JSON array string when isJSON is true', async () => {
       // Empty arrays are valid JSON and must not be rejected
       const instance = JsonUser.build({ data: '[]' });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it('accepts a non-empty JSON array string when isJSON is true', async function () {
+    it('accepts a non-empty JSON array string when isJSON is true', async () => {
       const instance = JsonUser.build({ data: '[1,2,3]' });
       await expect(instance.validate()).not.to.be.rejected;
     });
 
-    it('rejects an invalid JSON string when isJSON is true', async function () {
+    it('rejects an invalid JSON string when isJSON is true', async () => {
       const instance = JsonUser.build({ data: 'not-json' });
       await expect(instance.validate()).to.be.rejectedWith(
         ValidationError,
@@ -198,7 +199,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       );
     });
 
-    it('does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)', async function () {
+    it('does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)', async () => {
       const instance = JsonUser.build({ data: '{"valid":true}' });
       await expect(instance.validate()).not.to.be.rejected;
     });

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -176,10 +176,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     it('accepts a valid JSON object string when isJSON is true', async function () {
       const instance = JsonUser.build({ data: '{"key":"value"}' });
-      await expect(instance.validate()).not.to.be.rejectedWith(
-        Error,
-        /TypeError/,
-      );
+      await expect(instance.validate()).not.to.be.rejected;
     });
 
     it('accepts a valid JSON array string when isJSON is true', async function () {
@@ -202,19 +199,8 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     });
 
     it('does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)', async function () {
-      // Before the fix, passing `true` directly to validator.js isJSON caused a TypeError
-      // because v13+ expects an options object, not a boolean.
       const instance = JsonUser.build({ data: '{"valid":true}' });
-      let caughtError = null;
-      try {
-        await instance.validate();
-      } catch (error) {
-        caughtError = error;
-      }
-
-      if (caughtError) {
-        expect(caughtError).not.to.be.instanceOf(TypeError);
-      }
+      await expect(instance.validate()).not.to.be.rejected;
     });
   });
 });

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -190,18 +190,12 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     it('rejects JSON primitive values when isJSON is true with default options', async () => {
       const instance = JsonUser.build({ data: '123' });
-      await expect(instance.validate()).to.be.rejectedWith(
-        SequelizeValidationError,
-        /isJSON/,
-      );
+      await expect(instance.validate()).to.be.rejectedWith(SequelizeValidationError, /isJSON/);
     });
 
     it('rejects an invalid JSON string when isJSON is true', async () => {
       const instance = JsonUser.build({ data: 'not-json' });
-      await expect(instance.validate()).to.be.rejectedWith(
-        SequelizeValidationError,
-        /isJSON/,
-      );
+      await expect(instance.validate()).to.be.rejectedWith(SequelizeValidationError, /isJSON/);
     });
 
     it('does not throw a TypeError when isJSON is set to true (regression for validator.js v13+)', async () => {

--- a/packages/core/test/unit/model/validation.test.js
+++ b/packages/core/test/unit/model/validation.test.js
@@ -174,6 +174,12 @@ describe('InstanceValidator', () => {
         fail: '401288888888188f',
         pass: '4012888888881881',
       },
+      isJSON: {
+        // Both objects and arrays are valid JSON; primitives are not accepted by default.
+        // Empty arrays ([]) are also valid JSON and must not be rejected.
+        fail: 'not-json',
+        pass: '{"key":"value"}',
+      },
     };
 
     const applyFailTest = function applyFailTest(validatorDetails, i, validator) {


### PR DESCRIPTION
## Summary

Fixes a regression where `validate: { isJSON: true }` fails with validator.js v13+.

The `validator.isJSON(str, options)` function now expects `options` to be an object, not a boolean. When a model sets `isJSON: true`, Sequelize extracted `true` as the validator argument and called `validator.isJSON(value, true)`, which throws because validator.js v13+ treats `true` as an invalid options argument.

## Changes

- Added special handling in `_extractValidatorArgs()` for `isJSON`: when the validator arg is boolean `true`, pass `{}` (empty options object) instead.

## Test plan

- The fix is minimal (3 lines added) and follows the existing pattern for other special-case validators (e.g., `isImmutable`, `isLocalizedValidator`).

## Related

- Fixes #18141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON validator configured as `true` now accepts valid JSON objects/arrays, rejects invalid JSON with a clear validation error, and no longer triggers a TypeError regression.
* **Tests**
  * Added and updated unit tests covering `isJSON` validator behavior for valid and invalid inputs, including object/array cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->