### PR TITLE
feat(mysql): add support for skipLocked

### DIFF
--- a/packages/mysql/src/dialect.ts
+++ b/packages/mysql/src/dialect.ts
@@ -53,6 +53,7 @@ export class MySqlDialect extends AbstractDialect<MySqlDialectOptions, MySqlConn
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: true,
+    skipLocked: true,
     forShare: 'LOCK IN SHARE MODE',
     settingIsolationLevelDuringTransaction: false,
     schemas: true,


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Github Issue Link: https://github.com/sequelize/sequelize/issues/15589

  MySQL 8.0+ supports `SKIP LOCKED` syntax (introduced in MySQL 8.0.1), but the Sequelize MySQL
  dialect does not declare support for it. This PR adds `skipLocked: true` to the MySQL dialect's
  supported features.

  Without this, using `skipLocked: true` in a query silently ignores the option on MySQL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MySQL now supports SKIP LOCKED functionality for improved query execution and concurrency handling. This enables queries to skip rows currently locked by other transactions, reducing lock contention and improving performance in high-load scenarios where multiple operations frequently access the same data simultaneously.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sequelize/sequelize/pull/18225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->