### PR TITLE
feat: remove default export, deprecate export properties

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -828,7 +828,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         unless they are themselves objects
       * If direction is set, should be prepended
 
-    Currently this function is only used for ordering / grouping columns and Sequelize.col(), but it could
+    Currently this function is only used for ordering / grouping columns and sql.col(), but it could
     potentially also be used for other places where we want to be able to call SQL functions (e.g. as default values)
    @private
   */
@@ -993,9 +993,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
     if (isPlainObject(collection) && collection.raw) {
       // simple objects with raw is no longer supported
-      throw new Error(
-        'The `{raw: "..."}` syntax is no longer supported.  Use `sequelize.literal` instead.',
-      );
+      throw new Error('The `{raw: "..."}` syntax is no longer supported. Use `sql` instead.');
     }
 
     throw new Error(`Unknown structure passed to order / group: ${NodeUtil.inspect(collection)}`);

--- a/packages/core/src/expression-builders/base-sql-expression.ts
+++ b/packages/core/src/expression-builders/base-sql-expression.ts
@@ -18,7 +18,7 @@ export declare const SQL_IDENTIFIER: unique symbol;
 
 /**
  * Utility functions for representing SQL functions, and columns that should be escaped.
- * Please do not use these functions directly, use Sequelize.fn and Sequelize.col instead.
+ * Please do not use these functions directly.
  *
  * @private
  */

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -76,6 +76,7 @@ export * from './model-repository.types.js';
 export * from './model.js';
 export { Op, type OpTypes } from './operators.js';
 export * from './sequelize.js';
