### PR TITLE
fix(core): cache the Model class in isModelStatic to avoid repeated require()

### DIFF
--- a/packages/core/src/utils/model-utils.ts
+++ b/packages/core/src/utils/model-utils.ts
@@ -4,6 +4,9 @@ import type { TableNameWithSchema } from '../abstract-dialect/query-interface.js
 import type { Model, ModelStatic } from '../model';
 import { ModelDefinition } from '../model-definition.js';
 
+// Cache for the lazily-required Model class, see isModelStatic below.
+let cachedModelClass: ModelStatic | undefined;
+
 /**
  * Returns true if the value is a model subclass.
  *
@@ -11,9 +14,13 @@ import { ModelDefinition } from '../model-definition.js';
  */
 export function isModelStatic<M extends Model>(val: any): val is ModelStatic<M> {
   // TODO: temporary workaround due to cyclic import. Should not be necessary once Model is fully migrated to TypeScript.
-  const { Model: TmpModel } = require('../model');
+  // The result of this require() is cached after the first call: isModelStatic runs on a hot path (it is called
+  // once per association while building queries), and re-running require() on every call adds non-trivial
+  // module-resolution overhead under some loaders. The resolved Model class never changes once the module graph
+  // is initialized, so caching it is safe.
+  cachedModelClass ??= require('../model').Model as ModelStatic;
 
-  return typeof val === 'function' && val.prototype instanceof TmpModel;
+  return typeof val === 'function' && val.prototype instanceof cachedModelClass;
 }
 
 /**

--- a/packages/core/test/unit/utils/model-utils.test.ts
+++ b/packages/core/test/unit/utils/model-utils.test.ts
@@ -1,5 +1,7 @@
+import Module from 'node:module';
 import { Model, isModelStatic, isSameInitialModel } from '@sequelize/core';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { sequelize } from '../../support';
 
 describe('isModelStatic', () => {
@@ -7,6 +9,31 @@ describe('isModelStatic', () => {
     const MyModel = sequelize.define('MyModel', {});
 
     expect(isModelStatic(MyModel)).to.be.true;
+  });
+
+  it('does not re-require the Model class on every call (caches it)', () => {
+    const MyModel = sequelize.define('MyModelCacheCheck', {});
+
+    // Prime the cache: the very first call is allowed to require('../model').
+    isModelStatic(MyModel);
+
+    // Every require() goes through Module._load, including cache hits, so spying on it lets us
+    // assert that no further resolution of the Model module happens once the class is cached.
+    const loadSpy = sinon.spy(Module as unknown as { _load(...args: any[]): unknown }, '_load');
+
+    try {
+      for (let i = 0; i < 50; i++) {
+        isModelStatic(MyModel);
+      }
+    } finally {
+      loadSpy.restore();
+    }
+
+    const modelModuleLoads = loadSpy
+      .getCalls()
+      .filter(call => String(call.args[0]).endsWith('/model') || call.args[0] === '../model');
+
+    expect(modelModuleLoads).to.have.length(0);
   });
 
   it('returns false for model instances', () => {

--- a/packages/core/test/unit/utils/model-utils.test.ts
+++ b/packages/core/test/unit/utils/model-utils.test.ts
@@ -1,6 +1,6 @@
-import Module from 'node:module';
 import { Model, isModelStatic, isSameInitialModel } from '@sequelize/core';
 import { expect } from 'chai';
+import Module from 'node:module';
 import sinon from 'sinon';
 import { sequelize } from '../../support';
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? — _not applicable, no behavior/API change_
- [x] Did you update the typescript typings accordingly (if applicable)? — _not applicable_
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

Closes #18233

## Description of Changes

### The problem we hit

`isModelStatic()` calls `require('../model')` on **every** invocation:

```ts
export function isModelStatic<M extends Model>(val: any): val is ModelStatic<M> {
  // TODO: temporary workaround due to cyclic import.
  const { Model: TmpModel } = require('../model');

  return typeof val === 'function' && val.prototype instanceof TmpModel;
}
```

`isModelStatic` is on a hot path — it runs (directly, and via `isSameInitialModel` / `extractModelDefinition`) once per association while building queries. Although Node caches the loaded *module*, the `require()` **call itself** still funnels through `Module._load` and re-resolves the request every time.

We ran into this in production: under our Node module-resolution setup, that per-call `require('../model')` repeatedly walked `trySelf → findParentPackageJSON → fs.stat`, and on include-heavy queries (many associations) the resolution overhead showed up at the top of our CPU profiles. We were running this fix as a `patch-package` patch against `@sequelize/core@7.0.0-alpha.47` and wanted to upstream it.

Even on a plain Node setup where each resolution is cheaper, the work is pure waste: the resolved `Model` class never changes once the module graph is initialized.

### The fix

Cache the resolved `Model` class in a module-level variable and reuse it on subsequent calls. The lazy `require` (the cyclic-import workaround) is preserved for the *first* call, so module-load ordering is unchanged; only the redundant re-resolution on later calls is removed.

```ts
let cachedModelClass: ModelStatic | undefined;

export function isModelStatic<M extends Model>(val: any): val is ModelStatic<M> {
  // TODO: temporary workaround due to cyclic import. ...
  cachedModelClass ??= require('../model').Model as ModelStatic;

  return typeof val === 'function' && val.prototype instanceof cachedModelClass;
}
```

### Tests

Added a unit test that spies on `Module._load` and asserts the `Model` module is **not** re-resolved across 50 `isModelStatic` calls after warm-up.

I verified locally that the test passes with the fix and **fails without it** (the uncached version resolves the module once per call — 50 times). Behavior is unchanged and remains covered by the existing `isModelStatic` / `isSameInitialModel` tests; `yarn eslint` and `yarn lerna run test-typings --scope=@sequelize/core` both pass.

## List of Breaking Changes

None. This is an internal, behavior-preserving performance optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance by caching a frequently accessed class to avoid repeated module reloads.

* **Tests**
  * Added unit test to verify the caching behavior and prevent repeated module resolution during repeated calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->