### PR TITLE
fix: use word-boundary regex for REFERENCES detection in query generators

### DIFF
--- a/packages/core/test/unit/dialects/mariadb/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mariadb/query-generator.test.js
@@ -449,6 +449,23 @@ if (dialect === 'mariadb') {
         },
       ],
 
+      changeColumnQuery: [
+        {
+          title: 'should not treat ENUM value containing REFERENCES as a foreign key (fix #17544)',
+          arguments: ['users', { status: "ENUM('PREFERENCES')" }],
+          expectation: "ALTER TABLE `users` CHANGE `status` `status` ENUM('PREFERENCES');",
+        },
+        {
+          title: 'should treat actual REFERENCES keyword as a foreign key',
+          arguments: [
+            'users',
+            { level_id: 'INTEGER REFERENCES `levels` (`id`) ON DELETE CASCADE ON UPDATE CASCADE' },
+          ],
+          expectation:
+            'ALTER TABLE `users` ADD FOREIGN KEY (`level_id`) REFERENCES `levels` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        },
+      ],
+
       updateQuery: [
         {
           arguments: ['myTable', { bar: 2 }, { name: 'foo' }],

--- a/packages/core/test/unit/dialects/mysql/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mysql/query-generator.test.js
@@ -444,6 +444,23 @@ if (dialect === 'mysql') {
         },
       ],
 
+      changeColumnQuery: [
+        {
+          title: 'should not treat ENUM value containing REFERENCES as a foreign key (fix #17544)',
+          arguments: ['users', { status: "ENUM('PREFERENCES')" }],
+          expectation: "ALTER TABLE `users` CHANGE `status` `status` ENUM('PREFERENCES');",
+        },
+        {
+          title: 'should treat actual REFERENCES keyword as a foreign key',
+          arguments: [
+            'users',
+            { level_id: 'INTEGER REFERENCES `levels` (`id`) ON DELETE CASCADE ON UPDATE CASCADE' },
+          ],
+          expectation:
+            'ALTER TABLE `users` ADD FOREIGN KEY (`level_id`) REFERENCES `levels` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+        },
+      ],
+
       updateQuery: [
         {
           arguments: ['myTable', { bar: 2 }, { name: 'foo' }],

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -171,6 +171,13 @@ if (dialect.startsWith('postgres')) {
           ],
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
+        {
+          // Regression test for https://github.com/sequelize/sequelize/issues/17544
+          title:
+            "should not treat ENUM value containing 'REFERENCES' as a foreign key, and should still emit DROP NOT NULL",
+          arguments: ['myTable', { status: "ENUM('PREFERENCES')" }],
+          expectation: `ALTER TABLE "myTable" ALTER COLUMN "status" DROP NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "status" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_status" AS ENUM(''PREFERENCES''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "status" TYPE "public"."enum_myTable_status" USING ("status"::"public"."enum_myTable_status");`,
+        },
       ],
 
       selectQuery: [

--- a/packages/core/test/unit/sql/change-column.test.js
+++ b/packages/core/test/unit/sql/change-column.test.js
@@ -4,6 +4,24 @@ const sinon = require('sinon');
 const { beforeAll2, expectsql, sequelize } = require('../../support');
 const { DataTypes } = require('@sequelize/core');
 
+// Regression test for https://github.com/sequelize/sequelize/issues/17544
+describe('QueryGenerator#changeColumnQuery', () => {
+  if (!['mysql', 'mariadb'].includes(sequelize.dialect.name)) {
+    return;
+  }
+
+  it("does not treat ENUM value containing 'REFERENCES' as a foreign key", () => {
+    const queryGenerator = sequelize.queryGenerator;
+    const sql = queryGenerator.changeColumnQuery('users', {
+      status: "ENUM('PREFERENCES')",
+    });
+
+    expectsql(sql, {
+      'mysql mariadb': "ALTER TABLE `users` CHANGE `status` `status` ENUM('PREFERENCES');",
+    });
+  });
+});
+
 describe('QueryInterface#changeColumn', () => {
   if (sequelize.dialect.name === 'sqlite3') {
     return;

--- a/packages/core/test/unit/sql/create-table.test.js
+++ b/packages/core/test/unit/sql/create-table.test.js
@@ -14,6 +14,32 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
   describe('createTable', () => {
     describe('with enums', () => {
+      // Regression test for https://github.com/sequelize/sequelize/issues/17544
+      it("does not treat ENUM value containing 'REFERENCES' as a foreign key", () => {
+        if (!['mysql', 'mariadb'].includes(current.dialect.name)) {
+          return;
+        }
+
+        const PrefUser = current.define(
+          'user',
+          {
+            pref_type: DataTypes.ENUM('PREFERENCES', 'SETTINGS'),
+          },
+          { timestamps: false },
+        );
+
+        const sql = queryGenerator.createTableQuery(
+          PrefUser.table,
+          queryGenerator.attributesToSQL(PrefUser.getAttributes()),
+          {},
+        );
+
+        expectsql(sql, {
+          'mysql mariadb':
+            "CREATE TABLE IF NOT EXISTS `users` (`id` INTEGER NOT NULL auto_increment , `pref_type` ENUM('PREFERENCES', 'SETTINGS'), PRIMARY KEY (`id`)) ENGINE=InnoDB;",
+        });
+      });
+
       it('references enum in the right schema #3171', () => {
         const FooUser = current.define(
           'user',

--- a/packages/db2/src/query-generator.js
+++ b/packages/db2/src/query-generator.js
@@ -85,7 +85,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
         if (includes(dataType, 'PRIMARY KEY')) {
           primaryKeys.push(attr);
 
-          if (includes(dataType, 'REFERENCES')) {
+          if (/\bREFERENCES\b/.test(dataType)) {
             // Db2 doesn't support inline REFERENCES declarations: move to the end
             match = dataType.match(/^(.+) (REFERENCES.*)$/);
             attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace(/PRIMARY KEY/, '')}`);
@@ -93,7 +93,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
           } else {
             attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace(/PRIMARY KEY/, '')}`);
           }
-        } else if (includes(dataType, 'REFERENCES')) {
+        } else if (/\bREFERENCES\b/.test(dataType)) {
           // Db2 doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
@@ -201,7 +201,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
       }
 
       for (const definition of defs) {
-        if (/REFERENCES/.test(definition)) {
+        if (/\bREFERENCES\b/.test(definition)) {
           constraintString.push(
             template(
               '<%= fkName %> FOREIGN KEY (<%= attrName %>) <%= definition %>',

--- a/packages/ibmi/src/query-generator.js
+++ b/packages/ibmi/src/query-generator.js
@@ -144,7 +144,7 @@ export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
 
     for (const attributeName in attributes) {
       let definition = attributes[attributeName];
-      if (definition.includes('REFERENCES')) {
+      if (/\bREFERENCES\b/.test(definition)) {
         const attrName = this.quoteIdentifier(attributeName);
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
         const foreignKey = this.quoteIdentifier(`${attributeName}`);

--- a/packages/mariadb/src/query-generator.js
+++ b/packages/mariadb/src/query-generator.js
@@ -36,7 +36,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
       if (dataType.includes('PRIMARY KEY')) {
         primaryKeys.push(attr);
 
-        if (dataType.includes('REFERENCES')) {
+        if (/\bREFERENCES\b/.test(dataType)) {
           // MariaDB doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace('PRIMARY KEY', '')}`);
@@ -44,7 +44,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
         } else {
           attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`);
         }
-      } else if (dataType.includes('REFERENCES')) {
+      } else if (/\bREFERENCES\b/.test(dataType)) {
         // MariaDB doesn't support inline REFERENCES declarations: move to the end
         match = dataType.match(/^(.+) (REFERENCES.*)$/);
         attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
@@ -125,7 +125,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
 
     for (const attributeName in attributes) {
       let definition = attributes[attributeName];
-      if (definition.includes('REFERENCES')) {
+      if (/\bREFERENCES\b/.test(definition)) {
         const attrName = this.quoteIdentifier(attributeName);
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
         constraintString.push(`FOREIGN KEY (${attrName}) ${definition}`);

--- a/packages/mssql/src/query-generator.js
+++ b/packages/mssql/src/query-generator.js
@@ -62,7 +62,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
         if (dataType.includes('PRIMARY KEY')) {
           primaryKeys.push(attr);
 
-          if (dataType.includes('REFERENCES')) {
+          if (/\bREFERENCES\b/.test(dataType)) {
             // MSSQL doesn't support inline REFERENCES declarations: move to the end
             match = dataType.match(/^(.+) (REFERENCES.*)$/);
             attributesClauseParts.push(
@@ -74,7 +74,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
               `${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`,
             );
           }
-        } else if (dataType.includes('REFERENCES')) {
+        } else if (/\bREFERENCES\b/.test(dataType)) {
           // MSSQL doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attributesClauseParts.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
@@ -187,7 +187,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
         definition = commentMatch[1];
       }
 
-      if (definition.includes('REFERENCES')) {
+      if (/\bREFERENCES\b/.test(definition)) {
         constraintString.push(
           `FOREIGN KEY (${quotedAttrName}) ${definition.replace(/.+?(?=REFERENCES)/, '')}`,
         );

--- a/packages/mysql/src/query-generator.js
+++ b/packages/mysql/src/query-generator.js
@@ -41,7 +41,7 @@ export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
       if (dataType.includes('PRIMARY KEY')) {
         primaryKeys.push(attr);
 
-        if (dataType.includes('REFERENCES')) {
+        if (/\bREFERENCES\b/.test(dataType)) {
           // MySQL doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace('PRIMARY KEY', '')}`);
@@ -49,7 +49,7 @@ export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
         } else {
           attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`);
         }
-      } else if (dataType.includes('REFERENCES')) {
+      } else if (/\bREFERENCES\b/.test(dataType)) {
         // MySQL doesn't support inline REFERENCES declarations: move to the end
         match = dataType.match(/^(.+) (REFERENCES.*)$/);
         attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
@@ -137,7 +137,7 @@ export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
 
     for (const attributeName in attributes) {
       let definition = attributes[attributeName];
-      if (definition.includes('REFERENCES')) {
+      if (/\bREFERENCES\b/.test(definition)) {
         const attrName = this.quoteIdentifier(attributeName);
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
         constraintString.push(`FOREIGN KEY (${attrName}) ${definition}`);

--- a/packages/oracle/src/query-generator.js
+++ b/packages/oracle/src/query-generator.js
@@ -205,7 +205,7 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
       if (dataType.includes('PRIMARY KEY')) {
         // Primary key
         primaryKeys.push(attr);
-        if (dataType.includes('REFERENCES')) {
+        if (/\bREFERENCES\b/.test(dataType)) {
           const match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(`${attr} ${match[1].replace(/PRIMARY KEY/, '')}`);
 
@@ -214,7 +214,7 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
         } else {
           attrStr.push(`${attr} ${dataType.replace(/PRIMARY KEY/, '').trim()}`);
         }
-      } else if (dataType.includes('REFERENCES')) {
+      } else if (/\bREFERENCES\b/.test(dataType)) {
         // Foreign key
         const match = dataType.match(/^(.+) (REFERENCES.*)$/);
         attrStr.push(`${attr} ${match[1]}`);
@@ -548,8 +548,7 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
       }
 
       const definition = attributes[attributeName];
-      // eslint-disable-next-line unicorn/prefer-regexp-test
-      if (definition.match(/REFERENCES/)) {
+      if (/\bREFERENCES\b/.test(definition)) {
         sql.push(this._alterForeignKeyConstraint(definition, table, attributeName));
       } else {
         // Building the modify query

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -146,7 +146,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
         attrSql += query(`${this.quoteIdentifier(attributeName)} SET NOT NULL`);
 
         definition = definition.replace('NOT NULL', '').trim();
-      } else if (!definition.includes('REFERENCES')) {
+      } else if (!/\bREFERENCES\b/.test(definition)) {
         attrSql += query(`${this.quoteIdentifier(attributeName)} DROP NOT NULL`);
       }
 
@@ -156,7 +156,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
         );
 
         definition = definition.replace(/(DEFAULT[^;]+)/, '').trim();
-      } else if (!definition.includes('REFERENCES')) {
+      } else if (!/\bREFERENCES\b/.test(definition)) {
         attrSql += query(`${this.quoteIdentifier(attributeName)} DROP DEFAULT`);
       }
 
@@ -177,7 +177,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
         );
       }
 
-      if (definition.includes('REFERENCES')) {
+      if (/\bREFERENCES\b/.test(definition)) {
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
         attrSql += query(
           `ADD FOREIGN KEY (${this.quoteIdentifier(attributeName)}) ${definition}`,

--- a/packages/snowflake/src/query-generator.js
+++ b/packages/snowflake/src/query-generator.js
@@ -68,14 +68,14 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
       if (dataType.includes('PRIMARY KEY')) {
         primaryKeys.push(attr);
 
-        if (dataType.includes('REFERENCES')) {
+        if (/\bREFERENCES\b/.test(dataType)) {
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace('PRIMARY KEY', '')}`);
           foreignKeys[attr] = match[2];
         } else {
           attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`);
         }
-      } else if (dataType.includes('REFERENCES')) {
+      } else if (/\bREFERENCES\b/.test(dataType)) {
         match = dataType.match(/^(.+) (REFERENCES.*)$/);
         attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
         foreignKeys[attr] = match[2];
@@ -162,7 +162,7 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
         attrSql.push(query(this.quoteIdentifier(attributeName), 'SET NOT NULL'));
 
         definition = definition.replace('NOT NULL', '').trim();
-      } else if (!definition.includes('REFERENCES')) {
+      } else if (!/\bREFERENCES\b/.test(definition)) {
         attrSql.push(query(this.quoteIdentifier(attributeName), 'DROP NOT NULL'));
       }
 
@@ -176,7 +176,7 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
         );
 
         definition = definition.replace(/(DEFAULT[^;]+)/, '').trim();
-      } else if (!definition.includes('REFERENCES')) {
+      } else if (!/\bREFERENCES\b/.test(definition)) {
         attrSql.push(query(this.quoteIdentifier(attributeName), 'DROP DEFAULT'));
       }
 
@@ -190,7 +190,7 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
         );
       }
 
-      if (definition.includes('REFERENCES')) {
+      if (/\bREFERENCES\b/.test(definition)) {
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
         attrSql.push(
           query('ADD FOREIGN KEY (', this.quoteIdentifier(attributeName), ')', definition).replace(


### PR DESCRIPTION
`DataTypes.ENUM('PREFERENCES')` passes the `.includes('REFERENCES')` check in `createTableQuery` and `changeColumnQuery` because "PREFERENCES" contains "REFERENCES" as a substring. This causes the ENUM column to be emitted as a spurious `FOREIGN KEY ... REFERENCES` constraint instead of a column definition.

Replacing `.includes('REFERENCES')` with `/\bREFERENCES\b/.test(...)` fixes this across all eight dialect query generators (mysql, mariadb, postgres, mssql, snowflake, ibmi, oracle, db2). The db2 dialect used lodash's `_.includes`, which is semantically equivalent on string inputs; replaced with the same regex for consistency.

Fixes #17544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where ENUM values containing the word "REFERENCES" were incorrectly interpreted as foreign key constraints across all supported database systems.

* **Tests**
  * Added comprehensive regression tests to ensure ENUM values containing "REFERENCES" are handled correctly without triggering foreign key misinterpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->