### PR TITLE
meta(core): add regression test for foreign key duplication on schema-qualified alter

### DIFF
--- a/packages/core/test/integration/model/sync.test.js
+++ b/packages/core/test/integration/model/sync.test.js
@@ -164,6 +164,34 @@ describe(getTestDialectTeaser('Model.sync & Sequelize#sync'), () => {
     await sequelize.sync({ alter: true });
   });
 
+  it('does not duplicate foreign keys when altering tables in a non-default schema #12961', async () => {
+    // When a model lives in a non-default schema, its foreign-key reference is
+    // an object rather than a plain table name. The alter-sync path used to
+    // compare that object against the referenced table name string, so the
+    // existing constraint was never matched and got recreated on every sync,
+    // duplicating the foreign key.
+    if (!sequelize.dialect.supports.schemas) {
+      return;
+    }
+
+    const schema = 'fk_alter_schema';
+    await sequelize.createSchema(schema);
+
+    const Country = sequelize.define('Country', { name: DataTypes.STRING }, { schema });
+    const City = sequelize.define('City', { name: DataTypes.STRING }, { schema });
+
+    City.belongsTo(Country);
+
+    await sequelize.sync({ alter: true });
+    await sequelize.sync({ alter: true });
+
+    const cityForeignKeys = await sequelize.queryInterface.showConstraints(City, {
+      constraintType: 'FOREIGN KEY',
+    });
+
+    expect(cityForeignKeys.length).to.eq(1);
+  });
+
   it('creates one unique index for unique:true column', async () => {
     const User = sequelize.define('testSync', {
       email: {


### PR DESCRIPTION
Closes #12961.

That issue (duplicated foreign keys on every `sync({ alter: true })` when the model is in a non-default schema) is already fixed on `main` — the alter path now reads `.tableName` off the reference object instead of comparing the whole object, and matches on schema. But there was no test guarding it.

The existing "should properly alter tables when there are foreign keys" test uses the default schema and doesn't assert anything, so it wouldn't catch a regression here.

This adds a test that puts two related models in a non-default schema, syncs twice with `alter: true`, and asserts the foreign key count stays at 1. I confirmed it has teeth: reverting the `.tableName` extraction makes it fail with a count of 2. Runs on any dialect that supports schemas; verified against Postgres locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to verify that `Model.sync()` with schema customization properly handles foreign key constraints without duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sequelize/sequelize/pull/18228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->