### PR TITLE
feat: Add the ability to name an enum to allow for sharing it between multiple tables

### DIFF
--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2281,14 +2281,7 @@ export class ENUM<Member extends string> extends AbstractDataType<Member> {
   constructor(...args: [EnumValues<Member> | Member | EnumOptions<Member>, ...Member[]]) {
     super();
 
-    const values: readonly Member[] = this.#getEnumValues(args);
-    const [first] = args;
-    const optionsBag =
-      !isString(first) && !Array.isArray(first) && 'values' in first && typeof (first as { values?: unknown }).values !== 'string'
-        ? (first as EnumOptions<Member>)
-        : null;
-    const enumName = optionsBag?.name;
-    const enumSchema = optionsBag?.schema;
+    const { values, optionsBag } = this._getEnumValues(args);
 
     if (values.length === 0) {
       throw new TypeError(
@@ -2326,24 +2319,23 @@ sequelize.define('MyModel', {
       }
     }
 
-    this.options = {
-      values,
-      ...(enumName !== undefined && { name: enumName }),
-      ...(enumSchema !== undefined && { schema: enumSchema }),
-    };
+    const opts: NormalizedEnumOptions<Member> = { values };
+    if (optionsBag?.name !== undefined) opts.name = optionsBag.name;
+    if (optionsBag?.schema !== undefined) opts.schema = optionsBag.schema;
+    this.options = opts;
   }
 
-  #getEnumValues(
+  protected _getEnumValues(
     args: [EnumValues<Member> | Member | EnumOptions<Member>, ...Member[]],
-  ): readonly Member[] {
+  ): { values: readonly Member[]; optionsBag: EnumOptions<Member> | null } {
     if (args.length === 0) {
-      return EMPTY_ARRAY;
+      return { values: EMPTY_ARRAY, optionsBag: null };
     }
 
     const [first, ...rest] = args;
 
     if (isString(first)) {
-      return [first, ...rest];
+      return { values: [first, ...rest], optionsBag: null };
     }
 
     if (rest.length > 0) {
@@ -2352,9 +2344,11 @@ sequelize.define('MyModel', {
       );
     }
 
+    let optionsBag: EnumOptions<Member> | null = null;
     let enumOrArray: EnumValues<Member>;
     if (!Array.isArray(first) && 'values' in first && typeof first.values !== 'string') {
       // This is the option bag
+      optionsBag = first as EnumOptions<Member>;
       // @ts-expect-error -- Array.isArray does not narrow correctly when the array is readonly
       enumOrArray = first.values;
     } else {
@@ -2363,7 +2357,7 @@ sequelize.define('MyModel', {
     }
 
     if (Array.isArray(enumOrArray)) {
-      return [...enumOrArray];
+      return { values: [...enumOrArray], optionsBag };
     }
 
     // @ts-expect-error -- Array.isArray does not narrow correctly when the array is readonly
@@ -2377,7 +2371,7 @@ sequelize.define('MyModel', {
       }
     }
 
-    return enumKeys;
+    return { values: enumKeys, optionsBag };
   }
 
   validate(value: any): asserts value is Member {

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2281,7 +2281,7 @@ export class ENUM<Member extends string> extends AbstractDataType<Member> {
   constructor(...args: [EnumValues<Member> | Member | EnumOptions<Member>, ...Member[]]) {
     super();
 
-    const { values, optionsBag } = this._getEnumValues(args);
+    const { values, options } = this._getEnumValues(args);
 
     if (values.length === 0) {
       throw new TypeError(
@@ -2320,22 +2320,22 @@ sequelize.define('MyModel', {
     }
 
     const opts: NormalizedEnumOptions<Member> = { values };
-    if (optionsBag?.name !== undefined) opts.name = optionsBag.name;
-    if (optionsBag?.schema !== undefined) opts.schema = optionsBag.schema;
+    if (options?.name !== undefined) opts.name = options.name;
+    if (options?.schema !== undefined) opts.schema = options.schema;
     this.options = opts;
   }
 
   protected _getEnumValues(
     args: [EnumValues<Member> | Member | EnumOptions<Member>, ...Member[]],
-  ): { values: readonly Member[]; optionsBag: EnumOptions<Member> | null } {
+  ): { values: readonly Member[]; options: EnumOptions<Member> | null } {
     if (args.length === 0) {
-      return { values: EMPTY_ARRAY, optionsBag: null };
+      return { values: EMPTY_ARRAY, options: null };
     }
 
     const [first, ...rest] = args;
 
     if (isString(first)) {
-      return { values: [first, ...rest], optionsBag: null };
+      return { values: [first, ...rest], options: null };
     }
 
     if (rest.length > 0) {
@@ -2344,11 +2344,11 @@ sequelize.define('MyModel', {
       );
     }
 
-    let optionsBag: EnumOptions<Member> | null = null;
+    let options: EnumOptions<Member> | null = null;
     let enumOrArray: EnumValues<Member>;
     if (!Array.isArray(first) && 'values' in first && typeof first.values !== 'string') {
       // This is the option bag
-      optionsBag = first as EnumOptions<Member>;
+      options = first as EnumOptions<Member>;
       // @ts-expect-error -- Array.isArray does not narrow correctly when the array is readonly
       enumOrArray = first.values;
     } else {
@@ -2357,7 +2357,7 @@ sequelize.define('MyModel', {
     }
 
     if (Array.isArray(enumOrArray)) {
-      return { values: [...enumOrArray], optionsBag };
+      return { values: [...enumOrArray], options };
     }
 
     // @ts-expect-error -- Array.isArray does not narrow correctly when the array is readonly
@@ -2371,7 +2371,7 @@ sequelize.define('MyModel', {
       }
     }
 
-    return { values: enumKeys, optionsBag };
+    return { values: enumKeys, options };
   }
 
   validate(value: any): asserts value is Member {

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2322,11 +2322,19 @@ sequelize.define('MyModel', {
     const opts: NormalizedEnumOptions<Member> = { values };
 
     if (options?.name !== undefined) {
+      if (!isString(options.name) || options.name.length === 0) {
+        throw new TypeError('DataTypes.ENUM option "name" must be a non-empty string.');
+      }
+
       opts.name = options.name;
     }
 
     if (options?.schema !== undefined) {
       opts.schema = options.schema;
+
+      if (!isString(options.schema) || options.schema.length === 0) {
+        throw new TypeError('DataTypes.ENUM option "schema" must be a non-empty string.');
+      }
     }
 
     this.options = opts;

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2220,10 +2220,28 @@ type EnumValues<Member extends string> = readonly Member[] | Record<Member, Memb
 
 export interface EnumOptions<Member extends string> {
   values: EnumValues<Member>;
+  /**
+   * A custom name for the enum type in the database.
+   * Currently only supported by PostgreSQL, where enum types are named objects.
+   * When set, this name is used instead of the auto-generated `enum_<table>_<column>` name,
+   * allowing the same enum type to be shared across multiple columns or models.
+   */
+  enumName?: string;
+  /**
+   * The schema that the enum type belongs to.
+   * Currently only supported by PostgreSQL.
+   * When set, this schema is used for the enum type instead of the table's schema.
+   * This is useful when an enum type lives in a shared schema that is different from
+   * the table's schema.
+   * Requires {@link enumName} to also be set.
+   */
+  enumSchema?: string;
 }
 
 export interface NormalizedEnumOptions<Member extends string> {
   values: readonly Member[];
+  enumName?: string;
+  enumSchema?: string;
 }
 
 /**
@@ -2264,6 +2282,16 @@ export class ENUM<Member extends string> extends AbstractDataType<Member> {
     super();
 
     const values: readonly Member[] = this.#getEnumValues(args);
+    const [first] = args;
+    const isOptionsBag =
+      !isString(first) &&
+      !Array.isArray(first) &&
+      typeof first === 'object' &&
+      first !== null &&
+      'values' in first &&
+      typeof (first as { values?: unknown }).values !== 'string';
+    const enumName = isOptionsBag ? (first as EnumOptions<Member>).enumName : undefined;
+    const enumSchema = isOptionsBag ? (first as EnumOptions<Member>).enumSchema : undefined;
 
     if (values.length === 0) {
       throw new TypeError(
@@ -2303,6 +2331,8 @@ sequelize.define('MyModel', {
 
     this.options = {
       values,
+      ...(enumName !== undefined && { enumName }),
+      ...(enumSchema !== undefined && { enumSchema }),
     };
   }
 

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2320,8 +2320,12 @@ sequelize.define('MyModel', {
     }
 
     const opts: NormalizedEnumOptions<Member> = { values };
-    if (options?.name !== undefined) opts.name = options.name;
-    if (options?.schema !== undefined) opts.schema = options.schema;
+    if (options?.name !== undefined) {
+      opts.name = options.name;
+    }
+    if (options?.schema !== undefined) {
+      opts.schema = options.schema;
+    }
     this.options = opts;
   }
 

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2226,22 +2226,22 @@ export interface EnumOptions<Member extends string> {
    * When set, this name is used instead of the auto-generated `enum_<table>_<column>` name,
    * allowing the same enum type to be shared across multiple columns or models.
    */
-  enumName?: string;
+  name?: string;
   /**
    * The schema that the enum type belongs to.
    * Currently only supported by PostgreSQL.
    * When set, this schema is used for the enum type instead of the table's schema.
    * This is useful when an enum type lives in a shared schema that is different from
    * the table's schema.
-   * Requires {@link enumName} to also be set.
+   * Can be set without {@link name} to place the auto-generated enum type name in a specific schema.
    */
-  enumSchema?: string;
+  schema?: string;
 }
 
 export interface NormalizedEnumOptions<Member extends string> {
   values: readonly Member[];
-  enumName?: string;
-  enumSchema?: string;
+  name?: string;
+  schema?: string;
 }
 
 /**
@@ -2290,8 +2290,8 @@ export class ENUM<Member extends string> extends AbstractDataType<Member> {
       first !== null &&
       'values' in first &&
       typeof (first as { values?: unknown }).values !== 'string';
-    const enumName = isOptionsBag ? (first as EnumOptions<Member>).enumName : undefined;
-    const enumSchema = isOptionsBag ? (first as EnumOptions<Member>).enumSchema : undefined;
+    const enumName = isOptionsBag ? (first as EnumOptions<Member>).name : undefined;
+    const enumSchema = isOptionsBag ? (first as EnumOptions<Member>).schema : undefined;
 
     if (values.length === 0) {
       throw new TypeError(
@@ -2331,8 +2331,8 @@ sequelize.define('MyModel', {
 
     this.options = {
       values,
-      ...(enumName !== undefined && { enumName }),
-      ...(enumSchema !== undefined && { enumSchema }),
+      ...(enumName !== undefined && { name: enumName }),
+      ...(enumSchema !== undefined && { schema: enumSchema }),
     };
   }
 

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2320,12 +2320,15 @@ sequelize.define('MyModel', {
     }
 
     const opts: NormalizedEnumOptions<Member> = { values };
+
     if (options?.name !== undefined) {
       opts.name = options.name;
     }
+
     if (options?.schema !== undefined) {
       opts.schema = options.schema;
     }
+
     this.options = opts;
   }
 

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2283,15 +2283,12 @@ export class ENUM<Member extends string> extends AbstractDataType<Member> {
 
     const values: readonly Member[] = this.#getEnumValues(args);
     const [first] = args;
-    const isOptionsBag =
-      !isString(first) &&
-      !Array.isArray(first) &&
-      typeof first === 'object' &&
-      first !== null &&
-      'values' in first &&
-      typeof (first as { values?: unknown }).values !== 'string';
-    const enumName = isOptionsBag ? (first as EnumOptions<Member>).name : undefined;
-    const enumSchema = isOptionsBag ? (first as EnumOptions<Member>).schema : undefined;
+    const optionsBag =
+      !isString(first) && !Array.isArray(first) && 'values' in first && typeof (first as { values?: unknown }).values !== 'string'
+        ? (first as EnumOptions<Member>)
+        : null;
+    const enumName = optionsBag?.name;
+    const enumSchema = optionsBag?.schema;
 
     if (values.length === 0) {
       throw new TypeError(

--- a/packages/core/test/unit/data-types/misc-data-types.test.ts
+++ b/packages/core/test/unit/data-types/misc-data-types.test.ts
@@ -98,6 +98,18 @@ describe('DataTypes.ENUM', () => {
     );
   });
 
+  it('throws if the "name" option is an empty string', () => {
+    expect(() => {
+      DataTypes.ENUM({ values: ['a', 'b'], name: '' });
+    }).to.throw(TypeError, 'DataTypes.ENUM option "name" must be a non-empty string.');
+  });
+
+  it('throws if the "schema" option is an empty string', () => {
+    expect(() => {
+      DataTypes.ENUM({ values: ['a', 'b'], schema: '' });
+    }).to.throw(TypeError, 'DataTypes.ENUM option "schema" must be a non-empty string.');
+  });
+
   typeTest('accepts readonly arrays', () => {
     const values: readonly string[] = ['value 1', 'value 2'];
 

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -196,10 +196,12 @@ describe('PostgresQueryGenerator', () => {
       const { EnumSchemaOnlyUser } = vars;
       const moodAttr = EnumSchemaOnlyUser.modelDefinition.attributes.get('mood');
 
-      const result = queryGenerator.attributeToSQL(
+      const raw = queryGenerator.attributeToSQL(
         { type: moodAttr.type },
         { table: EnumSchemaOnlyUser.table, key: 'mood' },
       );
+      // dataTypeMapping strips the internal ENUM_NAMED() sentinel before emitting SQL
+      const result = queryGenerator.dataTypeMapping(EnumSchemaOnlyUser.table, 'mood', raw);
       expect(result).to.equal('"shared"."enum_users_mood"');
     });
 
@@ -207,10 +209,12 @@ describe('PostgresQueryGenerator', () => {
       const { CustomEnumSchemaUser } = vars;
       const moodAttr = CustomEnumSchemaUser.modelDefinition.attributes.get('mood');
 
-      const result = queryGenerator.attributeToSQL(
+      const raw = queryGenerator.attributeToSQL(
         { type: moodAttr.type },
         { table: CustomEnumSchemaUser.table, key: 'mood' },
       );
+      // dataTypeMapping strips the internal ENUM_NAMED() sentinel before emitting SQL
+      const result = queryGenerator.dataTypeMapping(CustomEnumSchemaUser.table, 'mood', raw);
       expect(result).to.equal('"shared"."mood_type"');
     });
   });
@@ -248,6 +252,50 @@ describe('PostgresQueryGenerator', () => {
       expect(result).to.include('CREATE TYPE "shared"."mood_type"');
       // ADD COLUMN should reference the custom type as an array
       expect(result).to.match(/"moods" "shared"\."mood_type"\[\]/);
+    });
+  });
+
+  describe('changeColumnQuery', () => {
+    it('adds USING cast for auto-named ENUM', () => {
+      const sq = createSequelizeInstance();
+      const User = sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'] }),
+      });
+      const qg = sq.dialect.queryGenerator;
+      const attrs = qg.attributesToSQL(
+        { mood: User.modelDefinition.attributes.get('mood') },
+        { context: 'changeColumn', table: User.table },
+      );
+      const result = qg.changeColumnQuery(User.table, attrs);
+      expect(result).to.include('USING ("mood"::"public"."enum_users_mood")');
+    });
+
+    it('adds USING cast for custom-named ENUM', () => {
+      const sq = createSequelizeInstance();
+      const User = sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
+      });
+      const qg = sq.dialect.queryGenerator;
+      const attrs = qg.attributesToSQL(
+        { mood: User.modelDefinition.attributes.get('mood') },
+        { context: 'changeColumn', table: User.table },
+      );
+      const result = qg.changeColumnQuery(User.table, attrs);
+      expect(result).to.include('USING ("mood"::"public"."mood_type")');
+    });
+
+    it('adds USING cast for custom-named ENUM with custom schema', () => {
+      const sq = createSequelizeInstance();
+      const User = sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'shared' }),
+      });
+      const qg = sq.dialect.queryGenerator;
+      const attrs = qg.attributesToSQL(
+        { mood: User.modelDefinition.attributes.get('mood') },
+        { context: 'changeColumn', table: User.table },
+      );
+      const result = qg.changeColumnQuery(User.table, attrs);
+      expect(result).to.include('USING ("mood"::"shared"."mood_type")');
     });
   });
 

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -427,7 +427,9 @@ describe('PostgresQueryGenerator', () => {
       const sq = createSequelizeInstance();
       const sharedEnum = DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' });
       sq.define('user', { mood: sharedEnum });
-      sq.define('profile', { feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }) });
+      sq.define('profile', {
+        feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
+      });
       stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
 
       await sq.queryInterface.dropTable('users');
@@ -445,7 +447,13 @@ describe('PostgresQueryGenerator', () => {
       );
       sq.define(
         'profile',
-        { feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'shared' }) },
+        {
+          feeling: DataTypes.ENUM({
+            values: ['happy', 'sad'],
+            name: 'mood_type',
+            schema: 'shared',
+          }),
+        },
         { schema: 'bar' },
       );
       stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
@@ -509,7 +517,11 @@ describe('PostgresQueryGenerator', () => {
         mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'schema_a' }),
       });
       sq.define('profile', {
-        feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'schema_b' }),
+        feeling: DataTypes.ENUM({
+          values: ['happy', 'sad'],
+          name: 'mood_type',
+          schema: 'schema_b',
+        }),
       });
       stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
 

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -30,7 +30,7 @@ describe('PostgresQueryGenerator', () => {
     });
 
     const CustomEnumUser = sequelize.define('user', {
-      mood: DataTypes.ENUM({ values: ['happy', 'sad'], enumName: 'mood_type' }),
+      mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
     });
 
     const CustomEnumSchemaUser = sequelize.define(
@@ -38,18 +38,18 @@ describe('PostgresQueryGenerator', () => {
       {
         mood: DataTypes.ENUM({
           values: ['happy', 'sad'],
-          enumName: 'mood_type',
-          enumSchema: 'shared',
+          name: 'mood_type',
+          schema: 'shared',
         }),
       },
       { schema: 'foo' },
     );
 
-    // enumSchema only (no enumName) — uses auto-generated name but with custom schema
+    // schema only (no name) — uses auto-generated name but with custom schema
     const EnumSchemaOnlyUser = sequelize.define(
       'user',
       {
-        mood: DataTypes.ENUM({ values: ['happy', 'sad'], enumSchema: 'shared' }),
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], schema: 'shared' }),
       },
       { schema: 'foo' },
     );

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -162,7 +162,7 @@ describe('PostgresQueryGenerator', () => {
         }),
         {
           postgres:
-            "ALTER TYPE \"public\".\"mood_type\" ADD VALUE IF NOT EXISTS 'neutral' AFTER 'happy'",
+            'ALTER TYPE "public"."mood_type" ADD VALUE IF NOT EXISTS \'neutral\' AFTER \'happy\'',
         },
       );
     });
@@ -178,7 +178,7 @@ describe('PostgresQueryGenerator', () => {
         }),
         {
           postgres:
-            "ALTER TYPE \"shared\".\"mood_type\" ADD VALUE IF NOT EXISTS 'neutral' AFTER 'happy'",
+            'ALTER TYPE "shared"."mood_type" ADD VALUE IF NOT EXISTS \'neutral\' AFTER \'happy\'',
         },
       );
     });
@@ -228,18 +228,15 @@ describe('PostgresQueryGenerator', () => {
     it('uses custom enumName for type filter', () => {
       const { FooUser } = vars;
 
-      expectsql(
-        queryGenerator.pgListEnums(FooUser.table, 'mood', { enumName: 'mood_type' }),
-        {
-          postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+      expectsql(queryGenerator.pgListEnums(FooUser.table, 'mood', { enumName: 'mood_type' }), {
+        postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
                    FROM pg_type t
                           JOIN pg_enum e ON t.oid = e.enumtypid
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
                    WHERE n.nspname = 'foo'
                      AND t.typname='mood_type'
                    GROUP BY 1`,
-        },
-      );
+      });
     });
 
     it('uses enumSchema for schema filter', () => {

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -215,6 +215,42 @@ describe('PostgresQueryGenerator', () => {
     });
   });
 
+  describe('addColumnQuery', () => {
+    it('prepends pgEnum with custom name', () => {
+      const sq = createSequelizeInstance();
+      const User = sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
+      });
+      const result = sq.dialect.queryGenerator.addColumnQuery(
+        User.table,
+        'mood',
+        User.getAttributes().mood,
+      );
+      // pgEnum CREATE TYPE statement should use the custom name
+      expect(result).to.include('CREATE TYPE "public"."mood_type"');
+      // ADD COLUMN should reference the custom type name
+      expect(result).to.match(/"mood" "public"\."mood_type"/);
+    });
+
+    it('prepends pgEnum with custom name and schema for ARRAY(ENUM)', () => {
+      const sq = createSequelizeInstance();
+      const User = sq.define('user', {
+        moods: DataTypes.ARRAY(
+          DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'shared' }),
+        ),
+      });
+      const result = sq.dialect.queryGenerator.addColumnQuery(
+        User.table,
+        'moods',
+        User.getAttributes().moods,
+      );
+      // pgEnum CREATE TYPE statement should use the custom name in the custom schema
+      expect(result).to.include('CREATE TYPE "shared"."mood_type"');
+      // ADD COLUMN should reference the custom type as an array
+      expect(result).to.match(/"moods" "shared"\."mood_type"\[\]/);
+    });
+  });
+
   describe('pgEnumAdd', () => {
     it('creates alter type with exists', () => {
       const { PublicUser } = vars;
@@ -435,6 +471,36 @@ describe('PostgresQueryGenerator', () => {
       const drops = getDropTypeSqls(stub);
       expect(drops).to.have.length(1);
       expect(drops[0]).to.equal('DROP TYPE IF EXISTS "public"."mood_type"; ');
+    });
+
+    it('drops a named enum from an ARRAY(ENUM) column when used only by the dropped model', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', {
+        moods: DataTypes.ARRAY(DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' })),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(1);
+      expect(drops[0]).to.equal('DROP TYPE IF EXISTS "public"."mood_type"; ');
+    });
+
+    it('does not drop a named enum from an ARRAY(ENUM) column when shared with another model', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', {
+        moods: DataTypes.ARRAY(DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' })),
+      });
+      sq.define('profile', {
+        moods: DataTypes.ARRAY(DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' })),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(0);
     });
 
     it('drops a named enum when another model uses the same name in a different schema', async () => {

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -559,6 +559,25 @@ describe('PostgresQueryGenerator', () => {
       expect(drops).to.have.length(0);
     });
 
+    it('treats undefined schema and explicit "public" as the same when checking sharing', async () => {
+      const sq = createSequelizeInstance();
+      // user: schema undefined on enum (resolves to default 'public')
+      sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
+      });
+      // profile: schema explicitly 'public' on enum
+      sq.define('profile', {
+        feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'public' }),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      // The enums are in the same effective schema ('public'), so it should NOT be dropped
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(0);
+    });
+
     it('drops a named enum when another model uses the same name in a different schema', async () => {
       const sq = createSequelizeInstance();
       sq.define('user', {

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -131,13 +131,13 @@ describe('PostgresQueryGenerator', () => {
 
     it('uses custom enumName', () => {
       const { CustomEnumUser } = vars;
+      const type = CustomEnumUser.getAttributes().mood.type;
 
       expectsql(
-        queryGenerator.pgEnum(
-          CustomEnumUser.table,
-          'mood',
-          CustomEnumUser.getAttributes().mood.type,
-        ),
+        queryGenerator.pgEnum(CustomEnumUser.table, 'mood', type, {
+          enumName: type.options.name,
+          enumSchema: type.options.schema,
+        }),
         {
           postgres: `DO 'BEGIN CREATE TYPE "public"."mood_type" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
         },
@@ -146,13 +146,13 @@ describe('PostgresQueryGenerator', () => {
 
     it('uses custom enumName and enumSchema', () => {
       const { CustomEnumSchemaUser } = vars;
+      const type = CustomEnumSchemaUser.getAttributes().mood.type;
 
       expectsql(
-        queryGenerator.pgEnum(
-          CustomEnumSchemaUser.table,
-          'mood',
-          CustomEnumSchemaUser.getAttributes().mood.type,
-        ),
+        queryGenerator.pgEnum(CustomEnumSchemaUser.table, 'mood', type, {
+          enumName: type.options.name,
+          enumSchema: type.options.schema,
+        }),
         {
           postgres: `DO 'BEGIN CREATE TYPE "shared"."mood_type" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
         },
@@ -161,13 +161,13 @@ describe('PostgresQueryGenerator', () => {
 
     it('uses enumSchema with auto-generated name when only enumSchema is provided', () => {
       const { EnumSchemaOnlyUser } = vars;
+      const type = EnumSchemaOnlyUser.getAttributes().mood.type;
 
       expectsql(
-        queryGenerator.pgEnum(
-          EnumSchemaOnlyUser.table,
-          'mood',
-          EnumSchemaOnlyUser.getAttributes().mood.type,
-        ),
+        queryGenerator.pgEnum(EnumSchemaOnlyUser.table, 'mood', type, {
+          enumName: type.options.name,
+          enumSchema: type.options.schema,
+        }),
         {
           postgres: `DO 'BEGIN CREATE TYPE "shared"."enum_users_mood" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
         },
@@ -176,14 +176,14 @@ describe('PostgresQueryGenerator', () => {
 
     it('drops the correct type name when force: true with a custom name', () => {
       const { CustomEnumSchemaUser } = vars;
+      const type = CustomEnumSchemaUser.getAttributes().mood.type;
 
       expectsql(
-        queryGenerator.pgEnum(
-          CustomEnumSchemaUser.table,
-          'mood',
-          CustomEnumSchemaUser.getAttributes().mood.type,
-          { force: true },
-        ),
+        queryGenerator.pgEnum(CustomEnumSchemaUser.table, 'mood', type, {
+          enumName: type.options.name,
+          enumSchema: type.options.schema,
+          force: true,
+        }),
         {
           postgres: `DROP TYPE IF EXISTS "shared"."mood_type"; DO 'BEGIN CREATE TYPE "shared"."mood_type" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
         },

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const { beforeAll2, expectsql, sequelize } = require('../../../support');
+const { beforeAll2, createSequelizeInstance, expectsql, sequelize } = require('../../../support');
 const { DataTypes } = require('@sequelize/core');
 const { expect } = require('chai');
+const sinon = require('sinon');
 
 const queryGenerator = sequelize.dialect.queryGenerator;
 
@@ -329,6 +330,128 @@ describe('PostgresQueryGenerator', () => {
                    GROUP BY 1`,
         },
       );
+    });
+  });
+
+  // Helper: collect the SQL strings passed to queryRaw that contain DROP TYPE
+  function getDropTypeSqls(stub) {
+    return stub.args.map(([sql]) => sql).filter(sql => sql.includes('DROP TYPE'));
+  }
+
+  describe('dropTable (enum cleanup)', () => {
+    let stub;
+
+    afterEach(() => {
+      stub?.restore();
+    });
+
+    it('drops an unnamed enum with the auto-generated name', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', { mood: DataTypes.ENUM('happy', 'sad') });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(1);
+      expect(drops[0]).to.equal('DROP TYPE IF EXISTS "public"."enum_users_mood"; ');
+    });
+
+    it('drops a named enum when used only by the dropped model', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(1);
+      expect(drops[0]).to.equal('DROP TYPE IF EXISTS "public"."mood_type"; ');
+    });
+
+    it('drops a named enum with a custom schema when used only by the dropped model', async () => {
+      const sq = createSequelizeInstance();
+      sq.define(
+        'user',
+        { mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'shared' }) },
+        { schema: 'foo' },
+      );
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable({ tableName: 'users', schema: 'foo' });
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(1);
+      expect(drops[0]).to.equal('DROP TYPE IF EXISTS "shared"."mood_type"; ');
+    });
+
+    it('does not drop a named enum that is shared with another model', async () => {
+      const sq = createSequelizeInstance();
+      const sharedEnum = DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' });
+      sq.define('user', { mood: sharedEnum });
+      sq.define('profile', { feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }) });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(0);
+    });
+
+    it('does not drop a named enum shared across schemas when schemas match', async () => {
+      const sq = createSequelizeInstance();
+      sq.define(
+        'user',
+        { mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'shared' }) },
+        { schema: 'foo' },
+      );
+      sq.define(
+        'profile',
+        { feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'shared' }) },
+        { schema: 'bar' },
+      );
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable({ tableName: 'users', schema: 'foo' });
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(0);
+    });
+
+    it('drops a named enum when another model uses a different name', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
+      });
+      sq.define('profile', {
+        feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'feeling_type' }),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(1);
+      expect(drops[0]).to.equal('DROP TYPE IF EXISTS "public"."mood_type"; ');
+    });
+
+    it('drops a named enum when another model uses the same name in a different schema', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'schema_a' }),
+      });
+      sq.define('profile', {
+        feeling: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type', schema: 'schema_b' }),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.dropTable('users');
+
+      const drops = getDropTypeSqls(stub);
+      expect(drops).to.have.length(1);
+      expect(drops[0]).to.equal('DROP TYPE IF EXISTS "schema_a"."mood_type"; ');
     });
   });
 });

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -29,7 +29,23 @@ describe('PostgresQueryGenerator', () => {
       },
     });
 
-    return { FooUser, PublicUser };
+    const CustomEnumUser = sequelize.define('user', {
+      mood: DataTypes.ENUM({ values: ['happy', 'sad'], enumName: 'mood_type' }),
+    });
+
+    const CustomEnumSchemaUser = sequelize.define(
+      'user',
+      {
+        mood: DataTypes.ENUM({
+          values: ['happy', 'sad'],
+          enumName: 'mood_type',
+          enumSchema: 'shared',
+        }),
+      },
+      { schema: 'foo' },
+    );
+
+    return { FooUser, PublicUser, CustomEnumUser, CustomEnumSchemaUser };
   });
 
   describe('pgEnumName', () => {
@@ -54,6 +70,25 @@ describe('PostgresQueryGenerator', () => {
         queryGenerator.pgEnumName(FooUser.table, 'theirMood', FooUser.getAttributes().mood.type),
       ).to.equal('"foo"."enum_users_theirMood"');
     });
+
+    it('uses enumName when provided', () => {
+      const { PublicUser } = vars;
+
+      expect(
+        queryGenerator.pgEnumName(PublicUser.table, 'mood', { enumName: 'mood_type' }),
+      ).to.equal('"public"."mood_type"');
+    });
+
+    it('uses enumSchema when provided', () => {
+      const { PublicUser } = vars;
+
+      expect(
+        queryGenerator.pgEnumName(PublicUser.table, 'mood', {
+          enumName: 'mood_type',
+          enumSchema: 'shared',
+        }),
+      ).to.equal('"shared"."mood_type"');
+    });
   });
 
   describe('pgEnum', () => {
@@ -75,6 +110,36 @@ describe('PostgresQueryGenerator', () => {
         },
       );
     });
+
+    it('uses custom enumName', () => {
+      const { CustomEnumUser } = vars;
+
+      expectsql(
+        queryGenerator.pgEnum(
+          CustomEnumUser.table,
+          'mood',
+          CustomEnumUser.getAttributes().mood.type,
+        ),
+        {
+          postgres: `DO 'BEGIN CREATE TYPE "public"."mood_type" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
+        },
+      );
+    });
+
+    it('uses custom enumName and enumSchema', () => {
+      const { CustomEnumSchemaUser } = vars;
+
+      expectsql(
+        queryGenerator.pgEnum(
+          CustomEnumSchemaUser.table,
+          'mood',
+          CustomEnumSchemaUser.getAttributes().mood.type,
+        ),
+        {
+          postgres: `DO 'BEGIN CREATE TYPE "shared"."mood_type" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
+        },
+      );
+    });
   });
 
   describe('pgEnumAdd', () => {
@@ -85,6 +150,37 @@ describe('PostgresQueryGenerator', () => {
         postgres:
           'ALTER TYPE "public"."enum_users_mood" ADD VALUE IF NOT EXISTS \'neutral\' AFTER \'happy\'',
       });
+    });
+
+    it('uses custom enumName', () => {
+      const { PublicUser } = vars;
+
+      expectsql(
+        queryGenerator.pgEnumAdd(PublicUser.table, 'mood', 'neutral', {
+          after: 'happy',
+          enumName: 'mood_type',
+        }),
+        {
+          postgres:
+            "ALTER TYPE \"public\".\"mood_type\" ADD VALUE IF NOT EXISTS 'neutral' AFTER 'happy'",
+        },
+      );
+    });
+
+    it('uses custom enumName and enumSchema', () => {
+      const { PublicUser } = vars;
+
+      expectsql(
+        queryGenerator.pgEnumAdd(PublicUser.table, 'mood', 'neutral', {
+          after: 'happy',
+          enumName: 'mood_type',
+          enumSchema: 'shared',
+        }),
+        {
+          postgres:
+            "ALTER TYPE \"shared\".\"mood_type\" ADD VALUE IF NOT EXISTS 'neutral' AFTER 'happy'",
+        },
+      );
     });
   });
 
@@ -124,6 +220,43 @@ describe('PostgresQueryGenerator', () => {
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
                    WHERE n.nspname = 'sche''"ma'
                      AND t.typname='enum_ta''"ble_attri''"bute'
+                   GROUP BY 1`,
+        },
+      );
+    });
+
+    it('uses custom enumName for type filter', () => {
+      const { FooUser } = vars;
+
+      expectsql(
+        queryGenerator.pgListEnums(FooUser.table, 'mood', { enumName: 'mood_type' }),
+        {
+          postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+                   FROM pg_type t
+                          JOIN pg_enum e ON t.oid = e.enumtypid
+                          JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+                   WHERE n.nspname = 'foo'
+                     AND t.typname='mood_type'
+                   GROUP BY 1`,
+        },
+      );
+    });
+
+    it('uses enumSchema for schema filter', () => {
+      const { FooUser } = vars;
+
+      expectsql(
+        queryGenerator.pgListEnums(FooUser.table, 'mood', {
+          enumName: 'mood_type',
+          enumSchema: 'shared',
+        }),
+        {
+          postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+                   FROM pg_type t
+                          JOIN pg_enum e ON t.oid = e.enumtypid
+                          JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+                   WHERE n.nspname = 'shared'
+                     AND t.typname='mood_type'
                    GROUP BY 1`,
         },
       );

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -297,6 +297,21 @@ describe('PostgresQueryGenerator', () => {
       const result = qg.changeColumnQuery(User.table, attrs);
       expect(result).to.include('USING ("mood"::"shared"."mood_type")');
     });
+
+    it('adds USING cast for schema-only ENUM (no custom name, custom schema)', () => {
+      const sq = createSequelizeInstance();
+      const User = sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], schema: 'shared' }),
+      });
+      const qg = sq.dialect.queryGenerator;
+      const attrs = qg.attributesToSQL(
+        { mood: User.modelDefinition.attributes.get('mood') },
+        { context: 'changeColumn', table: User.table },
+      );
+      const result = qg.changeColumnQuery(User.table, attrs);
+      // auto-generated name in the custom schema
+      expect(result).to.include('USING ("mood"::"shared"."enum_users_mood")');
+    });
   });
 
   describe('pgEnumAdd', () => {
@@ -421,6 +436,67 @@ describe('PostgresQueryGenerator', () => {
   function getDropTypeSqls(stub) {
     return stub.args.map(([sql]) => sql).filter(sql => sql.includes('DROP TYPE'));
   }
+
+  // Helper: collect the SQL strings passed to queryRaw that contain CREATE TYPE
+  function getCreateTypeSqls(stub) {
+    return stub.args.map(([sql]) => sql).filter(sql => sql?.includes('CREATE TYPE'));
+  }
+
+  describe('changeColumn (enum pre-create)', () => {
+    let stub;
+
+    afterEach(() => {
+      stub?.restore();
+    });
+
+    it('pre-creates the enum type before ALTER TABLE for a custom-named ENUM', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], name: 'mood_type' }),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.changeColumn('users', 'mood', {
+        type: DataTypes.ENUM({ values: ['happy', 'sad', 'neutral'], name: 'mood_type' }),
+      });
+
+      const creates = getCreateTypeSqls(stub);
+      expect(creates).to.have.length(1);
+      expect(creates[0]).to.include('"public"."mood_type"');
+    });
+
+    it('pre-creates the enum type before ALTER TABLE for a schema-only ENUM (no custom name)', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], schema: 'shared' }),
+      });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.changeColumn('users', 'mood', {
+        type: DataTypes.ENUM({ values: ['happy', 'sad', 'neutral'], schema: 'shared' }),
+      });
+
+      const creates = getCreateTypeSqls(stub);
+      expect(creates).to.have.length(1);
+      expect(creates[0]).to.include('"shared"."enum_users_mood"');
+    });
+
+    it('does not make a separate pre-create call for a plain auto-named ENUM', async () => {
+      const sq = createSequelizeInstance();
+      sq.define('user', { mood: DataTypes.ENUM('happy', 'sad') });
+      stub = sinon.stub(sq, 'queryRaw').resolves([[], 0]);
+
+      await sq.queryInterface.changeColumn('users', 'mood', {
+        type: DataTypes.ENUM('happy', 'sad', 'neutral'),
+      });
+
+      // For auto-named ENUMs the CREATE TYPE is embedded in the ALTER TABLE statement
+      // by changeColumnQuery — there is no separate pre-create queryRaw call.
+      expect(stub.callCount).to.equal(1);
+      expect(stub.firstCall.args[0]).to.include('CREATE TYPE');
+      expect(stub.firstCall.args[0]).to.include('ALTER TABLE');
+    });
+  });
 
   describe('dropTable (enum cleanup)', () => {
     let stub;

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -45,7 +45,16 @@ describe('PostgresQueryGenerator', () => {
       { schema: 'foo' },
     );
 
-    return { FooUser, PublicUser, CustomEnumUser, CustomEnumSchemaUser };
+    // enumSchema only (no enumName) — uses auto-generated name but with custom schema
+    const EnumSchemaOnlyUser = sequelize.define(
+      'user',
+      {
+        mood: DataTypes.ENUM({ values: ['happy', 'sad'], enumSchema: 'shared' }),
+      },
+      { schema: 'foo' },
+    );
+
+    return { FooUser, PublicUser, CustomEnumUser, CustomEnumSchemaUser, EnumSchemaOnlyUser };
   });
 
   describe('pgEnumName', () => {
@@ -88,6 +97,14 @@ describe('PostgresQueryGenerator', () => {
           enumSchema: 'shared',
         }),
       ).to.equal('"shared"."mood_type"');
+    });
+
+    it('uses enumSchema with auto-generated name when only enumSchema is provided', () => {
+      const { PublicUser } = vars;
+
+      expect(
+        queryGenerator.pgEnumName(PublicUser.table, 'mood', { enumSchema: 'shared' }),
+      ).to.equal('"shared"."enum_users_mood"');
     });
   });
 
@@ -139,6 +156,45 @@ describe('PostgresQueryGenerator', () => {
           postgres: `DO 'BEGIN CREATE TYPE "shared"."mood_type" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
         },
       );
+    });
+
+    it('uses enumSchema with auto-generated name when only enumSchema is provided', () => {
+      const { EnumSchemaOnlyUser } = vars;
+
+      expectsql(
+        queryGenerator.pgEnum(
+          EnumSchemaOnlyUser.table,
+          'mood',
+          EnumSchemaOnlyUser.getAttributes().mood.type,
+        ),
+        {
+          postgres: `DO 'BEGIN CREATE TYPE "shared"."enum_users_mood" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
+        },
+      );
+    });
+  });
+
+  describe('attributeToSQL (ENUM column type reference in CREATE TABLE)', () => {
+    it('uses enumSchema with auto-generated name when only enumSchema is provided', () => {
+      const { EnumSchemaOnlyUser } = vars;
+      const moodAttr = EnumSchemaOnlyUser.modelDefinition.attributes.get('mood');
+
+      const result = queryGenerator.attributeToSQL(
+        { type: moodAttr.type },
+        { table: EnumSchemaOnlyUser.table, key: 'mood' },
+      );
+      expect(result).to.equal('"shared"."enum_users_mood"');
+    });
+
+    it('uses custom enumName and enumSchema for column type reference', () => {
+      const { CustomEnumSchemaUser } = vars;
+      const moodAttr = CustomEnumSchemaUser.modelDefinition.attributes.get('mood');
+
+      const result = queryGenerator.attributeToSQL(
+        { type: moodAttr.type },
+        { table: CustomEnumSchemaUser.table, key: 'mood' },
+      );
+      expect(result).to.equal('"shared"."mood_type"');
     });
   });
 

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -172,6 +172,22 @@ describe('PostgresQueryGenerator', () => {
         },
       );
     });
+
+    it('drops the correct type name when force: true with a custom name', () => {
+      const { CustomEnumSchemaUser } = vars;
+
+      expectsql(
+        queryGenerator.pgEnum(
+          CustomEnumSchemaUser.table,
+          'mood',
+          CustomEnumSchemaUser.getAttributes().mood.type,
+          { force: true },
+        ),
+        {
+          postgres: `DROP TYPE IF EXISTS "shared"."mood_type"; DO 'BEGIN CREATE TYPE "shared"."mood_type" AS ENUM(''happy'', ''sad''); EXCEPTION WHEN duplicate_object THEN null; END';`,
+        },
+      );
+    });
   });
 
   describe('attributeToSQL (ENUM column type reference in CREATE TABLE)', () => {

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -434,7 +434,7 @@ describe('PostgresQueryGenerator', () => {
 
   // Helper: collect the SQL strings passed to queryRaw that contain DROP TYPE
   function getDropTypeSqls(stub) {
-    return stub.args.map(([sql]) => sql).filter(sql => sql.includes('DROP TYPE'));
+    return stub.args.map(([sql]) => sql).filter(sql => sql?.includes('DROP TYPE'));
   }
 
   // Helper: collect the SQL strings passed to queryRaw that contain CREATE TYPE

--- a/packages/postgres/src/_internal/data-types-overrides.ts
+++ b/packages/postgres/src/_internal/data-types-overrides.ts
@@ -435,8 +435,8 @@ export class ENUM<Members extends string> extends BaseTypes.ENUM<Members> {
     );
 
     return queryGenerator.pgEnumName(tableName, columnName, {
-      ...(this.options.enumName !== undefined && { enumName: this.options.enumName }),
-      ...(this.options.enumSchema !== undefined && { enumSchema: this.options.enumSchema }),
+      ...(this.options.name !== undefined && { enumName: this.options.name }),
+      ...(this.options.schema !== undefined && { enumSchema: this.options.schema }),
     });
   }
 }

--- a/packages/postgres/src/_internal/data-types-overrides.ts
+++ b/packages/postgres/src/_internal/data-types-overrides.ts
@@ -434,6 +434,9 @@ export class ENUM<Members extends string> extends BaseTypes.ENUM<Members> {
       'expected queryGenerator to be PostgresQueryGenerator',
     );
 
-    return queryGenerator.pgEnumName(tableName, columnName);
+    return queryGenerator.pgEnumName(tableName, columnName, {
+      ...(this.options.enumName !== undefined && { enumName: this.options.enumName }),
+      ...(this.options.enumSchema !== undefined && { enumSchema: this.options.enumSchema }),
+    });
   }
 }

--- a/packages/postgres/src/_internal/data-types-overrides.ts
+++ b/packages/postgres/src/_internal/data-types-overrides.ts
@@ -435,8 +435,8 @@ export class ENUM<Members extends string> extends BaseTypes.ENUM<Members> {
     );
 
     return queryGenerator.pgEnumName(tableName, columnName, {
-      ...(this.options.name !== undefined && { enumName: this.options.name }),
-      ...(this.options.schema !== undefined && { enumSchema: this.options.schema }),
+      enumName: this.options.name,
+      enumSchema: this.options.schema,
     });
   }
 }

--- a/packages/postgres/src/query-generator.d.ts
+++ b/packages/postgres/src/query-generator.d.ts
@@ -4,9 +4,9 @@ import { PostgresQueryGeneratorTypeScript } from './query-generator-typescript.i
 type PgEnumNameOptions = {
   schema?: boolean;
   /** Override the auto-generated enum type name. */
-  enumName?: string;
+  enumName?: string | undefined;
   /** Override the schema used for the enum type name prefix. */
-  enumSchema?: string;
+  enumSchema?: string | undefined;
 };
 
 export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {

--- a/packages/postgres/src/query-generator.d.ts
+++ b/packages/postgres/src/query-generator.d.ts
@@ -3,6 +3,10 @@ import { PostgresQueryGeneratorTypeScript } from './query-generator-typescript.i
 
 type PgEnumNameOptions = {
   schema?: boolean;
+  /** Override the auto-generated enum type name. */
+  enumName?: string;
+  /** Override the schema used for the enum type name prefix. */
+  enumSchema?: string;
 };
 
 export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -579,7 +579,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
 
     let sql = `DO ${this.escape(`BEGIN CREATE TYPE ${enumName} AS ${values}; EXCEPTION WHEN duplicate_object THEN null; END`)};`;
     if (Boolean(options) && options.force === true) {
-      sql = this.pgEnumDrop(tableName, attr) + sql;
+      sql = this.pgEnumDrop(null, null, enumName) + sql;
     }
 
     return sql;

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -534,8 +534,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     }
 
     // enumSchema overrides the table's schema when looking up the enum type
-    const schema =
-      options?.enumSchema !== undefined ? options.enumSchema : tableDetails.schema;
+    const schema = options?.enumSchema !== undefined ? options.enumSchema : tableDetails.schema;
 
     return (
       'SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t ' +
@@ -548,7 +547,8 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   pgEnum(tableName, attr, dataType, options) {
     // Merge enumName/enumSchema from the DataType's options (lower priority than explicit options)
     const mergedOptions =
-      dataType instanceof ENUM && (dataType.options.enumName || dataType.options.enumSchema !== undefined)
+      dataType instanceof ENUM &&
+      (dataType.options.enumName || dataType.options.enumSchema !== undefined)
         ? {
             ...(dataType.options.enumName !== undefined && { enumName: dataType.options.enumName }),
             ...(dataType.options.enumSchema !== undefined && {

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -573,7 +573,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     }
 
     let sql = `DO ${this.escape(`BEGIN CREATE TYPE ${enumName} AS ${values}; EXCEPTION WHEN duplicate_object THEN null; END`)};`;
-    if (Boolean(options) && options.force === true) {
+    if (options?.force === true) {
       sql = this.pgEnumDrop(null, null, enumName) + sql;
     }
 

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -231,7 +231,22 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       const enumType = arraySubtype || attribute.type;
       const values = enumType.options.values;
 
-      if (Array.isArray(values) && values.length > 0) {
+      if (enumType.options.enumName || enumType.options.enumSchema !== undefined) {
+        // When a custom enum name or schema is set, generate the final qualified type reference here
+        // so that dataTypeMapping does not lose the custom name/schema when it later
+        // replaces the ENUM(...) placeholder.
+        const tableName = options?.table;
+        const columnName = attribute.field || options?.key;
+        type = this.pgEnumName(tableName, columnName, {
+          enumName: enumType.options.enumName,
+          ...(enumType.options.enumSchema !== undefined && {
+            enumSchema: enumType.options.enumSchema,
+          }),
+        });
+        if (attribute.type instanceof DataTypes.ARRAY) {
+          type += '[]';
+        }
+      } else if (Array.isArray(values) && values.length > 0) {
         type = `ENUM(${values.map(value => this.escape(value)).join(', ')})`;
 
         if (attribute.type instanceof DataTypes.ARRAY) {

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -231,17 +231,15 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       const enumType = arraySubtype || attribute.type;
       const values = enumType.options.values;
 
-      if (enumType.options.enumName || enumType.options.enumSchema !== undefined) {
+      if (enumType.options.name || enumType.options.schema !== undefined) {
         // When a custom enum name or schema is set, generate the final qualified type reference here
         // so that dataTypeMapping does not lose the custom name/schema when it later
         // replaces the ENUM(...) placeholder.
         const tableName = options?.table;
         const columnName = attribute.field || options?.key;
         type = this.pgEnumName(tableName, columnName, {
-          enumName: enumType.options.enumName,
-          ...(enumType.options.enumSchema !== undefined && {
-            enumSchema: enumType.options.enumSchema,
-          }),
+          ...(enumType.options.name !== undefined && { enumName: enumType.options.name }),
+          ...(enumType.options.schema !== undefined && { enumSchema: enumType.options.schema }),
         });
         if (attribute.type instanceof DataTypes.ARRAY) {
           type += '[]';
@@ -563,12 +561,10 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     // Merge enumName/enumSchema from the DataType's options (lower priority than explicit options)
     const mergedOptions =
       dataType instanceof ENUM &&
-      (dataType.options.enumName || dataType.options.enumSchema !== undefined)
+      (dataType.options.name || dataType.options.schema !== undefined)
         ? {
-            ...(dataType.options.enumName !== undefined && { enumName: dataType.options.enumName }),
-            ...(dataType.options.enumSchema !== undefined && {
-              enumSchema: dataType.options.enumSchema,
-            }),
+            ...(dataType.options.name !== undefined && { enumName: dataType.options.name }),
+            ...(dataType.options.schema !== undefined && { enumSchema: dataType.options.schema }),
             ...options,
           }
         : options;

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -124,13 +124,21 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${ifNotExists} ${quotedKey} ${definition};`;
 
     if (dataType instanceof DataTypes.ENUM) {
-      query = this.pgEnum(table, key, dataType, { enumName: dataType.options.name, enumSchema: dataType.options.schema }) + query;
+      query =
+        this.pgEnum(table, key, dataType, {
+          enumName: dataType.options.name,
+          enumSchema: dataType.options.schema,
+        }) + query;
     } else if (
       dataType instanceof DataTypes.ARRAY &&
       dataType.options.type instanceof DataTypes.ENUM
     ) {
       const innerEnum = dataType.options.type;
-      query = this.pgEnum(table, key, innerEnum, { enumName: innerEnum.options.name, enumSchema: innerEnum.options.schema }) + query;
+      query =
+        this.pgEnum(table, key, innerEnum, {
+          enumName: innerEnum.options.name,
+          enumSchema: innerEnum.options.schema,
+        }) + query;
     }
 
     return query;

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -505,15 +505,17 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   pgEnumName(tableName, columnName, options = {}) {
     const tableDetails = this.extractTableDetails(tableName, options);
 
-    const enumName = `enum_${tableDetails.tableName}_${columnName}`;
+    const rawEnumName = options.enumName ?? `enum_${tableDetails.tableName}_${columnName}`;
     if (options.noEscape) {
-      return enumName;
+      return rawEnumName;
     }
 
-    const escapedEnumName = this.quoteIdentifier(enumName);
+    const escapedEnumName = this.quoteIdentifier(rawEnumName);
 
-    if (options.schema !== false && tableDetails.schema) {
-      return this.quoteIdentifier(tableDetails.schema) + tableDetails.delimiter + escapedEnumName;
+    // enumSchema overrides the table's schema for the enum type name prefix
+    const schema = 'enumSchema' in options ? options.enumSchema : tableDetails.schema;
+    if (options.schema !== false && schema) {
+      return this.quoteIdentifier(schema) + tableDetails.delimiter + escapedEnumName;
     }
 
     return escapedEnumName;
@@ -528,19 +530,34 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
 
     if (tableDetails.tableName && attrName) {
       // pgEnumName escapes as an identifier, we want to escape it as a string
-      enumName = ` AND t.typname=${this.escape(this.pgEnumName(tableDetails.tableName, attrName, { noEscape: true }))}`;
+      enumName = ` AND t.typname=${this.escape(this.pgEnumName(tableDetails.tableName, attrName, { noEscape: true, enumName: options?.enumName }))}`;
     }
+
+    // enumSchema overrides the table's schema when looking up the enum type
+    const schema =
+      options?.enumSchema !== undefined ? options.enumSchema : tableDetails.schema;
 
     return (
       'SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t ' +
       'JOIN pg_enum e ON t.oid = e.enumtypid ' +
       'JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace ' +
-      `WHERE n.nspname = ${this.escape(tableDetails.schema)}${enumName} GROUP BY 1`
+      `WHERE n.nspname = ${this.escape(schema)}${enumName} GROUP BY 1`
     );
   }
 
   pgEnum(tableName, attr, dataType, options) {
-    const enumName = this.pgEnumName(tableName, attr, options);
+    // Merge enumName/enumSchema from the DataType's options (lower priority than explicit options)
+    const mergedOptions =
+      dataType instanceof ENUM && (dataType.options.enumName || dataType.options.enumSchema !== undefined)
+        ? {
+            ...(dataType.options.enumName !== undefined && { enumName: dataType.options.enumName }),
+            ...(dataType.options.enumSchema !== undefined && {
+              enumSchema: dataType.options.enumSchema,
+            }),
+            ...options,
+          }
+        : options;
+    const enumName = this.pgEnumName(tableName, attr, mergedOptions);
     let values;
 
     if (dataType instanceof ENUM && dataType.options.values) {
@@ -558,7 +575,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   }
 
   pgEnumAdd(tableName, attr, value, options) {
-    const enumName = this.pgEnumName(tableName, attr);
+    const enumName = this.pgEnumName(tableName, attr, options);
     let sql = `ALTER TYPE ${enumName} ADD VALUE IF NOT EXISTS `;
 
     sql += this.escape(value);

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -167,6 +167,10 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
           this.pgEnumName(tableName, attributeName, { schema: false }),
         );
         definition += ` USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(tableName, attributeName)})`;
+        // TODO: custom-named ENUMs (DataTypes.ENUM({ name: '...' })) produce a qualified
+        // identifier here rather than ENUM(...), so the USING cast is never added for them.
+        // Fixing this properly requires changeColumnQuery to receive DataType objects rather
+        // than pre-processed strings.
       }
 
       if (/UNIQUE;*$/.test(definition)) {

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -176,10 +176,10 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
           this.pgEnumName(tableName, attributeName, { schema: false }),
         );
         definition += ` USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(tableName, attributeName)})`;
-        // TODO: custom-named ENUMs (DataTypes.ENUM({ name: '...' })) produce a qualified
-        // identifier here rather than ENUM(...), so the USING cast is never added for them.
-        // Fixing this properly requires changeColumnQuery to receive DataType objects rather
-        // than pre-processed strings.
+      } else if (attributes[attributeName].startsWith('ENUM_NAMED(')) {
+        // Custom-named ENUM: the type is managed externally; the type name is already in
+        // `definition` (ENUM_NAMED wrapper stripped by dataTypeMapping). Just add USING cast.
+        definition += ` USING (${this.quoteIdentifier(attributeName)}::${definition.trim()})`;
       }
 
       if (/UNIQUE;*$/.test(definition)) {
@@ -245,17 +245,19 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       const values = enumType.options.values;
 
       if (enumType.options.name || enumType.options.schema !== undefined) {
-        // When a custom enum name or schema is set, generate the final qualified type reference here
-        // so that dataTypeMapping does not lose the custom name/schema when it later
-        // replaces the ENUM(...) placeholder.
         const tableName = options?.table;
         const columnName = attribute.field || options?.key;
-        type = this.pgEnumName(tableName, columnName, {
+        const qualifiedName = this.pgEnumName(tableName, columnName, {
           enumName: enumType.options.name,
           enumSchema: enumType.options.schema,
         });
         if (attribute.type instanceof DataTypes.ARRAY) {
-          type += '[]';
+          // Arrays don't need a USING cast in changeColumnQuery, emit the type directly.
+          type = `${qualifiedName}[]`;
+        } else {
+          // Wrap in a sentinel so changeColumnQuery can detect this is an ENUM type and add
+          // the required USING cast. dataTypeMapping strips the wrapper before emitting SQL.
+          type = `ENUM_NAMED(${qualifiedName})`;
         }
       } else if (Array.isArray(values) && values.length > 0) {
         type = `ENUM(${values.map(value => this.escape(value)).join(', ')})`;
@@ -650,7 +652,11 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       dataType = dataType.replace('NOT NULL', '');
     }
 
-    if (dataType.startsWith('ENUM(')) {
+    if (dataType.startsWith('ENUM_NAMED(')) {
+      // Strip the sentinel added by attributeToSQL for custom-named ENUMs,
+      // leaving just the qualified type identifier.
+      dataType = dataType.replace(/^ENUM_NAMED\((.+)\)/, '$1');
+    } else if (dataType.startsWith('ENUM(')) {
       dataType = dataType.replace(/^ENUM\(.+\)/, this.pgEnumName(tableName, attr));
     }
 

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -124,12 +124,13 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${ifNotExists} ${quotedKey} ${definition};`;
 
     if (dataType instanceof DataTypes.ENUM) {
-      query = this.pgEnum(table, key, dataType) + query;
+      query = this.pgEnum(table, key, dataType, { enumName: dataType.options.name, enumSchema: dataType.options.schema }) + query;
     } else if (
       dataType instanceof DataTypes.ARRAY &&
       dataType.options.type instanceof DataTypes.ENUM
     ) {
-      query = this.pgEnum(table, key, dataType.options.type) + query;
+      const innerEnum = dataType.options.type;
+      query = this.pgEnum(table, key, innerEnum, { enumName: innerEnum.options.name, enumSchema: innerEnum.options.schema }) + query;
     }
 
     return query;
@@ -242,8 +243,8 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
         const tableName = options?.table;
         const columnName = attribute.field || options?.key;
         type = this.pgEnumName(tableName, columnName, {
-          ...(enumType.options.name !== undefined && { enumName: enumType.options.name }),
-          ...(enumType.options.schema !== undefined && { enumSchema: enumType.options.schema }),
+          enumName: enumType.options.name,
+          enumSchema: enumType.options.schema,
         });
         if (attribute.type instanceof DataTypes.ARRAY) {
           type += '[]';
@@ -530,7 +531,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     const escapedEnumName = this.quoteIdentifier(rawEnumName);
 
     // enumSchema overrides the table's schema for the enum type name prefix
-    const schema = 'enumSchema' in options ? options.enumSchema : tableDetails.schema;
+    const schema = options.enumSchema !== undefined ? options.enumSchema : tableDetails.schema;
     if (options.schema !== false && schema) {
       return this.quoteIdentifier(schema) + tableDetails.delimiter + escapedEnumName;
     }
@@ -562,17 +563,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   }
 
   pgEnum(tableName, attr, dataType, options) {
-    // Merge enumName/enumSchema from the DataType's options (lower priority than explicit options)
-    const mergedOptions =
-      dataType instanceof ENUM &&
-      (dataType.options.name || dataType.options.schema !== undefined)
-        ? {
-            ...(dataType.options.name !== undefined && { enumName: dataType.options.name }),
-            ...(dataType.options.schema !== undefined && { enumSchema: dataType.options.schema }),
-            ...options,
-          }
-        : options;
-    const enumName = this.pgEnumName(tableName, attr, mergedOptions);
+    const enumName = this.pgEnumName(tableName, attr, options);
     let values;
 
     if (dataType instanceof ENUM && dataType.options.values) {

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -34,7 +34,11 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         (type instanceof DataTypes.ARRAY && type.options.type instanceof DataTypes.ENUM) // ARRAY sub type is ENUM
       ) {
         const enumType = type instanceof DataTypes.ARRAY ? type.options.type : type;
-        const enumOptions = { ...options, enumName: enumType.options.name, enumSchema: enumType.options.schema };
+        const enumOptions = {
+          ...options,
+          enumName: enumType.options.name,
+          enumSchema: enumType.options.schema,
+        };
         sql = this.queryGenerator.pgListEnums(tableName, attribute.field || keys[i], enumOptions);
         promises.push(
           this.sequelize.queryRaw(sql, {

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -314,7 +314,9 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         // A named enum may be shared with other models. Only drop it if no other
         // registered model references the same name (and schema).
         const isSharedWithOtherModel = [...this.sequelize.models].some(otherModel => {
-          if (otherModel === model) return false;
+          if (otherModel === model) {
+            return false;
+          }
 
           return [...otherModel.modelDefinition.attributes.values()].some(otherAttr => {
             const otherType =

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -322,11 +322,18 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
     const attributes = model.modelDefinition.attributes;
 
     for (const attribute of attributes.values()) {
-      if (!(attribute.type instanceof DataTypes.ENUM)) {
+      const enumType =
+        attribute.type instanceof DataTypes.ARRAY &&
+        attribute.type.options.type instanceof DataTypes.ENUM
+          ? attribute.type.options.type
+          : attribute.type instanceof DataTypes.ENUM
+            ? attribute.type
+            : null;
+
+      if (enumType === null) {
         continue;
       }
 
-      const enumType = attribute.type;
       let sql;
 
       if (enumType.options.name) {
@@ -341,6 +348,8 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
                 ? otherAttr.type.options.type
                 : otherAttr.type;
 
+            // Note: undefined schema (use table's default) and an explicit 'public'
+            // are treated as different here even if they resolve to the same schema.
             return (
               otherType instanceof DataTypes.ENUM &&
               otherType.options.name === enumType.options.name &&

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -35,12 +35,12 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       ) {
         const enumType = type instanceof DataTypes.ARRAY ? type.options.type : type;
         const enumOptions =
-          enumType.options.enumName || enumType.options.enumSchema
+          enumType.options.name || enumType.options.schema !== undefined
             ? {
                 ...options,
-                ...(enumType.options.enumName && { enumName: enumType.options.enumName }),
-                ...(enumType.options.enumSchema !== undefined && {
-                  enumSchema: enumType.options.enumSchema,
+                ...(enumType.options.name && { enumName: enumType.options.name }),
+                ...(enumType.options.schema !== undefined && {
+                  enumSchema: enumType.options.schema,
                 }),
               }
             : options;
@@ -110,8 +110,8 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         type instanceof DataTypes.ENUM ||
         (type instanceof DataTypes.ARRAY && enumType instanceof DataTypes.ENUM) // ARRAY sub type is ENUM
       ) {
-        const customEnumName = enumType.options.enumName;
-        const customEnumSchema = enumType.options.enumSchema;
+        const customEnumName = enumType.options.name;
+        const customEnumSchema = enumType.options.schema;
         const enumOptions =
           customEnumName || customEnumSchema !== undefined
             ? {
@@ -304,15 +304,15 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
 
       const enumType = attribute.type;
       let sql;
-      if (enumType.options.enumName) {
+      if (enumType.options.name) {
         // Custom enum name: compute the fully-qualified type name with optional schema override
         const fullEnumName = this.queryGenerator.pgEnumName(
           { tableName, schema: options?.schema },
           attribute.attributeName,
           {
-            enumName: enumType.options.enumName,
-            ...(enumType.options.enumSchema !== undefined && {
-              enumSchema: enumType.options.enumSchema,
+            enumName: enumType.options.name,
+            ...(enumType.options.schema !== undefined && {
+              enumSchema: enumType.options.schema,
             }),
           },
         );

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -33,7 +33,18 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         type instanceof DataTypes.ENUM ||
         (type instanceof DataTypes.ARRAY && type.options.type instanceof DataTypes.ENUM) // ARRAY sub type is ENUM
       ) {
-        sql = this.queryGenerator.pgListEnums(tableName, attribute.field || keys[i], options);
+        const enumType = type instanceof DataTypes.ARRAY ? type.options.type : type;
+        const enumOptions =
+          enumType.options.enumName || enumType.options.enumSchema
+            ? {
+                ...options,
+                ...(enumType.options.enumName && { enumName: enumType.options.enumName }),
+                ...(enumType.options.enumSchema !== undefined && {
+                  enumSchema: enumType.options.enumSchema,
+                }),
+              }
+            : options;
+        sql = this.queryGenerator.pgListEnums(tableName, attribute.field || keys[i], enumOptions);
         promises.push(
           this.sequelize.queryRaw(sql, {
             ...options,
@@ -56,8 +67,18 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       relativeValue,
       position = 'before',
       spliceStart = promises.length,
+      enumName = undefined,
+      enumSchema = undefined,
     ) => {
       const valueOptions = { ...options };
+      if (enumName !== undefined) {
+        valueOptions.enumName = enumName;
+      }
+
+      if (enumSchema !== undefined) {
+        valueOptions.enumSchema = enumSchema;
+      }
+
       valueOptions.before = null;
       valueOptions.after = null;
 
@@ -89,12 +110,23 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         type instanceof DataTypes.ENUM ||
         (type instanceof DataTypes.ARRAY && enumType instanceof DataTypes.ENUM) // ARRAY sub type is ENUM
       ) {
+        const customEnumName = enumType.options.enumName;
+        const customEnumSchema = enumType.options.enumSchema;
+        const enumOptions =
+          customEnumName || customEnumSchema !== undefined
+            ? {
+                ...options,
+                ...(customEnumName && { enumName: customEnumName }),
+                ...(customEnumSchema !== undefined && { enumSchema: customEnumSchema }),
+              }
+            : options;
+
         // If the enum type doesn't exist then create it
         if (!results[enumIdx]) {
           promises.push(() => {
             return this.sequelize.queryRaw(
-              this.queryGenerator.pgEnum(tableName, field, enumType, options),
-              { ...options, raw: true },
+              this.queryGenerator.pgEnum(tableName, field, enumType, enumOptions),
+              { ...enumOptions, raw: true },
             );
           });
         } else if (Boolean(results[enumIdx]) && Boolean(model)) {
@@ -132,6 +164,8 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
                 lastOldEnumValue,
                 'before',
                 promisesLength,
+                customEnumName,
+                customEnumSchema,
               );
             }
 
@@ -144,7 +178,15 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
           if (lastOldEnumValue && rightestPosition < vals.length - 1) {
             const remainingEnumValues = vals.slice(rightestPosition + 1);
             for (let reverseIdx = remainingEnumValues.length - 1; reverseIdx >= 0; reverseIdx--) {
-              addEnumValue(field, remainingEnumValues[reverseIdx], lastOldEnumValue, 'after');
+              addEnumValue(
+                field,
+                remainingEnumValues[reverseIdx],
+                lastOldEnumValue,
+                'after',
+                promises.length,
+                customEnumName,
+                customEnumSchema,
+              );
             }
           }
         }
@@ -260,7 +302,25 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         continue;
       }
 
-      const sql = this.queryGenerator.pgEnumDrop(getTableName, attribute.attributeName);
+      const enumType = attribute.type;
+      let sql;
+      if (enumType.options.enumName) {
+        // Custom enum name: compute the fully-qualified type name with optional schema override
+        const fullEnumName = this.queryGenerator.pgEnumName(
+          { tableName, schema: options?.schema },
+          attribute.attributeName,
+          {
+            enumName: enumType.options.enumName,
+            ...(enumType.options.enumSchema !== undefined && {
+              enumSchema: enumType.options.enumSchema,
+            }),
+          },
+        );
+        sql = this.queryGenerator.pgEnumDrop(null, null, fullEnumName);
+      } else {
+        sql = this.queryGenerator.pgEnumDrop(getTableName, attribute.attributeName);
+      }
+
       promises.push(
         this.sequelize.queryRaw(sql, {
           ...options,

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -343,6 +343,16 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       if (enumType.options.name) {
         // A named enum may be shared with other models. Only drop it if no other
         // registered model references the same name (and schema).
+        //
+        // Resolve the effective schema: explicit options.schema > owning model's
+        // table schema > dialect default. This prevents mismatches between
+        // undefined and 'public' (or any other default) which resolve identically.
+        const defaultSchema = this.sequelize.dialect.getDefaultSchema();
+        const resolveEnumSchema = (et, ownerModel) =>
+          et.options.schema ?? ownerModel.table.schema ?? defaultSchema;
+
+        const currentEnumSchema = resolveEnumSchema(enumType, model);
+
         const isSharedWithOtherModel = [...this.sequelize.models].some(otherModel => {
           if (otherModel === model) {
             return false;
@@ -354,12 +364,10 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
                 ? otherAttr.type.options.type
                 : otherAttr.type;
 
-            // Note: undefined schema (use table's default) and an explicit 'public'
-            // are treated as different here even if they resolve to the same schema.
             return (
               otherType instanceof DataTypes.ENUM &&
               otherType.options.name === enumType.options.name &&
-              otherType.options.schema === enumType.options.schema
+              resolveEnumSchema(otherType, otherModel) === currentEnumSchema
             );
           });
         });
@@ -371,7 +379,7 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         const fullEnumName = this.queryGenerator.pgEnumName(
           { tableName, schema: options?.schema },
           attribute.attributeName,
-          { enumName: enumType.options.name, enumSchema: enumType.options.schema },
+          { enumName: enumType.options.name, enumSchema: currentEnumSchema },
         );
         sql = this.queryGenerator.pgEnumDrop(null, null, fullEnumName);
       } else {

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -327,14 +327,44 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       }
 
       const enumType = attribute.type;
+      let sql;
 
-      // Named enums are shared across tables by design — their lifecycle is managed
-      // independently, so we leave them in place when a table is dropped.
       if (enumType.options.name) {
-        continue;
-      }
+        // A named enum may be shared with other models. Only drop it if no other
+        // registered model references the same name (and schema).
+        const isSharedWithOtherModel = [...this.sequelize.models].some(otherModel => {
+          if (otherModel === model) return false;
 
-      const sql = this.queryGenerator.pgEnumDrop(getTableName, attribute.attributeName);
+          return [...otherModel.modelDefinition.attributes.values()].some(otherAttr => {
+            const otherType =
+              otherAttr.type instanceof DataTypes.ARRAY
+                ? otherAttr.type.options.type
+                : otherAttr.type;
+
+            return (
+              otherType instanceof DataTypes.ENUM &&
+              otherType.options.name === enumType.options.name &&
+              otherType.options.schema === enumType.options.schema
+            );
+          });
+        });
+
+        if (isSharedWithOtherModel) {
+          continue;
+        }
+
+        const fullEnumName = this.queryGenerator.pgEnumName(
+          { tableName, schema: options?.schema },
+          attribute.attributeName,
+          {
+            enumName: enumType.options.name,
+            ...(enumType.options.schema !== undefined && { enumSchema: enumType.options.schema }),
+          },
+        );
+        sql = this.queryGenerator.pgEnumDrop(null, null, fullEnumName);
+      } else {
+        sql = this.queryGenerator.pgEnumDrop(getTableName, attribute.attributeName);
+      }
 
       promises.push(
         this.sequelize.queryRaw(sql, {

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -58,8 +58,8 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       relativeValue,
       position = 'before',
       spliceStart = promises.length,
-      enumName = undefined,
-      enumSchema = undefined,
+      enumName,
+      enumSchema,
     ) => {
       const valueOptions = {
         ...options,

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -133,6 +133,30 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
           const enumVals = this.queryGenerator.fromArray(results[enumIdx].enum_value);
           const vals = enumType.options.values;
 
+          if (customEnumName) {
+            // Warn when the model declares values that don't exist in the shared named type.
+            // We can only add values (PostgreSQL has no DROP VALUE), so missing values silently
+            // become a superset — which is confusing when the name was shared by mistake.
+            const missingFromDb = vals.filter(v => !enumVals.includes(v));
+            const missingFromModel = enumVals.filter(v => !vals.includes(v));
+            if (missingFromModel.length > 0) {
+              console.warn(
+                `[Sequelize] ENUM type "${customEnumName}" in the database contains values not ` +
+                  `present in the model definition: ${missingFromModel.map(v => JSON.stringify(v)).join(', ')}. ` +
+                  `This can happen when multiple models share the same named ENUM type with different value sets.`,
+              );
+            }
+
+            if (missingFromDb.length > 0) {
+              console.warn(
+                `[Sequelize] ENUM type "${customEnumName}" in the database is missing values ` +
+                  `declared in the model: ${missingFromDb.map(v => JSON.stringify(v)).join(', ')}. ` +
+                  `These values will be added. If this ENUM is shared across models, ensure all ` +
+                  `models agree on the intended value set.`,
+              );
+            }
+          }
+
           // Going through already existing values allows us to make queries that depend on those values
           // We will prepend all new values between the old ones, but keep in mind - we can't change order of already existing values
           // Then we append the rest of new values AFTER the latest already existing value
@@ -303,23 +327,14 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       }
 
       const enumType = attribute.type;
-      let sql;
+
+      // Named enums are shared across tables by design — their lifecycle is managed
+      // independently, so we leave them in place when a table is dropped.
       if (enumType.options.name) {
-        // Custom enum name: compute the fully-qualified type name with optional schema override
-        const fullEnumName = this.queryGenerator.pgEnumName(
-          { tableName, schema: options?.schema },
-          attribute.attributeName,
-          {
-            enumName: enumType.options.name,
-            ...(enumType.options.schema !== undefined && {
-              enumSchema: enumType.options.schema,
-            }),
-          },
-        );
-        sql = this.queryGenerator.pgEnumDrop(null, null, fullEnumName);
-      } else {
-        sql = this.queryGenerator.pgEnumDrop(getTableName, attribute.attributeName);
+        continue;
       }
+
+      const sql = this.queryGenerator.pgEnumDrop(getTableName, attribute.attributeName);
 
       promises.push(
         this.sequelize.queryRaw(sql, {

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -8,9 +8,13 @@ import { PostgresQueryInterfaceTypescript } from './query-interface-typescript.i
  */
 export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
   /**
-   * Override changeColumn to ensure a custom-named ENUM type exists before the ALTER TABLE.
+   * Override changeColumn to ensure the ENUM type exists before the ALTER TABLE.
    * The abstract implementation converts attribute options to SQL strings before calling
    * changeColumnQuery, losing DataType objects. We handle pgEnum here while still having them.
+   *
+   * This is needed for any ENUM with a custom name OR a custom schema: attributeToSQL emits
+   * an ENUM_NAMED() sentinel in both cases, causing changeColumnQuery to reference the type
+   * by its schema-qualified name, which must already exist.
    *
    * @override
    */
@@ -24,7 +28,7 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
           ? rawType.options.type
           : null;
 
-    if (enumType?.options.name) {
+    if (enumType && (enumType.options.name || enumType.options.schema !== undefined)) {
       await this.sequelize.queryRaw(
         this.queryGenerator.pgEnum(tableName, attributeName, enumType, {
           enumName: enumType.options.name,

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -34,16 +34,7 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         (type instanceof DataTypes.ARRAY && type.options.type instanceof DataTypes.ENUM) // ARRAY sub type is ENUM
       ) {
         const enumType = type instanceof DataTypes.ARRAY ? type.options.type : type;
-        const enumOptions =
-          enumType.options.name || enumType.options.schema !== undefined
-            ? {
-                ...options,
-                ...(enumType.options.name && { enumName: enumType.options.name }),
-                ...(enumType.options.schema !== undefined && {
-                  enumSchema: enumType.options.schema,
-                }),
-              }
-            : options;
+        const enumOptions = { ...options, enumName: enumType.options.name, enumSchema: enumType.options.schema };
         sql = this.queryGenerator.pgListEnums(tableName, attribute.field || keys[i], enumOptions);
         promises.push(
           this.sequelize.queryRaw(sql, {
@@ -70,27 +61,13 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       enumName = undefined,
       enumSchema = undefined,
     ) => {
-      const valueOptions = { ...options };
-      if (enumName !== undefined) {
-        valueOptions.enumName = enumName;
-      }
-
-      if (enumSchema !== undefined) {
-        valueOptions.enumSchema = enumSchema;
-      }
-
-      valueOptions.before = null;
-      valueOptions.after = null;
-
-      switch (position) {
-        case 'after':
-          valueOptions.after = relativeValue;
-          break;
-        case 'before':
-        default:
-          valueOptions.before = relativeValue;
-          break;
-      }
+      const valueOptions = {
+        ...options,
+        enumName,
+        enumSchema,
+        before: position === 'before' ? relativeValue : null,
+        after: position === 'after' ? relativeValue : null,
+      };
 
       promises.splice(spliceStart, 0, () => {
         return this.sequelize.queryRaw(
@@ -112,14 +89,7 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
       ) {
         const customEnumName = enumType.options.name;
         const customEnumSchema = enumType.options.schema;
-        const enumOptions =
-          customEnumName || customEnumSchema !== undefined
-            ? {
-                ...options,
-                ...(customEnumName && { enumName: customEnumName }),
-                ...(customEnumSchema !== undefined && { enumSchema: customEnumSchema }),
-              }
-            : options;
+        const enumOptions = { ...options, enumName: customEnumName, enumSchema: customEnumSchema };
 
         // If the enum type doesn't exist then create it
         if (!results[enumIdx]) {
@@ -365,10 +335,7 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
         const fullEnumName = this.queryGenerator.pgEnumName(
           { tableName, schema: options?.schema },
           attribute.attributeName,
-          {
-            enumName: enumType.options.name,
-            ...(enumType.options.schema !== undefined && { enumSchema: enumType.options.schema }),
-          },
+          { enumName: enumType.options.name, enumSchema: enumType.options.schema },
         );
         sql = this.queryGenerator.pgEnumDrop(null, null, fullEnumName);
       } else {

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -8,6 +8,36 @@ import { PostgresQueryInterfaceTypescript } from './query-interface-typescript.i
  */
 export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
   /**
+   * Override changeColumn to ensure a custom-named ENUM type exists before the ALTER TABLE.
+   * The abstract implementation converts attribute options to SQL strings before calling
+   * changeColumnQuery, losing DataType objects. We handle pgEnum here while still having them.
+   *
+   * @override
+   */
+  async changeColumn(tableName, attributeName, dataTypeOrOptions, options) {
+    const normalizedAttr = this.normalizeAttribute(dataTypeOrOptions);
+    const rawType = normalizedAttr.type;
+    const enumType =
+      rawType instanceof DataTypes.ENUM
+        ? rawType
+        : rawType instanceof DataTypes.ARRAY && rawType.options.type instanceof DataTypes.ENUM
+          ? rawType.options.type
+          : null;
+
+    if (enumType?.options.name) {
+      await this.sequelize.queryRaw(
+        this.queryGenerator.pgEnum(tableName, attributeName, enumType, {
+          enumName: enumType.options.name,
+          enumSchema: enumType.options.schema,
+        }),
+        { ...options, raw: true },
+      );
+    }
+
+    return super.changeColumn(tableName, attributeName, dataTypeOrOptions, options);
+  }
+
+  /**
    * Ensure enum and their values.
    *
    * @param {string} tableName  Name of table to create


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

PostgreSQL enum types are named database objects. Sequelize has always auto-generated those names as `enum_<table>_<column>`, which works fine for a single column but makes it impossible to share one enum type across multiple tables, or to place it in a schema that differs from the table's schema. This PR adds `name` and `schema` options to `DataTypes.ENUM` to address both cases.                         

Closes #2577

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL ENUMs now support custom type names and schemas, including ARRAY-of-ENUM types.
  * Named enum types are created and referenced with schema-qualified identifiers during column changes.
  * Added support for JSON path extraction result data types.
* **Bug Fixes / Behavior**
  * Shared named enums are preserved when dropping tables.
  * Warnings are emitted when shared enum values differ from model definitions.
  * Empty enum names and schemas are rejected.
* **Tests**
  * Expanded coverage for enum SQL generation, lifecycle operations, arrays, schemas, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->