+export type { NormalizedOptions, Options, PoolOptions } from './sequelize.types.js';
 export {
   IsolationLevel,
   Lock,
@@ -86,9 +87,6 @@ export {
   type NormalizedTransactionOptions,
   type TransactionOptions,
 } from './transaction.js';
-// eslint-disable-next-line import/no-default-export -- legacy, will be removed in the future | TODO [>=8]: remove this alias
-export { Sequelize as default } from './sequelize.js';
-export type { NormalizedOptions, Options, PoolOptions } from './sequelize.types.js';
 export { isModelStatic, isSameInitialModel } from './utils/model-utils.js';
 export { useInflection } from './utils/string.js';
 export type { Validator } from './utils/validator-extras.js';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -6,13 +6,117 @@
  * @module sequelize
  */
 
-/** Exports the sequelize entry point. */
-const { Sequelize } = require('./sequelize');
+const { and, or, Sequelize } = require('./sequelize');
+const { AbstractConnectionManager } = require('./abstract-dialect/connection-manager');
+const { AbstractDialect } = require('./abstract-dialect/dialect');
+const { AbstractQueryGenerator } = require('./abstract-dialect/query-generator');
+const { AbstractQueryInterface } = require('./abstract-dialect/query-interface');
+const { AbstractQuery } = require('./abstract-dialect/query');
+const { Association } = require('./associations/base');
+const { BelongsToAssociation } = require('./associations/belongs-to');
+const { BelongsToManyAssociation } = require('./associations/belongs-to-many');
+const { HasManyAssociation } = require('./associations/has-many');
+const { HasOneAssociation } = require('./associations/has-one');
+const DataTypes = require('./data-types');
+const { ConstraintChecking, Deferrable } = require('./deferrable');
+const { IndexHints, ParameterStyle, QueryTypes, TableHints } = require('./enums');
+const SequelizeErrors = require('./errors');
+const { AssociationPath } = require('./expression-builders/association-path');
+const { Attribute } = require('./expression-builders/attribute');
+const { Cast, cast } = require('./expression-builders/cast');
+const { Col, col } = require('./expression-builders/col');
+const { Fn, fn } = require('./expression-builders/fn');
+const { Identifier } = require('./expression-builders/identifier');
+const { JsonPath } = require('./expression-builders/json-path');
+const { JSON_NULL, SQL_NULL } = require('./expression-builders/json-sql-null');
+const { json } = require('./expression-builders/json');
+const { List } = require('./expression-builders/list');
+const { Literal, literal } = require('./expression-builders/literal');
+const { sql } = require('./expression-builders/sql');
+const { Value } = require('./expression-builders/value');
+const { Where, where } = require('./expression-builders/where');
+const { GeoJsonType } = require('./geo-json');
+const { importModels } = require('./import-models');
+const { Model } = require('./model');
+const { ManualOnDelete } = require('./model-repository.types');
+const { Op } = require('./operators');
+const {
+  IsolationLevel,
+  Lock,
+  Transaction,
+  TransactionNestMode,
+  TransactionType,
+} = require('./transaction');
+const { isModelStatic, isSameInitialModel } = require('./utils/model-utils');
+const { useInflection } = require('./utils/string');
+const { Validator } = require('./utils/validator-extras');
+const { ValidationErrorItemOrigin, ValidationErrorItemType } = require('./errors/validation-error');
 
-// for backward compatibility, Sequelize is importable with both of these styles:
-//  const Sequelize = require('@sequelize/core')
-//  const { Sequelize } = require('@sequelize/core')
-// TODO [>7]: Make sequelize only importable using the second form, so we can remove properties from the constructor
-module.exports = Sequelize;
 module.exports.Sequelize = Sequelize;
-module.exports.default = Sequelize;
+module.exports.fn = fn;
+module.exports.Fn = Fn;
+module.exports.col = col;
+module.exports.Col = Col;
+module.exports.cast = cast;
+module.exports.Cast = Cast;
+module.exports.literal = literal;
+module.exports.Literal = Literal;
+module.exports.json = json;
+module.exports.where = where;
+module.exports.Where = Where;
+module.exports.List = List;
+module.exports.Identifier = Identifier;
+module.exports.JsonPath = JsonPath;
+module.exports.AssociationPath = AssociationPath;
+module.exports.Attribute = Attribute;
+module.exports.Value = Value;
+module.exports.sql = sql;
+module.exports.and = and;
+module.exports.or = or;
+module.exports.SQL_NULL = SQL_NULL;
+module.exports.JSON_NULL = JSON_NULL;
+
+module.exports.AbstractQueryInterface = AbstractQueryInterface;
+module.exports.AbstractConnectionManager = AbstractConnectionManager;
+module.exports.AbstractQueryGenerator = AbstractQueryGenerator;
+module.exports.AbstractQuery = AbstractQuery;
+module.exports.AbstractDialect = AbstractDialect;
+
+module.exports.Model = Model;
+
+module.exports.Transaction = Transaction;
+module.exports.TransactionNestMode = TransactionNestMode;
+module.exports.TransactionType = TransactionType;
+module.exports.Lock = Lock;
+module.exports.IsolationLevel = IsolationLevel;
+
+module.exports.Association = Association;
+module.exports.BelongsToAssociation = BelongsToAssociation;
+module.exports.HasOneAssociation = HasOneAssociation;
+module.exports.HasManyAssociation = HasManyAssociation;
+module.exports.BelongsToManyAssociation = BelongsToManyAssociation;
+
+// Errors
+Object.assign(module.exports, SequelizeErrors);
+
+module.exports.useInflection = useInflection;
+
+module.exports.QueryTypes = QueryTypes;
+module.exports.Op = Op;
+module.exports.TableHints = TableHints;
+module.exports.IndexHints = IndexHints;
+module.exports.DataTypes = DataTypes;
+module.exports.GeoJsonType = GeoJsonType;
+module.exports.Deferrable = Deferrable;
+module.exports.ConstraintChecking = ConstraintChecking;
+module.exports.ParameterStyle = ParameterStyle;
+
+module.exports.Validator = Validator;
+
+module.exports.ValidationErrorItemOrigin = ValidationErrorItemOrigin;
+module.exports.ValidationErrorItemType = ValidationErrorItemType;
+
+module.exports.isModelStatic = isModelStatic;
+module.exports.isSameInitialModel = isSameInitialModel;
+module.exports.importModels = importModels;
+module.exports.ManualOnDelete = ManualOnDelete;

--- a/packages/core/src/index.mjs
+++ b/packages/core/src/index.mjs
@@ -1,3 +1,6 @@
+// We use a default import so that `Pkg` is the CJS `module.exports` object, which includes
+// dynamically-assigned exports (e.g. via Object.assign). Using `import * as Pkg` only provides
+// statically-analyzable named exports, missing anything added dynamically.
 import Pkg from './index.js';
 
 // export * from './lib/sequelize';
@@ -103,6 +106,3 @@ export const isModelStatic = Pkg.isModelStatic;
 export const isSameInitialModel = Pkg.isSameInitialModel;
 export const importModels = Pkg.importModels;
 export const ManualOnDelete = Pkg.ManualOnDelete;
-
-// eslint-disable-next-line import/no-default-export -- legacy, will be removed in the future
-export { default } from './index.js';

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -488,7 +488,7 @@ export interface WhereOperators<AttributeType = any> {
    */
   [Op.notIRegexp]?: WhereOperators<AttributeType>[typeof Op.regexp];
 
-  /** @example `[Op.match]: Sequelize.fn('to_tsquery', 'fat & rat')` becomes `@@ to_tsquery('fat & rat')` */
+  /** @example `[Op.match]: sql.fn('to_tsquery', 'fat & rat')` becomes `@@ to_tsquery('fat & rat')` */
   [Op.match]?: AllowAnyAll<DynamicValues<AttributeType>>;
 
   /**

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -40,6 +40,8 @@ import * as DataTypes from './data-types';
 import { QueryTypes } from './enums.js';
 import * as SequelizeErrors from './errors';
 import { BaseSqlExpression } from './expression-builders/base-sql-expression.js';
+import { col } from './expression-builders/col.js';
+import { fn } from './expression-builders/fn.js';
 import { InstanceValidator } from './instance-validator';
 import {
   _validateIncludedElements,
@@ -1619,10 +1621,10 @@ ${associationOwner._getAssociationDebugList()}`);
 
     const attrOptions = this.getAttributes()[attribute];
     const field = (attrOptions && attrOptions.field) || attribute;
-    let aggregateColumn = this.sequelize.col(field);
+    let aggregateColumn = col(field);
 
     if (options.distinct) {
-      aggregateColumn = this.sequelize.fn('DISTINCT', aggregateColumn);
+      aggregateColumn = fn('DISTINCT', aggregateColumn);
     }
 
     let { group } = options;
@@ -1634,7 +1636,7 @@ ${associationOwner._getAssociationDebugList()}`);
     options.attributes = unionBy(
       options.attributes,
       group,
-      [[this.sequelize.fn(aggregateFunction, aggregateColumn), aggregateFunction]],
+      [[fn(aggregateFunction, aggregateColumn), aggregateFunction]],
       a => (Array.isArray(a) ? a[1] : a),
     );
 

--- a/packages/core/src/operators.ts
+++ b/packages/core/src/operators.ts
@@ -262,7 +262,7 @@ export interface OpTypes {
    * Operator @@
    *
    * ```js
-   * [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat')`
+   * [Op.match]: sql.fn('to_tsquery', 'fat & rat')`
    * ```
    * In SQL
    * ```sql

--- a/packages/core/src/sequelize.d.ts
+++ b/packages/core/src/sequelize.d.ts
@@ -224,7 +224,7 @@ export class Sequelize<
   /**
    * Creates a object representing a database function. This can be used in search queries, both in where and
    * order parts, and as default values in column definitions. If you want to refer to columns in your
-   * function, you should use `sequelize.col`, so that the columns are properly interpreted as columns and
+   * function, you should use `sql.col`, so that the columns are properly interpreted as columns and
    * not a strings.
    *
    * Convert a user's username to upper case
@@ -249,7 +249,7 @@ export class Sequelize<
 
   /**
    * Creates a object representing a column in the DB. This is often useful in conjunction with
-   * `sequelize.fn`, since raw string arguments to fn will be escaped.
+   * `sql.fn`, since raw string arguments to fn will be escaped.
    *
    * @param col The name of the column
    *
@@ -349,13 +349,13 @@ export class Sequelize<
    * The attr can either be an object taken from `Model.rawAttributes` (for example `Model.rawAttributes.id`
    * or
    * `Model.rawAttributes.name`). The attribute should be defined in your model definition. The attribute can
-   * also be an object from one of the sequelize utility functions (`sequelize.fn`, `sequelize.col` etc.)
+   * also be an object from one of the sequelize utility functions (`sql.fn`, `sql.col` etc.)
    *
    * For string attributes, use the regular `{ where: { attr: something }}` syntax. If you don't want your
-   * string to be escaped, use `sequelize.literal`.
+   * string to be escaped, use `sql.literal`.
    *
    * @param attr The attribute, which can be either an attribute object from `Model.rawAttributes` or a
-   *   sequelize object, for example an instance of `sequelize.fn`. For simple string attributes, use the
+   *   sequelize object, for example an instance of `sql.fn`. For simple string attributes, use the
    *   POJO syntax
    * @param comparator Comparator
    * @param logic The condition. Can be both a simply type, or a further condition (`.or`, `.and`, `.literal`

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -34,6 +34,7 @@ import { Literal, literal } from './expression-builders/literal.js';
 import { sql } from './expression-builders/sql';
 import { Value } from './expression-builders/value';
 import { Where, where } from './expression-builders/where.js';
+import { GeoJsonType } from './geo-json';
 import { importModels } from './import-models.js';
 import { Model } from './model';
 import { setTransactionFromCls } from './model-internals.js';
@@ -53,9 +54,11 @@ import {
   noGetDialect,
   noGetQueryInterface,
   noSequelizeDataType,
+  noSequelizeInstanceProperty,
   noSequelizeIsDefined,
   noSequelizeModel,
   noSequelizeRandom,
+  noSequelizeStaticProperty,
 } from './utils/deprecations';
 import { isModelStatic, isSameInitialModel } from './utils/model-utils';
 import { injectReplacements, mapBindParameters } from './utils/sql';
@@ -624,42 +627,455 @@ Use Sequelize#query if you wish to use replacements.`);
   }
 
   // Global exports
-  static Fn = Fn;
-  static Col = Col;
-  static Cast = Cast;
-  static Literal = Literal;
-  static Where = Where;
-  static List = List;
-  static Identifier = Identifier;
-  static Attribute = Attribute;
-  static Value = Value;
-  static AssociationPath = AssociationPath;
-  static JsonPath = JsonPath;
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Fn() {
+    noSequelizeStaticProperty('Fn');
 
-  static sql = sql;
+    return Fn;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Col() {
+    noSequelizeStaticProperty('Col');
+
+    return Col;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Cast() {
+    noSequelizeStaticProperty('Cast');
+
+    return Cast;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Literal() {
+    noSequelizeStaticProperty('Literal');
+
+    return Literal;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Where() {
+    noSequelizeStaticProperty('Where');
+
+    return Where;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get List() {
+    noSequelizeStaticProperty('List');
+
+    return List;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Identifier() {
+    noSequelizeStaticProperty('Identifier');
+
+    return Identifier;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Attribute() {
+    noSequelizeStaticProperty('Attribute');
+
+    return Attribute;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Value() {
+    noSequelizeStaticProperty('Value');
+
+    return Value;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get AssociationPath() {
+    noSequelizeStaticProperty('AssociationPath');
+
+    return AssociationPath;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get JsonPath() {
+    noSequelizeStaticProperty('JsonPath');
+
+    return JsonPath;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get sql() {
+    noSequelizeStaticProperty('sql');
+
+    return sql;
+  }
 
   // these are all available on the "sql" object, but are exposed for backwards compatibility
-  static fn = fn;
-  static col = col;
-  static cast = cast;
-  static literal = literal;
-  static json = json;
-  static where = where;
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get fn() {
+    noSequelizeStaticProperty('fn');
 
-  static and = and;
+    return fn;
+  }
 
-  static or = or;
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get col() {
+    noSequelizeStaticProperty('col');
 
-  static isModelStatic = isModelStatic;
+    return col;
+  }
 
-  static isSameInitialModel = isSameInitialModel;
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get cast() {
+    noSequelizeStaticProperty('cast');
 
-  static importModels = importModels;
+    return cast;
+  }
 
-  static TransactionNestMode = TransactionNestMode;
-  static TransactionType = TransactionType;
-  static Lock = Lock;
-  static IsolationLevel = IsolationLevel;
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get literal() {
+    noSequelizeStaticProperty('literal');
+
+    return literal;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get json() {
+    noSequelizeStaticProperty('json');
+
+    return json;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get where() {
+    noSequelizeStaticProperty('where');
+
+    return where;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get and() {
+    noSequelizeStaticProperty('and');
+
+    return and;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get or() {
+    noSequelizeStaticProperty('or');
+
+    return or;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get isModelStatic() {
+    noSequelizeStaticProperty('isModelStatic');
+
+    return isModelStatic;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get isSameInitialModel() {
+    noSequelizeStaticProperty('isSameInitialModel');
+
+    return isSameInitialModel;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get importModels() {
+    noSequelizeStaticProperty('importModels');
+
+    return importModels;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get TransactionNestMode() {
+    noSequelizeStaticProperty('TransactionNestMode');
+
+    return TransactionNestMode;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get TransactionType() {
+    noSequelizeStaticProperty('TransactionType');
+
+    return TransactionType;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Lock() {
+    noSequelizeStaticProperty('Lock');
+
+    return Lock;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get IsolationLevel() {
+    noSequelizeStaticProperty('IsolationLevel');
+
+    return IsolationLevel;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Op() {
+    noSequelizeStaticProperty('Op');
+
+    return Op;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get TableHints() {
+    noSequelizeStaticProperty('TableHints');
+
+    return TableHints;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get IndexHints() {
+    noSequelizeStaticProperty('IndexHints');
+
+    return IndexHints;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Transaction() {
+    noSequelizeStaticProperty('Transaction');
+
+    return Transaction;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get GeoJsonType() {
+    noSequelizeStaticProperty('GeoJsonType');
+
+    return GeoJsonType;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get QueryTypes() {
+    noSequelizeStaticProperty('QueryTypes');
+
+    return QueryTypes;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Validator() {
+    noSequelizeStaticProperty('Validator');
+
+    return Validator;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Model() {
+    noSequelizeStaticProperty('Model');
+
+    return Model;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get AbstractQueryInterface() {
+    noSequelizeStaticProperty('AbstractQueryInterface');
+
+    return AbstractQueryInterface;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get BelongsToAssociation() {
+    noSequelizeStaticProperty('BelongsToAssociation');
+
+    return BelongsToAssociation;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get HasOneAssociation() {
+    noSequelizeStaticProperty('HasOneAssociation');
+
+    return HasOneAssociation;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get HasManyAssociation() {
+    noSequelizeStaticProperty('HasManyAssociation');
+
+    return HasManyAssociation;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get BelongsToManyAssociation() {
+    noSequelizeStaticProperty('BelongsToManyAssociation');
+
+    return BelongsToManyAssociation;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get DataTypes() {
+    noSequelizeStaticProperty('DataTypes');
+
+    return DataTypes;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Deferrable() {
+    noSequelizeStaticProperty('Deferrable');
+
+    return Deferrable;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get ConstraintChecking() {
+    noSequelizeStaticProperty('ConstraintChecking');
+
+    return ConstraintChecking;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get Association() {
+    noSequelizeStaticProperty('Association');
+
+    return Association;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get useInflection() {
+    noSequelizeStaticProperty('useInflection');
+
+    return useInflection;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get SQL_NULL() {
+    noSequelizeStaticProperty('SQL_NULL');
+
+    return SQL_NULL;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get JSON_NULL() {
+    noSequelizeStaticProperty('JSON_NULL');
+
+    return JSON_NULL;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get ManualOnDelete() {
+    noSequelizeStaticProperty('ManualOnDelete');
+
+    return ManualOnDelete;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get ParameterStyle() {
+    noSequelizeStaticProperty('ParameterStyle');
+
+    return ParameterStyle;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get AbstractConnectionManager() {
+    noSequelizeStaticProperty('AbstractConnectionManager');
+
+    return AbstractConnectionManager;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get AbstractQueryGenerator() {
+    noSequelizeStaticProperty('AbstractQueryGenerator');
+
+    return AbstractQueryGenerator;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get AbstractQuery() {
+    noSequelizeStaticProperty('AbstractQuery');
+
+    return AbstractQuery;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  static get AbstractDialect() {
+    noSequelizeStaticProperty('AbstractDialect');
+
+    return AbstractDialect;
+  }
+
+  // Deprecated instance property aliases
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get fn() {
+    noSequelizeInstanceProperty('fn');
+
+    return fn;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get col() {
+    noSequelizeInstanceProperty('col');
+
+    return col;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get cast() {
+    noSequelizeInstanceProperty('cast');
+
+    return cast;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get literal() {
+    noSequelizeInstanceProperty('literal');
+
+    return literal;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get and() {
+    noSequelizeInstanceProperty('and');
+
+    return and;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get or() {
+    noSequelizeInstanceProperty('or');
+
+    return or;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get json() {
+    noSequelizeInstanceProperty('json');
+
+    return json;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get where() {
+    noSequelizeInstanceProperty('where');
+
+    return where;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get QueryTypes() {
+    noSequelizeInstanceProperty('QueryTypes');
+
+    return QueryTypes;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get Validator() {
+    noSequelizeInstanceProperty('Validator');
+
+    return Validator;
+  }
+
+  /** @deprecated Import directly from '@sequelize/core' instead */
+  get Association() {
+    noSequelizeInstanceProperty('Association');
+
+    return Association;
+  }
 
   log(...args) {
     let options;
@@ -735,15 +1151,7 @@ Remove the "values" property to resolve this issue.
   }
 }
 
-// Aliases
-Sequelize.prototype.fn = Sequelize.fn;
-Sequelize.prototype.col = Sequelize.col;
-Sequelize.prototype.cast = Sequelize.cast;
-Sequelize.prototype.literal = Sequelize.literal;
-Sequelize.prototype.and = Sequelize.and;
-Sequelize.prototype.or = Sequelize.or;
-Sequelize.prototype.json = Sequelize.json;
-Sequelize.prototype.where = Sequelize.where;
+// Deprecated instance property aliases
 Sequelize.prototype.validate = Sequelize.prototype.authenticate;
 
 /**
@@ -760,37 +1168,6 @@ Object.defineProperty(Sequelize, 'version', {
 });
 
 /**
- * Operators symbols to be used for querying data
- *
- * @see  {@link Operators}
- */
-Sequelize.Op = Op;
-
-/**
- * Available table hints to be used for querying data in mssql for table hints
- *
- * @see {@link TableHints}
- */
-Sequelize.TableHints = TableHints;
-
-/**
- * Available index hints to be used for querying data in mysql for index hints
- *
- * @see {@link IndexHints}
- */
-Sequelize.IndexHints = IndexHints;
-
-/**
- * A reference to the sequelize transaction class. Use this to access isolationLevels and types when creating a transaction
- *
- * @see {@link Transaction}
- * @see {@link Sequelize.transaction}
- */
-Sequelize.Transaction = Transaction;
-
-Sequelize.GeoJsonType = require('./geo-json').GeoJsonType;
-
-/**
  * A reference to Sequelize constructor from sequelize. Useful for accessing DataTypes, Errors etc.
  *
  * @see {@link Sequelize}
@@ -798,28 +1175,10 @@ Sequelize.GeoJsonType = require('./geo-json').GeoJsonType;
 Sequelize.prototype.Sequelize = Sequelize;
 
 /**
- * Available query types for use with `sequelize.query`
+ * Expose individual DataTypes on the Sequelize constructor.
  *
- * @see {@link QueryTypes}
+ * @deprecated Use DataTypes.X instead
  */
-Sequelize.prototype.QueryTypes = Sequelize.QueryTypes = QueryTypes;
-
-/**
- * Exposes the validator.js object, so you can extend it with custom validation functions. The validator is exposed both on the instance, and on the constructor.
- *
- * @see https://github.com/chriso/validator.js
- */
-Sequelize.prototype.Validator = Sequelize.Validator = Validator;
-
-Sequelize.Model = Model;
-
-Sequelize.AbstractQueryInterface = AbstractQueryInterface;
-Sequelize.BelongsToAssociation = BelongsToAssociation;
-Sequelize.HasOneAssociation = HasOneAssociation;
-Sequelize.HasManyAssociation = HasManyAssociation;
-Sequelize.BelongsToManyAssociation = BelongsToManyAssociation;
-
-Sequelize.DataTypes = DataTypes;
 for (const dataTypeName in DataTypes) {
   Object.defineProperty(Sequelize, dataTypeName, {
     get() {
@@ -831,50 +1190,21 @@ for (const dataTypeName in DataTypes) {
 }
 
 /**
- * A reference to the deferrable collection. Use this to access the different deferrable options.
+ * Expose errors on the Sequelize constructor.
  *
- * @see {@link QueryInterface#addConstraint}
+ * @deprecated Import directly from '@sequelize/core' instead
  */
-Sequelize.Deferrable = Deferrable;
-
-/**
- * A reference to the deferrable collection. Use this to access the different deferrable options.
- *
- * @see {@link Transaction.Deferrable}
- * @see {@link Sequelize#transaction}
- */
-Sequelize.ConstraintChecking = ConstraintChecking;
-
-/**
- * A reference to the sequelize association class.
- *
- * @see {@link Association}
- */
-Sequelize.prototype.Association = Sequelize.Association = Association;
-
-/**
- * Provide alternative version of `inflection` module to be used by `pluralize` etc.
- *
- * @param {object} _inflection - `inflection` module
- */
-Sequelize.useInflection = useInflection;
-
-Sequelize.SQL_NULL = SQL_NULL;
-Sequelize.JSON_NULL = JSON_NULL;
-Sequelize.ManualOnDelete = ManualOnDelete;
-Sequelize.ParameterStyle = ParameterStyle;
-
-Sequelize.AbstractConnectionManager = AbstractConnectionManager;
-Sequelize.AbstractQueryGenerator = AbstractQueryGenerator;
-Sequelize.AbstractQuery = AbstractQuery;
-Sequelize.AbstractDialect = AbstractDialect;
-
-/**
- * Expose various errors available
- */
-
 for (const error of Object.keys(SequelizeErrors)) {
-  Sequelize[error] = SequelizeErrors[error];
+  const errorClass = SequelizeErrors[error];
+  Object.defineProperty(Sequelize, error, {
+    get() {
+      noSequelizeStaticProperty(error);
+
+      return errorClass;
+    },
+    enumerable: true,
+    configurable: true,
+  });
 }
 
 /**

--- a/packages/core/src/utils/deprecations.ts
+++ b/packages/core/src/utils/deprecations.ts
@@ -146,7 +146,7 @@ export const noSequelizeRandom = deprecate(
   'SEQUELIZE0032',
 );
 
-const emittedStaticPropertyWarnings = new Set<string>();
+const staticPropertyDeprecations = new Map<string, () => void>();
 
 /**
  * Emits a deprecation warning (once per property name) when a named export is accessed
@@ -155,18 +155,20 @@ const emittedStaticPropertyWarnings = new Set<string>();
  * @param propertyName
  */
 export function noSequelizeStaticProperty(propertyName: string): void {
-  if (emittedStaticPropertyWarnings.has(propertyName)) {
-    return;
+  let deprecated = staticPropertyDeprecations.get(propertyName);
+  if (!deprecated) {
+    deprecated = deprecate(
+      noop,
+      `Do not use the Sequelize.${propertyName} static property. Import ${propertyName} directly from '@sequelize/core' instead.`,
+      `SEQUELIZE0033-${propertyName}`,
+    );
+    staticPropertyDeprecations.set(propertyName, deprecated);
   }
 
-  emittedStaticPropertyWarnings.add(propertyName);
-  process.emitWarning(
-    `Do not use the Sequelize.${propertyName} static property. Import ${propertyName} directly from '@sequelize/core' instead.`,
-    { type: 'DeprecationWarning', code: `SEQUELIZE0033-${propertyName}` },
-  );
+  deprecated();
 }
 
-const emittedInstancePropertyWarnings = new Set<string>();
+const instancePropertyDeprecations = new Map<string, () => void>();
 
 /**
  * Emits a deprecation warning (once per property name) when a named export is accessed
@@ -175,13 +177,15 @@ const emittedInstancePropertyWarnings = new Set<string>();
  * @param propertyName
  */
 export function noSequelizeInstanceProperty(propertyName: string): void {
-  if (emittedInstancePropertyWarnings.has(propertyName)) {
-    return;
+  let deprecated = instancePropertyDeprecations.get(propertyName);
+  if (!deprecated) {
+    deprecated = deprecate(
+      noop,
+      `Do not use the sequelize.${propertyName} instance property. Import ${propertyName} directly from '@sequelize/core' instead.`,
+      `SEQUELIZE0034-${propertyName}`,
+    );
+    instancePropertyDeprecations.set(propertyName, deprecated);
   }
 
-  emittedInstancePropertyWarnings.add(propertyName);
-  process.emitWarning(
-    `Do not use the sequelize.${propertyName} instance property. Import ${propertyName} directly from '@sequelize/core' instead.`,
-    { type: 'DeprecationWarning', code: `SEQUELIZE0034-${propertyName}` },
-  );
+  deprecated();
 }

--- a/packages/core/src/utils/deprecations.ts
+++ b/packages/core/src/utils/deprecations.ts
@@ -145,3 +145,43 @@ export const noSequelizeRandom = deprecate(
   'Do not use sequelize.random(). Use sql.random instead, as it can be used without needing a reference to sequelize.',
   'SEQUELIZE0032',
 );
+
+const emittedStaticPropertyWarnings = new Set<string>();
+
+/**
+ * Emits a deprecation warning (once per property name) when a named export is accessed
+ * as a static property on the Sequelize class instead of being imported directly.
+ *
+ * @param propertyName
+ */
+export function noSequelizeStaticProperty(propertyName: string): void {
+  if (emittedStaticPropertyWarnings.has(propertyName)) {
+    return;
+  }
+
+  emittedStaticPropertyWarnings.add(propertyName);
+  process.emitWarning(
+    `Do not use the Sequelize.${propertyName} static property. Import ${propertyName} directly from '@sequelize/core' instead.`,
+    { type: 'DeprecationWarning', code: `SEQUELIZE0033-${propertyName}` },
+  );
+}
+
+const emittedInstancePropertyWarnings = new Set<string>();
+
+/**
+ * Emits a deprecation warning (once per property name) when a named export is accessed
+ * as an instance property on a Sequelize instance instead of being imported directly.
+ *
+ * @param propertyName
+ */
+export function noSequelizeInstanceProperty(propertyName: string): void {
+  if (emittedInstancePropertyWarnings.has(propertyName)) {
+    return;
+  }
+
+  emittedInstancePropertyWarnings.add(propertyName);
+  process.emitWarning(
+    `Do not use the sequelize.${propertyName} instance property. Import ${propertyName} directly from '@sequelize/core' instead.`,
+    { type: 'DeprecationWarning', code: `SEQUELIZE0034-${propertyName}` },
+  );
+}

--- a/packages/core/test/integration/associations/belongs-to-many.test.js
+++ b/packages/core/test/integration/associations/belongs-to-many.test.js
@@ -4,7 +4,13 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, IsolationLevel, Op, Sequelize, sql } = require('@sequelize/core');
+const {
+  DataTypes,
+  ForeignKeyConstraintError,
+  IsolationLevel,
+  Op,
+  sql,
+} = require('@sequelize/core');
 const assert = require('node:assert');
 const sinon = require('sinon');
 
@@ -3564,9 +3570,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         await Promise.all([user1.setTasks([task1]), task2.setUsers([user2])]);
 
         await Promise.all([
-          expect(user1.destroy()).to.have.been.rejectedWith(Sequelize.ForeignKeyConstraintError), // Fails because of
+          expect(user1.destroy()).to.have.been.rejectedWith(ForeignKeyConstraintError), // Fails because of
           // RESTRICT constraint
-          expect(task2.destroy()).to.have.been.rejectedWith(Sequelize.ForeignKeyConstraintError),
+          expect(task2.destroy()).to.have.been.rejectedWith(ForeignKeyConstraintError),
         ]);
       });
 
@@ -3589,7 +3595,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         await Promise.all([user1.setTasks([task1]), task2.setUsers([user2])]);
 
         await Promise.all([
-          expect(user1.destroy()).to.have.been.rejectedWith(Sequelize.ForeignKeyConstraintError), // Fails because of
+          expect(user1.destroy()).to.have.been.rejectedWith(ForeignKeyConstraintError), // Fails because of
           // RESTRICT constraint
           task2.destroy(),
         ]);

--- a/packages/core/test/integration/associations/belongs-to.test.js
+++ b/packages/core/test/integration/associations/belongs-to.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, ForeignKeyConstraintError } = require('@sequelize/core');
 const assert = require('node:assert');
 
 const current = Support.sequelize;
@@ -260,13 +260,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       await this.sequelize.sync({ force: true });
       await expect(Task.create({ title: 'task', userXYZId: 5 })).to.be.rejectedWith(
-        Sequelize.ForeignKeyConstraintError,
+        ForeignKeyConstraintError,
       );
       const task = await Task.create({ title: 'task' });
 
       await expect(
         Task.update({ title: 'taskUpdate', userXYZId: 5 }, { where: { id: task.id } }),
-      ).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
+      ).to.be.rejectedWith(ForeignKeyConstraintError);
     });
 
     it('supports passing the primary key instead of an object', async function () {
@@ -639,9 +639,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         const user = await User.create({ username: 'foo' });
         const task = await Task.create({ title: 'task' });
         await task.setUser(user);
-        await expect(user.destroy()).to.eventually.be.rejectedWith(
-          Sequelize.ForeignKeyConstraintError,
-        );
+        await expect(user.destroy()).to.eventually.be.rejectedWith(ForeignKeyConstraintError);
         const tasks = await Task.findAll();
         expect(tasks).to.have.length(1);
       });
@@ -665,7 +663,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
         await expect(
           user.sequelize.queryInterface.update(user, tableName, { id: 999 }, { id: user.id }),
-        ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
+        ).to.eventually.be.rejectedWith(ForeignKeyConstraintError);
 
         // Should fail due to FK restriction
         const tasks = await Task.findAll();

--- a/packages/core/test/integration/associations/has-many.test.js
+++ b/packages/core/test/integration/associations/has-many.test.js
@@ -2,7 +2,7 @@
 
 const range = require('lodash/range');
 const { expect } = require('chai');
-const { DataTypes, Op, Sequelize } = require('@sequelize/core');
+const { DataTypes, ForeignKeyConstraintError, Op, sql } = require('@sequelize/core');
 const dayjs = require('dayjs');
 const sinon = require('sinon');
 const assert = require('node:assert');
@@ -90,7 +90,7 @@ describe('HasMany', () => {
               },
             },
           ],
-          group: this.sequelize.col(`${Task.name}.${Task.primaryKeyField}`),
+          group: sql.col(`${Task.name}.${Task.primaryKeyField}`),
         }),
       ).to.eventually.equal(1);
     });
@@ -1162,7 +1162,7 @@ describe('HasMany', () => {
           try {
             tasks = await user.destroy();
           } catch (error) {
-            if (!(error instanceof Sequelize.ForeignKeyConstraintError)) {
+            if (!(error instanceof ForeignKeyConstraintError)) {
               throw error;
             }
 
@@ -1203,7 +1203,7 @@ describe('HasMany', () => {
               { id: user.id },
             );
           } catch (error) {
-            if (!(error instanceof Sequelize.ForeignKeyConstraintError)) {
+            if (!(error instanceof ForeignKeyConstraintError)) {
               throw error;
             }
 

--- a/packages/core/test/integration/associations/has-one.test.js
+++ b/packages/core/test/integration/associations/has-one.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, ForeignKeyConstraintError } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const dialect = Support.getTestDialect();
@@ -184,13 +184,13 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
       await User.sync({ force: true });
       await Task.sync({ force: true });
       await expect(Task.create({ title: 'task', userXYZId: 5 })).to.be.rejectedWith(
-        Sequelize.ForeignKeyConstraintError,
+        ForeignKeyConstraintError,
       );
       const task = await Task.create({ title: 'task' });
 
       await expect(
         Task.update({ title: 'taskUpdate', userXYZId: 5 }, { where: { id: task.id } }),
-      ).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
+      ).to.be.rejectedWith(ForeignKeyConstraintError);
     });
 
     it('should setup underscored field with foreign keys when using underscored', function () {
@@ -399,9 +399,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
         const user = await User.create({ username: 'foo' });
         const task = await Task.create({ title: 'task' });
         await user.setTask(task);
-        await expect(user.destroy()).to.eventually.be.rejectedWith(
-          Sequelize.ForeignKeyConstraintError,
-        );
+        await expect(user.destroy()).to.eventually.be.rejectedWith(ForeignKeyConstraintError);
         const tasks = await Task.findAll();
         expect(tasks).to.have.length(1);
       });
@@ -426,7 +424,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
         await expect(
           user.sequelize.queryInterface.update(user, tableName, { id: 999 }, { id: user.id }),
-        ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
+        ).to.eventually.be.rejectedWith(ForeignKeyConstraintError);
 
         // Should fail due to FK restriction
         const tasks = await Task.findAll();

--- a/packages/core/test/integration/dialects/mariadb/connection-manager.test.js
+++ b/packages/core/test/integration/dialects/mariadb/connection-manager.test.js
@@ -7,7 +7,13 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const env = process.env;
-const { Sequelize } = require('@sequelize/core');
+const {
+  AccessDeniedError,
+  ConnectionError,
+  ConnectionRefusedError,
+  HostNotFoundError,
+  HostNotReachableError,
+} = require('@sequelize/core');
 
 describe('[MARIADB Specific] Connection Manager', () => {
   if (dialect !== 'mariadb') {
@@ -44,18 +50,14 @@ describe('[MARIADB Specific] Connection Manager', () => {
         port: 65_535,
         connectTimeout: 500,
       });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(
-        Sequelize.SequelizeConnectionError,
-      );
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(ConnectionError);
 
       await sequelize.close();
     });
 
     it('ECONNREFUSED', async () => {
       const sequelize = Support.createSingleTestSequelizeInstance({ host: testHost, port: 65_535 });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(
-        Sequelize.ConnectionRefusedError,
-      );
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(ConnectionRefusedError);
 
       await sequelize.close();
     });
@@ -64,16 +66,14 @@ describe('[MARIADB Specific] Connection Manager', () => {
       const sequelize = Support.createSingleTestSequelizeInstance({
         host: 'http://wowow.example.com',
       });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(Sequelize.HostNotFoundError);
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(HostNotFoundError);
 
       await sequelize.close();
     });
 
     it('EHOSTUNREACH', async () => {
       const sequelize = Support.createSingleTestSequelizeInstance({ host: '255.255.255.255' });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(
-        Sequelize.HostNotReachableError,
-      );
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(HostNotReachableError);
 
       await sequelize.close();
     });
@@ -85,7 +85,7 @@ describe('[MARIADB Specific] Connection Manager', () => {
         password: 'ddsd',
       });
 
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(Sequelize.AccessDeniedError);
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(AccessDeniedError);
 
       await sequelize.close();
     });

--- a/packages/core/test/integration/dialects/mssql/connection-manager.test.js
+++ b/packages/core/test/integration/dialects/mssql/connection-manager.test.js
@@ -2,7 +2,12 @@
 
 const { expect } = require('chai');
 const Support = require('../../support');
-const { Sequelize } = require('@sequelize/core');
+const {
+  AccessDeniedError,
+  ConnectionRefusedError,
+  HostNotFoundError,
+  HostNotReachableError,
+} = require('@sequelize/core');
 
 const dialectName = Support.getTestDialect();
 
@@ -18,9 +23,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
         server: '127.0.0.1',
         port: 34_237,
       });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(
-        Sequelize.ConnectionRefusedError,
-      );
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(ConnectionRefusedError);
 
       await sequelize.close();
     });
@@ -29,7 +32,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
       const sequelize = Support.createSingleTestSequelizeInstance({
         server: 'wowow.example.com',
       });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(Sequelize.HostNotFoundError);
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(HostNotFoundError);
 
       await sequelize.close();
     });
@@ -37,9 +40,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
     // TODO [>=7.0.0-beta]: Refactor so this is the only connection it tries to connect with
     it.skip('EHOSTUNREACH', async () => {
       const sequelize = Support.createSingleTestSequelizeInstance({ server: '255.255.255.255' });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(
-        Sequelize.HostNotReachableError,
-      );
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(HostNotReachableError);
 
       await sequelize.close();
     });
@@ -55,7 +56,7 @@ describe('[MSSQL Specific] Connection Manager', () => {
           },
         },
       });
-      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(Sequelize.AccessDeniedError);
+      await expect(sequelize.pool.acquire()).to.have.been.rejectedWith(AccessDeniedError);
 
       await sequelize.close();
     });

--- a/packages/core/test/integration/dialects/mysql/errors.test.js
+++ b/packages/core/test/integration/dialects/mysql/errors.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, ForeignKeyConstraintError } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Errors', () => {
@@ -51,14 +51,14 @@ if (dialect === 'mysql') {
         await user1.setTasks([task1]);
 
         await Promise.all([
-          validateError(user1.destroy(), Sequelize.ForeignKeyConstraintError, {
+          validateError(user1.destroy(), ForeignKeyConstraintError, {
             fields: ['userId'],
             table: 'users',
             value: undefined,
             index: 'tasksusers_ibfk_1',
             reltype: 'parent',
           }),
-          validateError(task1.destroy(), Sequelize.ForeignKeyConstraintError, {
+          validateError(task1.destroy(), ForeignKeyConstraintError, {
             fields: ['taskId'],
             table: 'tasks',
             value: undefined,
@@ -73,7 +73,7 @@ if (dialect === 'mysql') {
 
         await validateError(
           this.Task.create({ title: 'task', primaryUserId: 5 }),
-          Sequelize.ForeignKeyConstraintError,
+          ForeignKeyConstraintError,
           {
             fields: ['primaryUserId'],
             table: 'users',

--- a/packages/core/test/integration/dialects/postgres/error.test.js
+++ b/packages/core/test/integration/dialects/postgres/error.test.js
@@ -5,7 +5,7 @@ const each = require('lodash/each');
 const chai = require('chai');
 
 const expect = chai.expect;
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, ExclusionConstraintError } = require('@sequelize/core');
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
@@ -34,7 +34,7 @@ if (dialect.startsWith('postgres')) {
         table: 'table_name',
         cause: new Error('Test error'),
       };
-      const err = new Sequelize.ExclusionConstraintError(errDetails);
+      const err = new ExclusionConstraintError(errDetails);
 
       each(errDetails, (value, key) => {
         expect(err[key]).to.be.deep.equal(value, `Value for key ${key} is invalid`);
@@ -56,7 +56,7 @@ if (dialect.startsWith('postgres')) {
           guestName: 'Frequent Visitor',
           period: [new Date(2015, 0, 2), new Date(2015, 0, 5)],
         }),
-      ).to.eventually.be.rejectedWith(Sequelize.ExclusionConstraintError);
+      ).to.eventually.be.rejectedWith(ExclusionConstraintError);
     });
   });
 }

--- a/packages/core/test/integration/dialects/postgres/query-interface.test.js
+++ b/packages/core/test/integration/dialects/postgres/query-interface.test.js
@@ -8,7 +8,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { DataTypes } = require('@sequelize/core');
+const { DataTypes, QueryTypes, sql } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] QueryInterface', () => {
@@ -45,7 +45,7 @@ if (dialect.startsWith('postgres')) {
       it('renames a function', async function () {
         await this.queryInterface.renameFunction('rftest1', [], 'rftest2');
         const res = await this.sequelize.query('select rftest2();', {
-          type: this.sequelize.QueryTypes.SELECT,
+          type: QueryTypes.SELECT,
         });
         expect(res[0].rftest2).to.be.eql('testreturn');
       });
@@ -85,7 +85,7 @@ if (dialect.startsWith('postgres')) {
         );
         // validate
         const res = await this.sequelize.query("select create_job('test');", {
-          type: this.sequelize.QueryTypes.SELECT,
+          type: QueryTypes.SELECT,
         });
         expect(res[0].create_job).to.be.eql('test');
       });
@@ -104,7 +104,7 @@ if (dialect.startsWith('postgres')) {
         );
         // validate
         const res = await this.sequelize.query("select create_job('test');", {
-          type: this.sequelize.QueryTypes.SELECT,
+          type: QueryTypes.SELECT,
         });
         expect(res[0].create_job).to.be.eql('test');
       });
@@ -221,7 +221,7 @@ if (dialect.startsWith('postgres')) {
         );
         // validate
         const res = await this.sequelize.query("select create_job('abc');", {
-          type: this.sequelize.QueryTypes.SELECT,
+          type: QueryTypes.SELECT,
         });
         expect(res[0].create_job).to.be.eql('second');
       });
@@ -262,7 +262,7 @@ if (dialect.startsWith('postgres')) {
           options,
         );
         const res = await this.sequelize.query('select add_one();', {
-          type: this.sequelize.QueryTypes.SELECT,
+          type: QueryTypes.SELECT,
         });
         expect(res[0].add_one).to.be.eql(101);
       });
@@ -293,7 +293,7 @@ if (dialect.startsWith('postgres')) {
         await expect(
           // now call the function we attempted to drop.. if dropFunction worked as expect it should produce an error.
           this.sequelize.query("select droptest('test');", {
-            type: this.sequelize.QueryTypes.SELECT,
+            type: QueryTypes.SELECT,
           }),
           // test that we did get the expected error indicating that droptest was properly removed.
         ).to.be.rejectedWith(/.*function droptest.* does not exist/);
@@ -329,7 +329,7 @@ if (dialect.startsWith('postgres')) {
         await this.queryInterface.addIndex(
           'Group',
           [
-            this.sequelize.literal(`(
+            sql.literal(`(
             CASE "username"
               WHEN 'foo' THEN 'bar'
               ELSE 'baz'
@@ -346,13 +346,9 @@ if (dialect.startsWith('postgres')) {
       });
 
       it('adds, reads and removes a named functional index to the table', async function () {
-        await this.queryInterface.addIndex(
-          'Group',
-          [this.sequelize.fn('lower', this.sequelize.col('username'))],
-          {
-            name: 'group_username_lower',
-          },
-        );
+        await this.queryInterface.addIndex('Group', [sql.fn('lower', sql.col('username'))], {
+          name: 'group_username_lower',
+        });
 
         const indexes0 = await this.queryInterface.showIndex('Group');
         const indexColumns0 = uniq(indexes0.map(index => index.name));

--- a/packages/core/test/integration/dialects/postgres/query.test.js
+++ b/packages/core/test/integration/dialects/postgres/query.test.js
@@ -7,7 +7,7 @@ const Support = require('../../support');
 const sinon = require('sinon');
 
 const dialect = Support.getTestDialect();
-const { DatabaseError, DataTypes, Op } = require('@sequelize/core');
+const { DatabaseError, DataTypes, Op, sql } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Query', () => {
@@ -261,7 +261,7 @@ if (dialect.startsWith('postgres')) {
       const baseTest = (
         await Foo.findAll({
           subQuery: false,
-          order: sequelizeMinifyAliases.literal(`"Foo".my_name`),
+          order: sql.literal(`"Foo".my_name`),
         })
       ).map(f => f.name);
       expect(baseTest[0]).to.equal('record1');
@@ -269,7 +269,7 @@ if (dialect.startsWith('postgres')) {
       const orderByAscSubquery = (
         await Foo.findAll({
           attributes: {
-            include: [[sequelizeMinifyAliases.literal(`"Foo".my_name`), 'customAttribute']],
+            include: [[sql.literal(`"Foo".my_name`), 'customAttribute']],
           },
           subQuery: true,
           order: [['customAttribute']],
@@ -281,7 +281,7 @@ if (dialect.startsWith('postgres')) {
       const orderByDescSubquery = (
         await Foo.findAll({
           attributes: {
-            include: [[sequelizeMinifyAliases.literal(`"Foo".my_name`), 'customAttribute']],
+            include: [[sql.literal(`"Foo".my_name`), 'customAttribute']],
           },
           subQuery: true,
           order: [['customAttribute', 'DESC']],
@@ -489,7 +489,7 @@ if (dialect.startsWith('postgres')) {
       await Foo.findAll({
         subQuery: false,
         attributes: {
-          include: [[sequelizeMinifyAliases.literal('"Foo".my_name'), 'order_0']],
+          include: [[sql.literal('"Foo".my_name'), 'order_0']],
         },
         order: [['order_0', 'DESC']],
       });

--- a/packages/core/test/integration/error.test.ts
+++ b/packages/core/test/integration/error.test.ts
@@ -35,7 +35,12 @@ const queryInterface = sequelize.queryInterface;
 
 describe(getTestDialectTeaser('Sequelize Errors'), () => {
   describe('API Surface', () => {
-    allowDeprecationsInSuite(['SEQUELIZE0007']);
+    allowDeprecationsInSuite([
+      'SEQUELIZE0007',
+      'SEQUELIZE0033-BaseError',
+      'SEQUELIZE0033-ValidationError',
+      'SEQUELIZE0033-OptimisticLockError',
+    ]);
 
     it('Should have the Error constructors exposed', () => {
       expect(Sequelize).to.have.property('BaseError');

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -6,7 +6,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { and, DataTypes, or, Sequelize } = require('@sequelize/core');
+const { and, DataTypes, or, sql } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const current = Support.sequelize;
@@ -139,7 +139,7 @@ Instead of specifying a Model, either:
 
       const result = await Table1.findAll({
         raw: true,
-        attributes: [[Sequelize.fn('SUM', Sequelize.col('table2.Tables3.value')), 'sum']],
+        attributes: [[sql.fn('SUM', sql.col('table2.Tables3.value')), 'sum']],
         include: [
           {
             model: Table2,
@@ -721,11 +721,11 @@ Instead of specifying a Model, either:
       switch (dialect) {
         case 'mssql': {
           findAttributes = [
-            Sequelize.literal(
+            sql.literal(
               'CAST(CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 0 END AS BIT) AS "postComments.someProperty"',
             ),
             [
-              Sequelize.literal('CAST(CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 0 END AS BIT)'),
+              sql.literal('CAST(CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 0 END AS BIT)'),
               'someProperty2',
             ],
           ];
@@ -735,8 +735,8 @@ Instead of specifying a Model, either:
 
         case 'ibmi': {
           findAttributes = [
-            Sequelize.literal('1 AS "postComments.someProperty"'),
-            [Sequelize.literal('1'), 'someProperty2'],
+            sql.literal('1 AS "postComments.someProperty"'),
+            [sql.literal('1'), 'someProperty2'],
           ];
 
           break;
@@ -744,10 +744,8 @@ Instead of specifying a Model, either:
 
         case 'db2': {
           findAttributes = [
-            Sequelize.literal(
-              'EXISTS(SELECT 1 FROM SYSIBM.SYSDUMMY1) AS "postComments.someProperty"',
-            ),
-            [Sequelize.literal('EXISTS(SELECT 1 FROM SYSIBM.SYSDUMMY1)'), 'someProperty2'],
+            sql.literal('EXISTS(SELECT 1 FROM SYSIBM.SYSDUMMY1) AS "postComments.someProperty"'),
+            [sql.literal('EXISTS(SELECT 1 FROM SYSIBM.SYSDUMMY1)'), 'someProperty2'],
           ];
 
           break;
@@ -755,11 +753,11 @@ Instead of specifying a Model, either:
 
         case 'oracle': {
           findAttributes = [
-            Sequelize.literal(
+            sql.literal(
               '(CASE WHEN EXISTS(SELECT 1 FROM DUAL) THEN 1 ELSE 0 END) AS "postComments.someProperty"',
             ),
             [
-              Sequelize.literal('(CASE WHEN EXISTS(SELECT 1 FROM DUAL) THEN 1 ELSE 0 END)'),
+              sql.literal('(CASE WHEN EXISTS(SELECT 1 FROM DUAL) THEN 1 ELSE 0 END)'),
               'someProperty2',
             ],
           ];
@@ -769,8 +767,8 @@ Instead of specifying a Model, either:
 
         default: {
           findAttributes = [
-            Sequelize.literal('EXISTS(SELECT 1) AS "postComments.someProperty"'),
-            [Sequelize.literal('EXISTS(SELECT 1)'), 'someProperty2'],
+            sql.literal('EXISTS(SELECT 1) AS "postComments.someProperty"'),
+            [sql.literal('EXISTS(SELECT 1)'), 'someProperty2'],
           ];
         }
       }

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -107,7 +107,7 @@ Instead of specifying a Model, either:
       expect(user).to.be.ok;
     });
 
-    it('should support to use associations with Sequelize.col', async function () {
+    it('should support to use associations with sql.col', async function () {
       const Table1 = this.sequelize.define('Table1');
       const Table2 = this.sequelize.define('Table2');
       const Table3 = this.sequelize.define('Table3', { value: DataTypes.INTEGER });

--- a/packages/core/test/integration/include/findAll.test.js
+++ b/packages/core/test/integration/include/findAll.test.js
@@ -7,7 +7,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, Op } = require('@sequelize/core');
+const { DataTypes, Op, sql } = require('@sequelize/core');
 const promiseProps = require('p-props');
 
 function sortById(a, b) {
@@ -1279,7 +1279,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           { model: this.models.Price },
         ],
         limit: 3,
-        order: [[this.sequelize.col(`${this.models.Product.name}.id`), 'ASC']],
+        order: [[sql.col(`${this.models.Product.name}.id`), 'ASC']],
       });
 
       expect(products.length).to.equal(3);
@@ -1798,9 +1798,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       );
 
       const posts = await Post.findAll({
-        attributes: [
-          [this.sequelize.fn('COUNT', this.sequelize.col('comments.id')), 'commentCount'],
-        ],
+        attributes: [[sql.fn('COUNT', sql.col('comments.id')), 'commentCount']],
         include: [{ association: Post.Comments, attributes: [] }],
         group: ['Post.id'],
       });
@@ -1841,9 +1839,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       );
 
       const users = await User.findAll({
-        attributes: [
-          [this.sequelize.fn('COUNT', this.sequelize.col('projects.id')), 'projectsCount'],
-        ],
+        attributes: [[sql.fn('COUNT', sql.col('projects.id')), 'projectsCount']],
         include: {
           association: User.associations.projects,
           attributes: [],
@@ -1891,9 +1887,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         include: [
           {
             association: Post.Comments,
-            attributes: [
-              [this.sequelize.fn('COUNT', this.sequelize.col('comments.id')), 'commentCount'],
-            ],
+            attributes: [[sql.fn('COUNT', sql.col('comments.id')), 'commentCount']],
           },
         ],
         raw: true,

--- a/packages/core/test/integration/include/findAndCountAll.test.js
+++ b/packages/core/test/integration/include/findAndCountAll.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const Support = require('../support');
 
-const { DataTypes, Op } = require('@sequelize/core');
+const { DataTypes, Op, or } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
   before(function () {
@@ -376,7 +376,6 @@ describe(Support.getTestDialectTeaser('Include'), () => {
     });
 
     it('should properly work with sequelize.function', async function () {
-      const sequelize = this.sequelize;
       const User = this.sequelize.define('User', {
         id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
         first_name: { type: DataTypes.STRING },
@@ -407,7 +406,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       const result = await User.findAndCountAll({
         limit: 1,
         offset: 1,
-        where: sequelize.or(
+        where: or(
           { first_name: { [Op.like]: '%user-fname%' } },
           { last_name: { [Op.like]: '%user-lname%' } },
         ),

--- a/packages/core/test/integration/instance.test.js
+++ b/packages/core/test/integration/instance.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { DataTypes, sql } = require('@sequelize/core');
+const { and, DataTypes, or, sql } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');
@@ -297,7 +297,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       await this.ParanoidUser.create({ username: 'cuss' });
 
       const users0 = await this.ParanoidUser.findAll({
-        where: this.sequelize.and({
+        where: and({
           username: 'cuss',
         }),
       });
@@ -306,7 +306,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       await users0[0].destroy();
 
       const users = await this.ParanoidUser.findAll({
-        where: this.sequelize.and({
+        where: and({
           username: 'cuss',
         }),
       });
@@ -318,7 +318,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       await this.ParanoidUser.create({ username: 'cuss' });
 
       const users0 = await this.ParanoidUser.findAll({
-        where: this.sequelize.or({
+        where: or({
           username: 'cuss',
         }),
       });
@@ -327,7 +327,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       await users0[0].destroy();
 
       const users = await this.ParanoidUser.findAll({
-        where: this.sequelize.or({
+        where: or({
           username: 'cuss',
         }),
       });

--- a/packages/core/test/integration/instance.validations.test.js
+++ b/packages/core/test/integration/instance.validations.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, sql, ValidationError, Validator } = require('@sequelize/core');
 const Support = require('./support');
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
@@ -418,7 +418,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     await User.sync();
     const error = await expect(User.build({ name: 'error' }).validate()).to.be.rejected;
-    expect(error).to.be.instanceof(Sequelize.ValidationError);
+    expect(error).to.be.instanceof(ValidationError);
     expect(error.get('name')[0].message).to.equal('Invalid username');
 
     await expect(User.build({ name: 'no error' }).validate()).not.to.be.rejected;
@@ -536,7 +536,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       },
     });
 
-    const failingBar = Bar.build({ field: this.sequelize.literal('5 + 1') });
+    const failingBar = Bar.build({ field: sql.literal('5 + 1') });
 
     await expect(failingBar.validate()).not.to.be.rejected;
   });
@@ -587,7 +587,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       User.build({
         email: ['iama', 'dummy.com'],
       }).validate(),
-    ).to.be.rejectedWith(Sequelize.ValidationError);
+    ).to.be.rejectedWith(ValidationError);
   });
 
   it('raises an error for array on a STRING(20)', async function () {
@@ -601,7 +601,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       User.build({
         email: ['iama', 'dummy.com'],
       }).validate(),
-    ).to.be.rejectedWith(Sequelize.ValidationError);
+    ).to.be.rejectedWith(ValidationError);
   });
 
   it('raises an error for array on a TEXT', async function () {
@@ -615,7 +615,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       User.build({
         email: ['iama', 'dummy.com'],
       }).validate(),
-    ).to.be.rejectedWith(Sequelize.ValidationError);
+    ).to.be.rejectedWith(ValidationError);
   });
 
   it('raises an error for {} on a STRING', async function () {
@@ -629,7 +629,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       User.build({
         email: { lol: true },
       }).validate(),
-    ).to.be.rejectedWith(Sequelize.ValidationError);
+    ).to.be.rejectedWith(ValidationError);
   });
 
   it('raises an error for {} on a STRING(20)', async function () {
@@ -643,7 +643,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       User.build({
         email: { lol: true },
       }).validate(),
-    ).to.be.rejectedWith(Sequelize.ValidationError);
+    ).to.be.rejectedWith(ValidationError);
   });
 
   it('raises an error for {} on a TEXT', async function () {
@@ -657,7 +657,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       User.build({
         email: { lol: true },
       }).validate(),
-    ).to.be.rejectedWith(Sequelize.ValidationError);
+    ).to.be.rejectedWith(ValidationError);
   });
 
   it('does not raise an error for null on a STRING (where null is allowed)', async function () {
@@ -713,7 +713,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   });
 
   it('allows me to add custom validation functions to validator.js', async function () {
-    this.sequelize.Validator.extend('isExactly7Characters', val => {
+    Validator.extend('isExactly7Characters', val => {
       return val.length === 7;
     });
 

--- a/packages/core/test/integration/instance/update.test.js
+++ b/packages/core/test/integration/instance/update.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, Sequelize, sql } = require('@sequelize/core');
+const { DataTypes, sql, ValidationError } = require('@sequelize/core');
 
 const current = Support.sequelize;
 
@@ -357,7 +357,7 @@ describe('Model#update', () => {
       const user = await this.User.create({ aNumber: 0 });
 
       const error = await expect(user.update({ validateTest: 'hello' })).to.be.rejectedWith(
-        Sequelize.ValidationError,
+        ValidationError,
       );
 
       expect(error).to.exist;
@@ -398,7 +398,7 @@ describe('Model#update', () => {
         user0.update({
           name: 'B',
         }),
-      ).to.be.rejectedWith(Sequelize.ValidationError);
+      ).to.be.rejectedWith(ValidationError);
 
       const user = await User.findOne({});
       expect(user.get('email')).to.equal('valid.email@gmail.com');
@@ -433,7 +433,7 @@ describe('Model#update', () => {
           name: 'B',
           email: 'still.valid.email@gmail.com',
         }),
-      ).to.be.rejectedWith(Sequelize.ValidationError);
+      ).to.be.rejectedWith(ValidationError);
 
       const user = await User.findOne({});
       expect(user.get('email')).to.equal('valid.email@gmail.com');

--- a/packages/core/test/integration/instance/values.test.js
+++ b/packages/core/test/integration/instance/values.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../support');
 
 const dialect = Support.getTestDialect();
-const { Col, DataTypes, Fn } = require('@sequelize/core');
+const { Col, DataTypes, Fn, sql } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('DAO'), () => {
   describe('Values', () => {
@@ -108,16 +108,16 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
         // so we must create a record with the right value for always_false, then reference it in an update
         const now =
           dialect === 'sqlite3'
-            ? this.sequelize.fn('', this.sequelize.fn('datetime', 'now'))
+            ? sql.fn('', sql.fn('datetime', 'now'))
             : dialect === 'mssql'
-              ? this.sequelize.fn('', this.sequelize.fn('getdate'))
+              ? sql.fn('', sql.fn('getdate'))
               : dialect === 'oracle'
-                ? this.sequelize.fn('', this.sequelize.literal('SYSDATE'))
-                : this.sequelize.fn('NOW');
+                ? sql.fn('', sql.literal('SYSDATE'))
+                : sql.fn('NOW');
 
         user.set({
           d: now,
-          b: this.sequelize.col('always_false'),
+          b: sql.col('always_false'),
         });
 
         expect(user.get('d')).to.be.instanceof(Fn);

--- a/packages/core/test/integration/instance/values.test.js
+++ b/packages/core/test/integration/instance/values.test.js
@@ -88,7 +88,7 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
         expect(user.get('updated_at')).not.to.be.ok;
       });
 
-      it('allows use of sequelize.fn and sequelize.col in date and bool fields', async function () {
+      it('allows use of sql.fn and sql.col in date and bool fields', async function () {
         const User = this.sequelize.define(
           'User',
           {

--- a/packages/core/test/integration/model.test.js
+++ b/packages/core/test/integration/model.test.js
@@ -7,7 +7,15 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { AggregateError, DataTypes, Op, Sequelize, sql } = require('@sequelize/core');
+const {
+  AggregateError,
+  and,
+  DataTypes,
+  Op,
+  or,
+  sql,
+  UniqueConstraintError,
+} = require('@sequelize/core');
 
 const dialectName = Support.getTestDialect();
 const dialect = Support.sequelize.dialect;
@@ -324,7 +332,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             User.create({ username: 'tobi', email: 'tobi@tobi.me' }),
           ]);
         } catch (error) {
-          if (!(error instanceof Sequelize.UniqueConstraintError)) {
+          if (!(error instanceof UniqueConstraintError)) {
             throw error;
           }
 
@@ -380,7 +388,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             User.create({ user_id: 1, email: 'tobi@tobi.me' }),
           ]);
         } catch (error) {
-          if (!(error instanceof Sequelize.UniqueConstraintError)) {
+          if (!(error instanceof UniqueConstraintError)) {
             throw error;
           }
 
@@ -1577,10 +1585,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('should not fail when array contains Sequelize.or / and', async function () {
       const res = await this.User.findAll({
-        where: [
-          this.sequelize.or({ username: 'vader' }, { username: 'luke' }),
-          this.sequelize.and({ id: [1, 2, 3] }),
-        ],
+        where: [or({ username: 'vader' }, { username: 'luke' }), and({ id: [1, 2, 3] })],
       });
 
       expect(res).to.have.length(2);
@@ -1588,7 +1593,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('should not fail with an include', async function () {
       const users = await this.User.findAll({
-        where: this.sequelize.literal(
+        where: sql.literal(
           `${this.sequelize.queryGenerator.quoteIdentifiers('projects.title')} = ${this.sequelize.queryGenerator.escape('republic')}`,
         ),
         include: [{ model: this.Project }],
@@ -1606,7 +1611,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       const users = await this.User.findAll({
         paranoid: false,
-        where: this.sequelize.literal(
+        where: sql.literal(
           `${tableName + this.sequelize.queryGenerator.quoteIdentifier('deletedAt')} IS NOT NULL `,
         ),
         include: [{ model: this.Project }],
@@ -1620,11 +1625,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const res = await this.User.findAll({
         paranoid: false,
         where: [
-          this.sequelize.or({ username: 'leia' }, { username: 'luke' }),
-          this.sequelize.and(
-            { id: [1, 2, 3] },
-            this.sequelize.or({ deletedAt: null }, { deletedAt: { [Op.gte]: new Date(0) } }),
-          ),
+          or({ username: 'leia' }, { username: 'luke' }),
+          and({ id: [1, 2, 3] }, or({ deletedAt: null }, { deletedAt: { [Op.gte]: new Date(0) } })),
         ],
       });
 

--- a/packages/core/test/integration/model/attributes/field.test.js
+++ b/packages/core/test/integration/model/attributes/field.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, or, sql } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 
@@ -432,7 +432,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         const user = await this.User.findOne({
-          where: this.sequelize.or(
+          where: or(
             {
               name: 'Foobar',
             },
@@ -474,33 +474,33 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         let findAttributes;
         if (dialect === 'mssql') {
           findAttributes = [
-            Sequelize.literal(
+            sql.literal(
               'CAST(CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 0 END AS BIT) AS "someProperty"',
             ),
             [
-              Sequelize.literal('CAST(CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 0 END AS BIT)'),
+              sql.literal('CAST(CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 0 END AS BIT)'),
               'someProperty2',
             ],
           ];
         } else if (['db2', 'ibmi'].includes(dialect)) {
           findAttributes = [
-            Sequelize.literal('1 AS "someProperty"'),
-            [Sequelize.literal('1'), 'someProperty2'],
+            sql.literal('1 AS "someProperty"'),
+            [sql.literal('1'), 'someProperty2'],
           ];
         } else if (dialect === 'oracle') {
           findAttributes = [
-            Sequelize.literal(
+            sql.literal(
               '(CASE WHEN EXISTS(SELECT 1 FROM DUAL) THEN 1 ELSE 0 END) AS "someProperty"',
             ),
             [
-              Sequelize.literal('(CASE WHEN EXISTS(SELECT 1 FROM DUAL) THEN 1 ELSE 0 END)'),
+              sql.literal('(CASE WHEN EXISTS(SELECT 1 FROM DUAL) THEN 1 ELSE 0 END)'),
               'someProperty2',
             ],
           ];
         } else {
           findAttributes = [
-            Sequelize.literal('EXISTS(SELECT 1) AS "someProperty"'),
-            [Sequelize.literal('EXISTS(SELECT 1)'), 'someProperty2'],
+            sql.literal('EXISTS(SELECT 1) AS "someProperty"'),
+            [sql.literal('EXISTS(SELECT 1)'), 'someProperty2'],
           ];
         }
 

--- a/packages/core/test/integration/model/attributes/types.test.js
+++ b/packages/core/test/integration/model/attributes/types.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, sql } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../../support');
@@ -117,7 +117,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           const post = await Post.findOne({
-            attributes: ['id', 'text', Sequelize.literal(boolQuery)],
+            attributes: ['id', 'text', sql.literal(boolQuery)],
           });
           expect(post.get('someBoolean')).to.be.ok;
           expect(post.get().someBoolean).to.be.ok;

--- a/packages/core/test/integration/model/create.test.js
+++ b/packages/core/test/integration/model/create.test.js
@@ -7,7 +7,14 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, Op, Sequelize, sql } = require('@sequelize/core');
+const {
+  DataTypes,
+  Op,
+  or,
+  sql,
+  UniqueConstraintError,
+  ValidationError,
+} = require('@sequelize/core');
 
 const delay = require('delay');
 const assert = require('node:assert');
@@ -109,7 +116,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             username: 'gottlieb',
           },
         }),
-      ).to.eventually.be.rejectedWith(Sequelize.UniqueConstraintError);
+      ).to.eventually.be.rejectedWith(UniqueConstraintError);
     });
 
     it('should error correctly when defaults contain a unique key and a non-existent field', async function () {
@@ -141,7 +148,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             bar: 121,
           },
         }),
-      ).to.eventually.be.rejectedWith(Sequelize.UniqueConstraintError);
+      ).to.eventually.be.rejectedWith(UniqueConstraintError);
     });
 
     it('should error correctly when defaults contain a unique key and the where clause is complex', async function () {
@@ -176,7 +183,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           },
         });
       } catch (error) {
-        expect(error).to.be.instanceof(Sequelize.UniqueConstraintError);
+        expect(error).to.be.instanceof(UniqueConstraintError);
         if (dialectName !== 'ibmi') {
           expect(error.errors[0].path).to.be.a('string', 'username');
         }
@@ -413,7 +420,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('supports .or() (only using default values)', async function () {
       const [user, created] = await this.User.findOrCreate({
-        where: Sequelize.or({ username: 'Fooobzz' }, { secretValue: 'Yolo' }),
+        where: or({ username: 'Fooobzz' }, { secretValue: 'Yolo' }),
         defaults: { username: 'Fooobzz', secretValue: 'Yolo' },
       });
 
@@ -451,7 +458,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               1000,
             );
           } catch (error) {
-            if (error instanceof Sequelize.ValidationError) {
+            if (error instanceof ValidationError) {
               return test(times + 1);
             }
 
@@ -566,7 +573,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   username: 'gottlieb',
                 },
               }),
-            ).to.be.rejectedWith(Sequelize.UniqueConstraintError);
+            ).to.be.rejectedWith(UniqueConstraintError);
 
             expect(error.fields).to.be.ok;
           })(),
@@ -580,7 +587,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   username: 'gottlieb',
                 },
               }),
-            ).to.be.rejectedWith(Sequelize.UniqueConstraintError);
+            ).to.be.rejectedWith(UniqueConstraintError);
 
             expect(error.fields).to.be.ok;
           })(),
@@ -717,7 +724,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       const error = await expect(User.create({ email: 'invalid' })).to.be.rejectedWith(
-        Sequelize.ValidationError,
+        ValidationError,
       );
       expect(error.get('email')).to.be.instanceof(Array);
       expect(error.get('email')[0]).to.exist;
@@ -918,7 +925,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       const user = await this.User.create(
         {
-          intVal: this.customSequelize.cast('1', type),
+          intVal: sql.cast('1', type),
         },
         {
           logging(sql) {
@@ -934,17 +941,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('is possible to use casting multiple times mixed in with other utilities', async function () {
-      let type = this.customSequelize.cast(
-        this.customSequelize.cast(this.customSequelize.literal('1-2'), 'integer'),
-        'integer',
-      );
+      let type = sql.cast(sql.cast(sql.literal('1-2'), 'integer'), 'integer');
       let match = false;
 
       if (['mysql', 'mariadb'].includes(dialectName)) {
-        type = this.customSequelize.cast(
-          this.customSequelize.cast(this.customSequelize.literal('1-2'), 'unsigned'),
-          'signed',
-        );
+        type = sql.cast(sql.cast(sql.literal('1-2'), 'unsigned'), 'signed');
       }
 
       const user = await this.User.create(
@@ -971,9 +972,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('is possible to just use .literal() to bypass escaping', async function () {
       const user = await this.User.create({
-        intVal: this.customSequelize.literal(
-          `CAST(1-2 AS ${dialectName === 'mysql' ? 'SIGNED' : 'INTEGER'})`,
-        ),
+        intVal: sql.literal(`CAST(1-2 AS ${dialectName === 'mysql' ? 'SIGNED' : 'INTEGER'})`),
       });
 
       const user0 = await this.User.findByPk(user.id);
@@ -982,7 +981,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('is possible to use funtions when creating an instance', async function () {
       const user = await this.User.create({
-        secretValue: this.customSequelize.fn('upper', 'sequelize'),
+        secretValue: sql.fn('upper', 'sequelize'),
       });
 
       const user0 = await this.User.findByPk(user.id);
@@ -991,7 +990,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('should escape $ in sequelize functions arguments', async function () {
       const user = await this.User.create({
-        secretValue: this.customSequelize.fn('upper', '$sequelize'),
+        secretValue: sql.fn('upper', '$sequelize'),
       });
 
       const user0 = await this.User.findByPk(user.id);
@@ -1021,7 +1020,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         userWithDefaults = this.customSequelize.define('userWithDefaults', {
           uuid: {
             type: 'UUID',
-            defaultValue: this.customSequelize.fn('uuid_generate_v4'),
+            defaultValue: sql.fn('uuid_generate_v4'),
           },
         });
 
@@ -1041,7 +1040,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         userWithDefaults = this.customSequelize.define('userWithDefaults', {
           year: {
             type: DataTypes.STRING,
-            defaultValue: this.customSequelize.fn('', this.customSequelize.fn('date', 'now')),
+            defaultValue: sql.fn('', sql.fn('date', 'now')),
           },
         });
 
@@ -1122,7 +1121,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       try {
         await User.create({ username: 'foo' });
       } catch (error) {
-        if (!(error instanceof Sequelize.UniqueConstraintError)) {
+        if (!(error instanceof UniqueConstraintError)) {
           throw error;
         }
 
@@ -1141,7 +1140,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           await User.create({ username: 'foo' });
           await User.create({ username: 'fOO' });
         } catch (error) {
-          if (!(error instanceof Sequelize.UniqueConstraintError)) {
+          if (!(error instanceof UniqueConstraintError)) {
             throw error;
           }
 
@@ -1169,7 +1168,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           await User.sync({ force: true });
           await User.create({ username: 42 });
         } catch (error) {
-          if (!(error instanceof Sequelize.ValidationError)) {
+          if (!(error instanceof ValidationError)) {
             throw error;
           }
 
@@ -1193,7 +1192,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           await User.create({ username: 'foo' });
           await User.create({ username: 'foo' });
         } catch (error) {
-          if (!(error instanceof Sequelize.UniqueConstraintError)) {
+          if (!(error instanceof UniqueConstraintError)) {
             throw error;
           }
 
@@ -1234,7 +1233,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       try {
         await UserNull.create({ username: 'foo', smth: 'bar' });
       } catch (error) {
-        if (!(error instanceof Sequelize.UniqueConstraintError)) {
+        if (!(error instanceof UniqueConstraintError)) {
           throw error;
         }
 
@@ -1624,7 +1623,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should return default value set by the database (create)', async function () {
       const User = this.customSequelize.define('User', {
         name: DataTypes.STRING,
-        code: { type: DataTypes.INTEGER, defaultValue: Sequelize.literal(2020) },
+        code: { type: DataTypes.INTEGER, defaultValue: sql.literal(2020) },
       });
 
       await User.sync({ force: true });

--- a/packages/core/test/integration/model/findAll.test.js
+++ b/packages/core/test/integration/model/findAll.test.js
@@ -1464,7 +1464,7 @@ The following associations are defined on "Worker": "ToDos"`);
         expect(user).to.have.length(1);
       });
 
-      it('should be possible to order by sequelize.sql.col()', async function () {
+      it('should be possible to order by sql.col()', async function () {
         const Company = this.sequelize.define('Company', {
           name: DataTypes.STRING,
         });

--- a/packages/core/test/integration/model/findAll.test.js
+++ b/packages/core/test/integration/model/findAll.test.js
@@ -8,7 +8,14 @@ const sinon = require('sinon');
 const expect = chai.expect;
 const Support = require('../support');
 
-const { DataTypes, Op, Sequelize } = require('@sequelize/core');
+const {
+  ConnectionError,
+  DataTypes,
+  EmptyResultError,
+  Op,
+  QueryError,
+  sql,
+} = require('@sequelize/core');
 
 const dayjs = require('dayjs');
 const promiseProps = require('p-props');
@@ -63,7 +70,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('should throw on an attempt to fetch no attributes', async function () {
       await expect(this.User.findAll({ attributes: [] })).to.be.rejectedWith(
-        Sequelize.QueryError,
+        QueryError,
         /^Attempted a SELECT query.+without selecting any columns$/,
       );
     });
@@ -84,7 +91,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           {
             model: Comment,
             as: 'comments',
-            attributes: [[Sequelize.fn('COUNT', Sequelize.col('comments.id')), 'commentCount']],
+            attributes: [[sql.fn('COUNT', sql.col('comments.id')), 'commentCount']],
           },
         ],
       });
@@ -1457,7 +1464,7 @@ The following associations are defined on "Worker": "ToDos"`);
         expect(user).to.have.length(1);
       });
 
-      it('should be possible to order by sequelize.col()', async function () {
+      it('should be possible to order by sequelize.sql.col()', async function () {
         const Company = this.sequelize.define('Company', {
           name: DataTypes.STRING,
         });
@@ -1465,7 +1472,7 @@ The following associations are defined on "Worker": "ToDos"`);
         await Company.sync();
 
         await Company.findAll({
-          order: [this.sequelize.col('name')],
+          order: [sql.col('name')],
         });
       });
 
@@ -1679,11 +1686,8 @@ The following associations are defined on "Worker": "ToDos"`);
 
     it('handles grouped rows', async function () {
       const info = await this.User.findAndCountAll({
-        attributes: [
-          [Sequelize.fn('sum', Sequelize.col('intVal')), 'sum'],
-          Sequelize.col('intVal'),
-        ],
-        group: [Sequelize.col('intVal')],
+        attributes: [[sql.fn('sum', sql.col('intVal')), 'sum'], sql.col('intVal')],
+        group: [sql.col('intVal')],
         countGroupedRows: true,
         raw: true,
       });
@@ -1761,7 +1765,7 @@ The following associations are defined on "Worker": "ToDos"`);
             username: 'some-username-that-is-not-used-anywhere',
           },
         }),
-      ).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+      ).to.eventually.be.rejectedWith(EmptyResultError);
     });
 
     it('throws custom error with initialized', async () => {
@@ -1771,7 +1775,7 @@ The following associations are defined on "Worker": "ToDos"`);
           username: DataTypes.STRING(100),
         },
         {
-          rejectOnEmpty: new Sequelize.ConnectionError('Some Error'), // using custom error instance
+          rejectOnEmpty: new ConnectionError('Some Error'), // using custom error instance
         },
       );
 
@@ -1783,7 +1787,7 @@ The following associations are defined on "Worker": "ToDos"`);
             username: 'some-username-that-is-not-used-anywhere-for-sure-this-time',
           },
         }),
-      ).to.eventually.be.rejectedWith(Sequelize.ConnectionError);
+      ).to.eventually.be.rejectedWith(ConnectionError);
     });
 
     it('throws custom error with instance', async () => {
@@ -1793,7 +1797,7 @@ The following associations are defined on "Worker": "ToDos"`);
           username: DataTypes.STRING(100),
         },
         {
-          rejectOnEmpty: Sequelize.ConnectionError, // using custom error instance
+          rejectOnEmpty: ConnectionError, // using custom error instance
         },
       );
 
@@ -1805,7 +1809,7 @@ The following associations are defined on "Worker": "ToDos"`);
             username: 'some-username-that-is-not-used-anywhere-for-sure-this-time',
           },
         }),
-      ).to.eventually.be.rejectedWith(Sequelize.ConnectionError);
+      ).to.eventually.be.rejectedWith(ConnectionError);
     });
   });
 });

--- a/packages/core/test/integration/model/findAll/group.test.js
+++ b/packages/core/test/integration/model/findAll/group.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, sql } = require('@sequelize/core');
 
 const current = Support.sequelize;
 
@@ -39,7 +39,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]);
 
         const posts = await Post.findAll({
-          attributes: [[Sequelize.fn('COUNT', Sequelize.col('comments.id')), 'comment_count']],
+          attributes: [[sql.fn('COUNT', sql.col('comments.id')), 'comment_count']],
           include: [{ model: Comment, attributes: [] }],
           group: ['Post.id'],
           order: [['id']],
@@ -76,10 +76,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]);
 
         const posts = await Comment.findAll({
-          attributes: [
-            'postId',
-            [Sequelize.fn('COUNT', Sequelize.col('Comment.id')), 'comment_count'],
-          ],
+          attributes: ['postId', [sql.fn('COUNT', sql.col('Comment.id')), 'comment_count']],
           include: [{ model: Post, attributes: [] }],
           group: ['postId'],
           order: [['postId']],

--- a/packages/core/test/integration/model/findAll/groupedLimit.test.js
+++ b/packages/core/test/integration/model/findAll/groupedLimit.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, sql } = require('@sequelize/core');
 
 const current = Support.sequelize;
 
@@ -152,7 +152,7 @@ if (current.dialect.supports['UNION ALL']) {
                 values: this.projects.map(item => item.get('id')),
               },
               order: [
-                Sequelize.fn('ABS', Sequelize.col('age')),
+                sql.fn('ABS', sql.col('age')),
                 // Two users have the same abs(age), so we need to make sure that the order is deterministic
                 ['id', 'DESC'],
               ],
@@ -175,7 +175,7 @@ if (current.dialect.supports['UNION ALL']) {
                 on: this.User.ParanoidProjects,
                 values: this.projects.map(item => item.get('id')),
               },
-              order: [Sequelize.fn('ABS', Sequelize.col('age')), ['id', 'DESC']],
+              order: [sql.fn('ABS', sql.col('age')), ['id', 'DESC']],
               include: [this.User.Tasks],
             });
 
@@ -198,7 +198,7 @@ if (current.dialect.supports['UNION ALL']) {
                 on: this.User.ParanoidProjects,
                 values: this.projects.map(item => item.get('id')),
               },
-              order: [Sequelize.fn('ABS', Sequelize.col('age')), ['id', 'DESC']],
+              order: [sql.fn('ABS', sql.col('age')), ['id', 'DESC']],
               include: [this.User.Tasks],
             });
 

--- a/packages/core/test/integration/model/findAll/order.test.js
+++ b/packages/core/test/integration/model/findAll/order.test.js
@@ -4,14 +4,14 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const { DataTypes } = require('@sequelize/core');
+const { DataTypes, sql } = require('@sequelize/core');
 
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('findAll', () => {
     describe('order', () => {
-      describe('Sequelize.literal()', () => {
+      describe('sql.literal()', () => {
         beforeEach(async function () {
           this.User = this.sequelize.define('User', {
             email: DataTypes.STRING,
@@ -26,11 +26,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         if (!['oracle', 'ibmi', 'mssql'].includes(current.dialect.name)) {
           const email = current.dialect.name === 'db2' ? '"email"' : 'email';
-          it('should work with order: literal()', async function () {
+          it('should work with order: sql.literal()', async function () {
             const users = await this.User.findAll({
-              order: this.sequelize.literal(
-                `${email} = ${this.sequelize.escape('test@sequelizejs.com')}`,
-              ),
+              order: sql.literal(`${email} = ${this.sequelize.escape('test@sequelizejs.com')}`),
             });
 
             expect(users.length).to.equal(1);
@@ -39,13 +37,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
           });
 
-          it('should work with order: [literal()]', async function () {
+          it('should work with order: [sql.literal()]', async function () {
             const users = await this.User.findAll({
-              order: [
-                this.sequelize.literal(
-                  `${email} = ${this.sequelize.escape('test@sequelizejs.com')}`,
-                ),
-              ],
+              order: [sql.literal(`${email} = ${this.sequelize.escape('test@sequelizejs.com')}`)],
             });
 
             expect(users.length).to.equal(1);
@@ -54,15 +48,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
           });
 
-          it('should work with order: [[literal()]]', async function () {
+          it('should work with order: [[sql.literal()]]', async function () {
             const users = await this.User.findAll({
-              order: [
-                [
-                  this.sequelize.literal(
-                    `${email} = ${this.sequelize.escape('test@sequelizejs.com')}`,
-                  ),
-                ],
-              ],
+              order: [[sql.literal(`${email} = ${this.sequelize.escape('test@sequelizejs.com')}`)]],
             });
 
             expect(users.length).to.equal(1);
@@ -98,11 +86,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should not throw on a literal', async function () {
           if (['db2', 'ibmi', 'oracle'].includes(current.dialect.name)) {
             await this.User.findAll({
-              order: [['id', this.sequelize.literal('ASC, "name" DESC')]],
+              order: [['id', sql.literal('ASC, "name" DESC')]],
             });
           } else {
             await this.User.findAll({
-              order: [['id', this.sequelize.literal('ASC, name DESC')]],
+              order: [['id', sql.literal('ASC, name DESC')]],
             });
           }
         });

--- a/packages/core/test/integration/model/findOne.test.js
+++ b/packages/core/test/integration/model/findOne.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const expect = chai.expect;
 const Support = require('../support');
 
-const { DataTypes, Op, Sequelize } = require('@sequelize/core');
+const { DataTypes, EmptyResultError, Op } = require('@sequelize/core');
 const pMap = require('p-map');
 
 const current = Support.sequelize;
@@ -1067,7 +1067,7 @@ The following associations are defined on "Worker": "ToDos"`);
             },
             rejectOnEmpty: true,
           }),
-        ).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+        ).to.eventually.be.rejectedWith(EmptyResultError);
       });
 
       it('throws error when record not found by findByPk', async function () {
@@ -1075,7 +1075,7 @@ The following associations are defined on "Worker": "ToDos"`);
           this.User.findByPk(2, {
             rejectOnEmpty: true,
           }),
-        ).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+        ).to.eventually.be.rejectedWith(EmptyResultError);
       });
 
       it('throws error when record not found by find', async function () {
@@ -1086,7 +1086,7 @@ The following associations are defined on "Worker": "ToDos"`);
             },
             rejectOnEmpty: true,
           }),
-        ).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+        ).to.eventually.be.rejectedWith(EmptyResultError);
       });
 
       it('works from model options', async () => {
@@ -1108,7 +1108,7 @@ The following associations are defined on "Worker": "ToDos"`);
               username: 'some-username-that-is-not-used-anywhere',
             },
           }),
-        ).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+        ).to.eventually.be.rejectedWith(EmptyResultError);
       });
 
       it('override model options', async () => {

--- a/packages/core/test/integration/model/scope.test.js
+++ b/packages/core/test/integration/model/scope.test.js
@@ -101,7 +101,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       await this.ScopeMe.withScope('issue8473').findAll();
     });
 
-    it('should not throw error with sequelize.where', async function () {
+    it('should not throw error with sql.where', async function () {
       const records = await this.ScopeMe.withScope('like_t').findAll();
       expect(records).to.have.length(2);
     });

--- a/packages/core/test/integration/model/scope.test.js
+++ b/packages/core/test/integration/model/scope.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const { DataTypes, Op, Sequelize } = require('@sequelize/core');
+const { DataTypes, Op, sql } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
@@ -50,11 +50,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               },
             },
             like_t: {
-              where: Sequelize.where(
-                Sequelize.fn('LOWER', Sequelize.col('username')),
-                Op.like,
-                '%t%',
-              ),
+              where: sql.where(sql.fn('LOWER', sql.col('username')), Op.like, '%t%'),
             },
           },
         },

--- a/packages/core/test/integration/model/upsert.test.js
+++ b/packages/core/test/integration/model/upsert.test.js
@@ -3,7 +3,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const { beforeEach2, sequelize } = require('../support');
-const { DataTypes, Sequelize, sql } = require('@sequelize/core');
+const { DataTypes, ForeignKeyConstraintError, sql, ValidationError } = require('@sequelize/core');
 
 const dialectName = sequelize.dialect.name;
 
@@ -184,7 +184,7 @@ describe('Model', () => {
         });
 
         await expect(User.upsert({ email: 'notanemail' })).to.eventually.be.rejectedWith(
-          Sequelize.ValidationError,
+          ValidationError,
         );
       });
 
@@ -283,7 +283,7 @@ describe('Model', () => {
         const [, created0] = await this.User.upsert({
           id: 42,
           username: 'john',
-          foo: this.sequelize.fn('upper', 'mixedCase1'),
+          foo: sql.fn('upper', 'mixedCase1'),
         });
         if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created0).to.be.null;
@@ -295,7 +295,7 @@ describe('Model', () => {
         const [, created] = await this.User.upsert({
           id: 42,
           username: 'doe',
-          foo: this.sequelize.fn('upper', 'mixedCase2'),
+          foo: sql.fn('upper', 'mixedCase2'),
         });
         if (['db2', 'sqlite3', 'postgres'].includes(dialectName)) {
           expect(created).to.be.null;
@@ -548,7 +548,7 @@ describe('Model', () => {
           await User.create({ username: 'user1' });
           await expect(
             Posts.upsert({ title: 'Title', username: 'user2' }),
-          ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
+          ).to.eventually.be.rejectedWith(ForeignKeyConstraintError);
         });
       }
 
@@ -598,11 +598,11 @@ describe('Model', () => {
         it('should allow to use calculated values on duplicate', async function () {
           await this.User.upsert({
             id: 1,
-            counter: this.sequelize.literal('`counter` + 1'),
+            counter: sql.literal('`counter` + 1'),
           });
           await this.User.upsert({
             id: 1,
-            counter: this.sequelize.literal('`counter` + 1'),
+            counter: sql.literal('`counter` + 1'),
           });
           const user = await this.User.findByPk(1);
           expect(user.counter).to.equal(2);
@@ -717,7 +717,7 @@ describe('Model', () => {
           it('should return default value set by the database (upsert)', async function () {
             const User = this.sequelize.define('User', {
               name: { type: DataTypes.STRING, primaryKey: true },
-              code: { type: DataTypes.INTEGER, defaultValue: Sequelize.literal(2020) },
+              code: { type: DataTypes.INTEGER, defaultValue: sql.literal(2020) },
             });
 
             await User.sync({ force: true });

--- a/packages/core/test/integration/sequelize/deferrable.test.js
+++ b/packages/core/test/integration/sequelize/deferrable.test.js
@@ -4,7 +4,12 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { ConstraintChecking, DataTypes, Deferrable, Sequelize } = require('@sequelize/core');
+const {
+  ConstraintChecking,
+  DataTypes,
+  Deferrable,
+  ForeignKeyConstraintError,
+} = require('@sequelize/core');
 
 if (Support.sequelize.dialect.supports.constraints.deferrable) {
   describe(Support.getTestDialectTeaser('Sequelize'), () => {
@@ -49,7 +54,7 @@ if (Support.sequelize.dialect.supports.constraints.deferrable) {
           describe('NOT', () => {
             it('does not allow the violation of the foreign key constraint', async function () {
               await expect(this.run(Deferrable.NOT)).to.eventually.be.rejectedWith(
-                Sequelize.ForeignKeyConstraintError,
+                ForeignKeyConstraintError,
               );
             });
           });
@@ -67,7 +72,7 @@ if (Support.sequelize.dialect.supports.constraints.deferrable) {
                 this.run(Deferrable.INITIALLY_IMMEDIATE, {
                   constraintChecking: undefined,
                 }),
-              ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
+              ).to.eventually.be.rejectedWith(ForeignKeyConstraintError);
             });
 
             it('allows the violation of the foreign key constraint if the transaction deferred only the foreign key constraint', async function () {

--- a/packages/core/test/integration/sequelize/query.test.js
+++ b/packages/core/test/integration/sequelize/query.test.js
@@ -5,7 +5,7 @@ const {
   DatabaseError,
   DataTypes,
   ForeignKeyConstraintError,
-  Sequelize,
+  QueryTypes,
   sql,
   UniqueConstraintError,
 } = require('@sequelize/core');
@@ -100,13 +100,13 @@ describe(getTestDialectTeaser('Sequelize'), () => {
     describe('QueryTypes', () => {
       it('RAW', async function () {
         await this.sequelize.query(this.insertQuery, {
-          type: Sequelize.QueryTypes.RAW,
+          type: QueryTypes.RAW,
         });
 
         const [rows, count] = await this.sequelize.query(
           `SELECT * FROM ${qq(this.User.tableName)};`,
           {
-            type: Sequelize.QueryTypes.RAW,
+            type: QueryTypes.RAW,
           },
         );
 
@@ -143,7 +143,7 @@ describe(getTestDialectTeaser('Sequelize'), () => {
               },
             },
           ),
-        ).to.be.rejectedWith(Sequelize.UniqueConstraintError);
+        ).to.be.rejectedWith(UniqueConstraintError);
         expect(spy.callCount).to.eql(['db2', 'ibmi'].includes(dialectName) ? 1 : 3);
       });
     });
@@ -782,7 +782,7 @@ describe(getTestDialectTeaser('Sequelize'), () => {
       const expected = [{ foo: isBigInt ? '1' : 1, bar: isBigInt ? '2' : 2 }];
       const result = await this.sequelize.query(
         `select ? as ${queryGenerator.quoteIdentifier('foo')}, ? as ${queryGenerator.quoteIdentifier('bar')}${fromQuery()}`,
-        { type: this.sequelize.QueryTypes.SELECT, replacements: [1, 2] },
+        { type: QueryTypes.SELECT, replacements: [1, 2] },
       );
       expect(result).to.deep.equal(expected);
     });
@@ -848,7 +848,7 @@ describe(getTestDialectTeaser('Sequelize'), () => {
         const result = await this.sequelize.query(
           `select $1${typeCast} as ${queryGenerator.quoteIdentifier('foo')}, $2${typeCast} as ${queryGenerator.quoteIdentifier('bar')}${fromQuery()}`,
           {
-            type: this.sequelize.QueryTypes.SELECT,
+            type: QueryTypes.SELECT,
             bind: [1, 2],
             logging(s) {
               logSql = s;

--- a/packages/core/test/integration/timezone.test.js
+++ b/packages/core/test/integration/timezone.test.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
+const { QueryTypes } = require('@sequelize/core');
 
 const dialectName = Support.getTestDialect();
 const dialect = Support.sequelize.dialect;
@@ -35,9 +36,9 @@ describe(Support.getTestDialectTeaser('Timezone'), () => {
     const query = `SELECT ${now} as ${queryGenerator.quoteIdentifier('now')}`;
 
     const [now1, now2, now3] = await Promise.all([
-      this.sequelize.query(query, { type: this.sequelize.QueryTypes.SELECT }),
-      this.sequelizeWithTimezone.query(query, { type: this.sequelize.QueryTypes.SELECT }),
-      this.sequelizeWithNamedTimezone.query(query, { type: this.sequelize.QueryTypes.SELECT }),
+      this.sequelize.query(query, { type: QueryTypes.SELECT }),
+      this.sequelizeWithTimezone.query(query, { type: QueryTypes.SELECT }),
+      this.sequelizeWithNamedTimezone.query(query, { type: QueryTypes.SELECT }),
     ]);
 
     const elapsedQueryTime = Date.now() - startQueryTime + 1001;

--- a/packages/core/test/integration/trigger.test.js
+++ b/packages/core/test/integration/trigger.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const { DataTypes } = require('@sequelize/core');
+const { DataTypes, QueryTypes } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
@@ -51,7 +51,7 @@ if (current.dialect.supports.tmpTableTrigger) {
 
         await User.sync({ force: true });
 
-        await this.sequelize.query(triggerQuery, { type: this.sequelize.QueryTypes.RAW });
+        await this.sequelize.query(triggerQuery, { type: QueryTypes.RAW });
       });
 
       it('should return output rows after insert', async () => {

--- a/packages/core/test/unit/dialects/db2/query-generator.test.js
+++ b/packages/core/test/unit/dialects/db2/query-generator.test.js
@@ -8,7 +8,7 @@ const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const { Op } = require('@sequelize/core');
+const { Op, sql } = require('@sequelize/core');
 const { Db2QueryGenerator: QueryGenerator } = require('@sequelize/db2');
 const { createSequelizeInstance } = require('../../../support');
 
@@ -194,10 +194,8 @@ if (dialect === 'db2') {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
             },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt");',
@@ -205,13 +203,11 @@ if (dialect === 'db2') {
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
             },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt"), "title";',
@@ -327,10 +323,8 @@ if (dialect === 'db2') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                foo: sequelize.fn('NOW'),
-              };
+            {
+              foo: sql.fn('NOW'),
             },
           ],
           expectation: {
@@ -481,10 +475,8 @@ if (dialect === 'db2') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.fn('NOW'),
-              };
+            {
+              bar: sql.fn('NOW'),
             },
             { name: 'foo' },
           ],
@@ -498,10 +490,8 @@ if (dialect === 'db2') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.col('foo'),
-              };
+            {
+              bar: sql.col('foo'),
             },
             { name: 'foo' },
           ],

--- a/packages/core/test/unit/dialects/mariadb/errors.test.js
+++ b/packages/core/test/unit/dialects/mariadb/errors.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../../support');
 
-const { Sequelize } = require('@sequelize/core');
+const { ForeignKeyConstraintError, UniqueConstraintError } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const queryProto = Support.sequelize.dialect.Query.prototype;
@@ -21,7 +21,7 @@ if (dialect === 'mariadb') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(ForeignKeyConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');
@@ -39,7 +39,7 @@ if (dialect === 'mariadb') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(ForeignKeyConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');
@@ -57,7 +57,7 @@ if (dialect === 'mariadb') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.UniqueConstraintError);
+      expect(parsedErr).to.be.instanceOf(UniqueConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.fields.models_uniqueName2_unique).to.equal('unique name one\r');
     });

--- a/packages/core/test/unit/dialects/mariadb/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mariadb/query-generator.test.js
@@ -8,7 +8,7 @@ const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const { Op } = require('@sequelize/core');
+const { Op, sql } = require('@sequelize/core');
 const { MariaDbQueryGenerator } = require('@sequelize/mariadb');
 const { createSequelizeInstance } = require('../../../support');
 
@@ -200,10 +200,8 @@ if (dialect === 'mariadb') {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
@@ -211,13 +209,11 @@ if (dialect === 'mariadb') {
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
@@ -332,10 +328,8 @@ if (dialect === 'mariadb') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                foo: sequelize.fn('NOW'),
-              };
+            {
+              foo: sql.fn('NOW'),
             },
           ],
           expectation: {
@@ -492,10 +486,8 @@ if (dialect === 'mariadb') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.fn('NOW'),
-              };
+            {
+              bar: sql.fn('NOW'),
             },
             { name: 'foo' },
           ],
@@ -508,10 +500,8 @@ if (dialect === 'mariadb') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.col('foo'),
-              };
+            {
+              bar: sql.col('foo'),
             },
             { name: 'foo' },
           ],

--- a/packages/core/test/unit/dialects/mysql/errors.test.js
+++ b/packages/core/test/unit/dialects/mysql/errors.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../../support');
 
-const { Sequelize } = require('@sequelize/core');
+const { ForeignKeyConstraintError, UniqueConstraintError } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const queryProto = Support.sequelize.dialect.Query.prototype;
@@ -21,7 +21,7 @@ if (dialect === 'mysql') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(ForeignKeyConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');
@@ -39,7 +39,7 @@ if (dialect === 'mysql') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(ForeignKeyConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');
@@ -55,7 +55,7 @@ if (dialect === 'mysql') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.UniqueConstraintError);
+      expect(parsedErr).to.be.instanceOf(UniqueConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.fields.num).to.equal('13888888888\r');
     });

--- a/packages/core/test/unit/dialects/mysql/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mysql/query-generator.test.js
@@ -8,7 +8,7 @@ const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const { Op } = require('@sequelize/core');
+const { Op, sql } = require('@sequelize/core');
 const { MySqlQueryGenerator } = require('@sequelize/mysql');
 const { createSequelizeInstance } = require('../../../support');
 
@@ -200,10 +200,8 @@ if (dialect === 'mysql') {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
@@ -211,13 +209,11 @@ if (dialect === 'mysql') {
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
@@ -327,10 +323,8 @@ if (dialect === 'mysql') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                foo: sequelize.fn('NOW'),
-              };
+            {
+              foo: sql.fn('NOW'),
             },
           ],
           expectation: {
@@ -487,10 +481,8 @@ if (dialect === 'mysql') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.fn('NOW'),
-              };
+            {
+              bar: sql.fn('NOW'),
             },
             { name: 'foo' },
           ],
@@ -503,10 +495,8 @@ if (dialect === 'mysql') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.col('foo'),
-              };
+            {
+              bar: sql.col('foo'),
             },
             { name: 'foo' },
           ],

--- a/packages/core/test/unit/dialects/oracle/query-generator.test.js
+++ b/packages/core/test/unit/dialects/oracle/query-generator.test.js
@@ -5,7 +5,7 @@ const each = require('lodash/each');
 const chai = require('chai');
 
 const expect = chai.expect;
-const { DataTypes } = require('@sequelize/core');
+const { DataTypes, sql } = require('@sequelize/core');
 const { OracleQueryGenerator: QueryGenerator } = require('@sequelize/oracle');
 const Support = require('../../../support');
 
@@ -210,20 +210,20 @@ if (dialect.startsWith('oracle')) {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            sequelize => ({
-              group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-            }),
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
+            },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt");',
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            sequelize => ({
-              group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-            }),
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
+            },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt"), "title";',
           context: QueryGenerator,
@@ -398,9 +398,9 @@ if (dialect.startsWith('oracle')) {
         {
           arguments: [
             'myTable',
-            sequelize => ({
-              foo: sequelize.fn('NOW'),
-            }),
+            {
+              foo: sql.fn('NOW'),
+            },
           ],
           expectation: {
             query: 'INSERT INTO "myTable" ("foo") VALUES (NOW());',
@@ -630,9 +630,9 @@ if (dialect.startsWith('oracle')) {
         {
           arguments: [
             'myTable',
-            sequelize => ({
-              bar: sequelize.fn('NOW'),
-            }),
+            {
+              bar: sql.fn('NOW'),
+            },
             { name: 'foo' },
           ],
           expectation: {
@@ -644,9 +644,9 @@ if (dialect.startsWith('oracle')) {
         {
           arguments: [
             'myTable',
-            sequelize => ({
-              bar: sequelize.col('foo'),
-            }),
+            {
+              bar: sql.col('foo'),
+            },
             { name: 'foo' },
           ],
           expectation: {

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -5,7 +5,7 @@ const each = require('lodash/each');
 const chai = require('chai');
 
 const expect = chai.expect;
-const { Op } = require('@sequelize/core');
+const { Op, sql } = require('@sequelize/core');
 const { PostgresQueryGenerator: QueryGenerator } = require('@sequelize/postgres');
 const Support = require('../../../support');
 
@@ -248,23 +248,19 @@ if (dialect.startsWith('postgres')) {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
             },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt");',
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
             },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt"), "title";',
@@ -455,10 +451,8 @@ if (dialect.startsWith('postgres')) {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                foo: sequelize.fn('NOW'),
-              };
+            {
+              foo: sql.fn('NOW'),
             },
           ],
           expectation: {
@@ -890,10 +884,8 @@ if (dialect.startsWith('postgres')) {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.fn('NOW'),
-              };
+            {
+              bar: sql.fn('NOW'),
             },
             { name: 'foo' },
           ],
@@ -906,10 +898,8 @@ if (dialect.startsWith('postgres')) {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.col('foo'),
-              };
+            {
+              bar: sql.col('foo'),
             },
             { name: 'foo' },
           ],

--- a/packages/core/test/unit/dialects/snowflake/errors.test.js
+++ b/packages/core/test/unit/dialects/snowflake/errors.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../../support');
 
-const { Sequelize } = require('@sequelize/core');
+const { ForeignKeyConstraintError, UniqueConstraintError } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const queryProto = Support.sequelize.dialect.Query.prototype;
@@ -21,7 +21,7 @@ if (dialect === 'snowflake') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(ForeignKeyConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');
@@ -39,7 +39,7 @@ if (dialect === 'snowflake') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(ForeignKeyConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');
@@ -55,7 +55,7 @@ if (dialect === 'snowflake') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Sequelize.UniqueConstraintError);
+      expect(parsedErr).to.be.instanceOf(UniqueConstraintError);
       expect(parsedErr.cause).to.equal(fakeErr);
       expect(parsedErr.fields.num).to.equal('13888888888\r');
     });

--- a/packages/core/test/unit/dialects/snowflake/query-generator.test.js
+++ b/packages/core/test/unit/dialects/snowflake/query-generator.test.js
@@ -8,7 +8,7 @@ const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const { Op } = require('@sequelize/core');
+const { Op, sql } = require('@sequelize/core');
 const { SnowflakeQueryGenerator: QueryGenerator } = require('@sequelize/snowflake');
 const { createSequelizeInstance } = require('../../../support');
 
@@ -247,10 +247,8 @@ if (dialect === 'snowflake') {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
             },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt");',
@@ -258,13 +256,11 @@ if (dialect === 'snowflake') {
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
             },
           ],
           expectation: 'SELECT * FROM "myTable" GROUP BY YEAR("createdAt"), "title";',
@@ -388,10 +384,8 @@ if (dialect === 'snowflake') {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
             },
           ],
           expectation: 'SELECT * FROM myTable GROUP BY YEAR(createdAt);',
@@ -399,13 +393,11 @@ if (dialect === 'snowflake') {
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
             },
           ],
           expectation: 'SELECT * FROM myTable GROUP BY YEAR(createdAt), title;',
@@ -515,10 +507,8 @@ if (dialect === 'snowflake') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                foo: sequelize.fn('NOW'),
-              };
+            {
+              foo: sql.fn('NOW'),
             },
           ],
           expectation: {
@@ -598,10 +588,8 @@ if (dialect === 'snowflake') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                foo: sequelize.fn('NOW'),
-              };
+            {
+              foo: sql.fn('NOW'),
             },
           ],
           expectation: {
@@ -837,10 +825,8 @@ if (dialect === 'snowflake') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.fn('NOW'),
-              };
+            {
+              bar: sql.fn('NOW'),
             },
             { name: 'foo' },
           ],
@@ -853,10 +839,8 @@ if (dialect === 'snowflake') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.col('foo'),
-              };
+            {
+              bar: sql.col('foo'),
             },
             { name: 'foo' },
           ],
@@ -913,10 +897,8 @@ if (dialect === 'snowflake') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.fn('NOW'),
-              };
+            {
+              bar: sql.fn('NOW'),
             },
             { name: 'foo' },
           ],
@@ -930,10 +912,8 @@ if (dialect === 'snowflake') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.col('foo'),
-              };
+            {
+              bar: sql.col('foo'),
             },
             { name: 'foo' },
           ],

--- a/packages/core/test/unit/dialects/sqlite/query-generator.test.js
+++ b/packages/core/test/unit/dialects/sqlite/query-generator.test.js
@@ -11,6 +11,7 @@ const dialect = Support.getTestDialect();
 const dayjs = require('dayjs');
 const { SqliteQueryGenerator: QueryGenerator } = require('@sequelize/sqlite3');
 const { createSequelizeInstance } = require('../../../support');
+const { sql } = require('@sequelize/core');
 
 if (dialect === 'sqlite3') {
   describe('[SQLITE Specific] QueryGenerator', () => {
@@ -174,10 +175,8 @@ if (dialect === 'sqlite3') {
           title: 'functions work for group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt'))],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt'))],
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
@@ -185,13 +184,11 @@ if (dialect === 'sqlite3') {
           needsSequelize: true,
         },
         {
-          title: 'It is possible to mix sequelize.fn and string arguments to group by',
+          title: 'It is possible to mix sql.fn and string arguments to group by',
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title'],
-              };
+            {
+              group: [sql.fn('YEAR', sql.col('createdAt')), 'title'],
             },
           ],
           expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
@@ -275,10 +272,8 @@ if (dialect === 'sqlite3') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                foo: sequelize.fn('NOW'),
-              };
+            {
+              foo: sql.fn('NOW'),
             },
           ],
           expectation: {
@@ -468,10 +463,8 @@ if (dialect === 'sqlite3') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.fn('NOW'),
-              };
+            {
+              bar: sql.fn('NOW'),
             },
             { name: 'foo' },
           ],
@@ -484,10 +477,8 @@ if (dialect === 'sqlite3') {
         {
           arguments: [
             'myTable',
-            function (sequelize) {
-              return {
-                bar: sequelize.col('foo'),
-              };
+            {
+              bar: sql.col('foo'),
             },
             { name: 'foo' },
           ],

--- a/packages/core/test/unit/model/find-one.test.js
+++ b/packages/core/test/unit/model/find-one.test.js
@@ -7,19 +7,20 @@ const Support = require('../../support');
 
 const current = Support.sequelize;
 const sinon = require('sinon');
-const { DataTypes, Op, Sequelize } = require('@sequelize/core');
+const { DataTypes, Model, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method findOne', () => {
     before(function () {
-      this.oldFindAll = Sequelize.Model.findAll;
+      this.oldFindAll = Model.findAll;
     });
+
     after(function () {
-      Sequelize.Model.findAll = this.oldFindAll;
+      Model.findAll = this.oldFindAll;
     });
 
     beforeEach(function () {
-      this.stub = Sequelize.Model.findAll = sinon.stub().resolves();
+      this.stub = Model.findAll = sinon.stub().resolves();
     });
 
     it('should add limit when using { $ gt on the primary key', async function () {
@@ -44,8 +45,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       await Model.findOne({ where: { unique1: 42 } });
       expect(this.stub.getCall(0).args[0]).to.be.an('object').to.have.property('limit');
     });
+
     it('should call internal findAll() method if findOne() is overridden', async () => {
-      const Model = current.define('model', {
+      const MyModel = current.define('MyModel', {
         unique1: {
           type: DataTypes.INTEGER,
           unique: 'unique',
@@ -55,11 +57,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           unique: 'unique',
         },
       });
-      Model.findAll = sinon.stub();
+      MyModel.findAll = sinon.stub();
 
-      await Model.findOne();
-      Model.findAll.should.not.have.been.called;
-      Sequelize.Model.findAll.should.have.been.called;
+      await MyModel.findOne();
+      MyModel.findAll.should.not.have.been.called;
+      Model.findAll.should.have.been.called;
     });
   });
 });

--- a/packages/core/test/unit/model/include.test.js
+++ b/packages/core/test/unit/model/include.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const { DataTypes, Op, Sequelize } = require('@sequelize/core');
+const { DataTypes, Model, Op } = require('@sequelize/core');
 const {
   _validateIncludedElements,
 } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/model-internals.js');
@@ -269,7 +269,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const options = {
           include: ['Owner'],
         };
-        Sequelize.Model._conformIncludes(options, this.Company);
+        Model._conformIncludes(options, this.Company);
 
         expect(options.include[0]).to.deep.equal({
           model: this.User,
@@ -287,7 +287,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             },
           ],
         };
-        Sequelize.Model._conformIncludes(options, this.Company);
+        Model._conformIncludes(options, this.Company);
 
         expect(options.include[0]).to.deep.equal({
           model: this.User,
@@ -307,7 +307,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         };
 
         expect(() => {
-          Sequelize.Model._conformIncludes(options, this.Company);
+          Model._conformIncludes(options, this.Company);
         }).to.throw(
           'Invalid Include received. Include has to be either a Model, an Association, the name of an association, or a plain object compatible with IncludeOptions.',
         );
@@ -323,7 +323,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         };
 
         expect(() => {
-          Sequelize.Model._conformIncludes(options, this.Company);
+          Model._conformIncludes(options, this.Company);
         }).to.throw(
           'Invalid Include received. Include has to be either a Model, an Association, the name of an association, or a plain object compatible with IncludeOptions.',
         );

--- a/packages/core/test/unit/model/scope.test.ts
+++ b/packages/core/test/unit/model/scope.test.ts
@@ -564,7 +564,7 @@ describe(getTestDialectTeaser('Model'), () => {
       });
 
       describe('sequelize where', () => {
-        it('should group 2 sequelize.where with an Op.and', () => {
+        it('should group 2 sql.where with an Op.and', () => {
           const { TestModel } = vars;
 
           const scope = TestModel.withScope([
@@ -579,7 +579,7 @@ describe(getTestDialectTeaser('Model'), () => {
           expect(scope).to.deep.equal(expected);
         });
 
-        it('should group 2 sequelize.where and other scopes with an Op.and', () => {
+        it('should group 2 sql.where and other scopes with an Op.and', () => {
           const { TestModel } = vars;
 
           const scope = TestModel.withScope([

--- a/packages/core/test/unit/model/scope.test.ts
+++ b/packages/core/test/unit/model/scope.test.ts
@@ -1,5 +1,5 @@
 import type { FindOptions } from '@sequelize/core';
-import { DataTypes, Op, Sequelize, col, literal, where } from '@sequelize/core';
+import { col, DataTypes, literal, Op, sql, where } from '@sequelize/core';
 import { expect } from 'chai';
 import assert from 'node:assert';
 import { beforeEach2, getTestDialectTeaser, resetSequelizeInstance } from '../../support';
@@ -595,7 +595,7 @@ describe(getTestDialectTeaser('Model'), () => {
                 { field: 1 },
                 { field: 1 },
                 { [Op.or]: [{ field: 1 }, { field: 1 }] },
-                Sequelize.where(col('field'), Op.is, 1),
+                sql.where(sql.col('field'), Op.is, 1),
               ],
             },
           };

--- a/packages/core/test/unit/model/upsert.test.js
+++ b/packages/core/test/unit/model/upsert.test.js
@@ -7,7 +7,7 @@ const Support = require('../../support');
 
 const current = Support.sequelize;
 const sinon = require('sinon');
-const { DataTypes, Sequelize } = require('@sequelize/core');
+const { DataTypes, ValidationError } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   if (current.dialect.supports.upserts) {
@@ -63,7 +63,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           this.User.upsert({
             name: 'Grumpy Cat',
           }),
-        ).not.to.be.rejectedWith(Sequelize.ValidationError);
+        ).not.to.be.rejectedWith(ValidationError);
       });
 
       it('creates new record with correct field names', async function () {

--- a/packages/core/test/unit/model/validation.test.js
+++ b/packages/core/test/unit/model/validation.test.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai');
 const sinon = require('sinon');
-const { DataTypes, Op, Sequelize } = require('@sequelize/core');
+const { DataTypes, Op, ValidationError, ValidationErrorItem } = require('@sequelize/core');
 const { rand, sequelize } = require('../../support');
 
 const dialect = sequelize.dialect;
@@ -400,14 +400,14 @@ describe('InstanceValidator', () => {
             User.create({
               integer: 'jan',
             }),
-          ).to.be.rejectedWith(Sequelize.ValidationError, `'jan' is not a valid integer`);
+          ).to.be.rejectedWith(ValidationError, `'jan' is not a valid integer`);
 
           expect(error)
             .to.have.property('errors')
             .that.is.an('array')
             .with.lengthOf(1)
             .and.with.property(0)
-            .that.is.an.instanceOf(Sequelize.ValidationErrorItem)
+            .that.is.an.instanceOf(ValidationErrorItem)
             .and.include({
               type: 'Validation error',
               path: 'integer',
@@ -422,12 +422,12 @@ describe('InstanceValidator', () => {
               integer: 4.5,
             }),
           )
-            .to.be.rejectedWith(Sequelize.ValidationError)
+            .to.be.rejectedWith(ValidationError)
             .which.eventually.have.property('errors')
             .that.is.an('array')
             .with.lengthOf(1)
             .and.with.property(0)
-            .that.is.an.instanceOf(Sequelize.ValidationErrorItem)
+            .that.is.an.instanceOf(ValidationErrorItem)
             .and.include({
               type: 'Validation error',
               path: 'integer',
@@ -440,12 +440,12 @@ describe('InstanceValidator', () => {
       describe('update', () => {
         it('should throw when passing string', async () => {
           await expect(User.update({ integer: 'jan' }, { where: {} }))
-            .to.be.rejectedWith(Sequelize.ValidationError)
+            .to.be.rejectedWith(ValidationError)
             .which.eventually.have.property('errors')
             .that.is.an('array')
             .with.lengthOf(1)
             .and.with.property(0)
-            .that.is.an.instanceOf(Sequelize.ValidationErrorItem)
+            .that.is.an.instanceOf(ValidationErrorItem)
             .and.include({
               type: 'Validation error',
               path: 'integer',
@@ -463,12 +463,12 @@ describe('InstanceValidator', () => {
               { where: {} },
             ),
           )
-            .to.be.rejectedWith(Sequelize.ValidationError)
+            .to.be.rejectedWith(ValidationError)
             .which.eventually.have.property('errors')
             .that.is.an('array')
             .with.lengthOf(1)
             .and.with.property(0)
-            .that.is.an.instanceOf(Sequelize.ValidationErrorItem)
+            .that.is.an.instanceOf(ValidationErrorItem)
             .and.include({
               type: 'Validation error',
               path: 'integer',
@@ -553,7 +553,7 @@ describe('InstanceValidator', () => {
             User.create({
               integer: -1,
             }),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
         });
 
         it('custom model validation function fails', async () => {
@@ -561,7 +561,7 @@ describe('InstanceValidator', () => {
             User.create({
               name: 'error',
             }),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
         });
       });
 
@@ -574,7 +574,7 @@ describe('InstanceValidator', () => {
               },
               { where: {} },
             ),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
         });
 
         it('when custom model validation function fails', async () => {
@@ -585,7 +585,7 @@ describe('InstanceValidator', () => {
               },
               { where: {} },
             ),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
         });
       });
     });
@@ -650,7 +650,7 @@ describe('InstanceValidator', () => {
             User.create({
               name: 'error',
             }),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
         });
       });
 
@@ -663,7 +663,7 @@ describe('InstanceValidator', () => {
               },
               { where: {} },
             ),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
         });
       });
     });
@@ -740,7 +740,7 @@ describe('InstanceValidator', () => {
               integer: 11,
               name: null,
             }),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
 
           await expect(this.customValidator).to.have.been.calledOnce;
         });
@@ -754,7 +754,7 @@ describe('InstanceValidator', () => {
               },
               { where: {} },
             ),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
 
           await expect(this.customValidator).to.have.been.calledOnce;
         });
@@ -792,7 +792,7 @@ describe('InstanceValidator', () => {
               integer: 99,
               name: null,
             }),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
 
           await expect(this.customValidator).to.have.not.been.called;
         });
@@ -806,7 +806,7 @@ describe('InstanceValidator', () => {
               },
               { where: {} },
             ),
-          ).to.be.rejectedWith(Sequelize.ValidationError);
+          ).to.be.rejectedWith(ValidationError);
 
           await expect(this.customValidator).to.have.not.been.called;
         });

--- a/packages/core/test/unit/sql/index.test.js
+++ b/packages/core/test/unit/sql/index.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support = require('../../support');
-const { literal, Op } = require('@sequelize/core');
+const { literal, Op, sql } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
@@ -147,7 +147,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
     it('function', () => {
       expectsql(
-        queryGenerator.addIndexQuery('table', [current.fn('UPPER', current.col('test'))], {
+        queryGenerator.addIndexQuery('table', [sql.fn('UPPER', sql.col('test'))], {
           name: 'myindex',
         }),
         {

--- a/packages/core/test/unit/sql/order.test.ts
+++ b/packages/core/test/unit/sql/order.test.ts
@@ -416,7 +416,7 @@ describe('QueryGenerator#selectQuery with "order"', () => {
         }),
       ).to.eventually.be.rejectedWith(
         Error,
-        'The `{raw: "..."}` syntax is no longer supported.  Use `sequelize.literal` instead.',
+        'The `{raw: "..."}` syntax is no longer supported. Use `sql` instead.',
       );
     });
 
@@ -436,7 +436,7 @@ describe('QueryGenerator#selectQuery with "order"', () => {
         }),
       ).to.eventually.be.rejectedWith(
         Error,
-        'The `{raw: "..."}` syntax is no longer supported.  Use `sequelize.literal` instead.',
+        'The `{raw: "..."}` syntax is no longer supported. Use `sql` instead.',
       );
     });
   });

--- a/test/esm-named-exports.test.js
+++ b/test/esm-named-exports.test.js
@@ -7,57 +7,10 @@ const expect = chai.expect;
  * Context: https://github.com/sequelize/sequelize/pull/13689
  */
 
-// require('@sequelize/core') returns the Sequelize class
-// The typings do not reflect this as some properties of the Sequelize class are not declared as exported in types/index.d.ts.
-// This array lists the properties that are present on the class, but should not be exported in the esm export file nor in types/index.d.ts.
+// This array lists the properties that are present on the CJS export,
+// but should not be exported in the esm export file nor in types/index.d.ts.
 const ignoredCjsKeysMap = {
-  '@sequelize/core': [
-    // make no sense to export
-    'length',
-    'prototype',
-    'name',
-    'version',
-
-    // importing the data type directly has been removed, and accessing them on the Sequelize constructor is deprecated.
-    // Use DataTypes.x exclusively.
-    'ABSTRACT',
-    'ARRAY',
-    'BIGINT',
-    'BLOB',
-    'BOOLEAN',
-    'CHAR',
-    'CIDR',
-    'CITEXT',
-    'DATE',
-    'DATEONLY',
-    'DECIMAL',
-    'DOUBLE',
-    'ENUM',
-    'FLOAT',
-    'GEOGRAPHY',
-    'GEOMETRY',
-    'HSTORE',
-    'INET',
-    'INTEGER',
-    'JSON',
-    'JSONB',
-    'MACADDR',
-    'MACADDR8',
-    'MEDIUMINT',
-    'NOW',
-    'RANGE',
-    'REAL',
-    'SMALLINT',
-    'STRING',
-    'TEXT',
-    'TIME',
-    'TINYINT',
-    'TSVECTOR',
-    'UUID',
-    'UUIDV1',
-    'UUIDV4',
-    'VIRTUAL',
-  ],
+  '@sequelize/core': [],
   '@sequelize/core/decorators-legacy': ['__esModule'],
   '@sequelize/db2': ['__esModule'],
   '@sequelize/db2-ibmi': ['__esModule'],


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

- Removed the default export from the `@sequelize/core`. The Sequelize class can only be imported as a named export
- Because they're no longer needed, deprecate all properties of the Sequelize constructor that has been replaced by a proper named export (`Sequelize.fn`, `Sequelize.AbstractDialect`, etc).

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->

- The default export has been removed, import the Sequelize class as a named export instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many SQL helpers, operators, utilities, and error classes are now available as direct named exports from @sequelize/core.

* **Deprecations**
  * Accessing properties via the Sequelize class/instance (e.g. legacy static/instance aliases) is deprecated and will emit once-per-property warnings; migrate to direct named imports.
  * Legacy default export/alias removed—use named imports or import the package namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->