### PR TITLE
fix: use a unique name for each nested savepoint

### DIFF
--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -29,7 +29,6 @@ export class Transaction {
   readonly #afterHooks = new Set<TransactionCallback>();
 
   readonly #name: string;
-  readonly #savepoints = new Map<string, Transaction>();
   readonly options: Readonly<NormalizedTransactionOptions>;
   readonly parent: Transaction | null;
   readonly id: string;
@@ -56,8 +55,10 @@ export class Transaction {
 
     if (this.parent) {
       this.id = this.parent.id;
-      this.#name = `${this.id}-sp-${this.parent.#savepoints.size}`;
-      this.parent.#savepoints.set(this.#name, this);
+      // Each savepoint needs a unique name. Deriving it from a per-parent
+      // counter made the first savepoint at every nesting level share the same
+      // name, so `ROLLBACK TO SAVEPOINT` could target the wrong savepoint.
+      this.#name = generateTransactionId();
     } else {
       const id = generateTransactionId();
       this.id = id;

--- a/packages/core/test/unit/transaction.test.ts
+++ b/packages/core/test/unit/transaction.test.ts
@@ -1,4 +1,4 @@
-import { IsolationLevel } from '@sequelize/core';
+import { IsolationLevel, TransactionNestMode } from '@sequelize/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { beforeAll2, getTestDialect, sequelize } from '../support';
@@ -85,6 +85,44 @@ describe('Transaction', () => {
         throw error;
       }
     }
+  });
+
+  // https://github.com/sequelize/sequelize/issues/18207
+  it('uses a unique name for each nested savepoint', async function () {
+    if (!sequelize.dialect.supports.savepoints) {
+      return this.skip();
+    }
+
+    // Hand out a distinct id on every call so the savepoint names can only
+    // collide if they are derived from something other than a fresh id.
+    let counter = 0;
+    vars.stubTransactionId.callsFake(() => `txn-${counter++}`);
+
+    await sequelize.transaction(async t1 => {
+      await sequelize.transaction(
+        { transaction: t1, nestMode: TransactionNestMode.savepoint },
+        async t2 => {
+          await sequelize.transaction(
+            { transaction: t2, nestMode: TransactionNestMode.savepoint },
+            async () => {},
+          );
+        },
+      );
+    });
+
+    const isSavepointCreation = (sql: string) =>
+      (sql.includes('SAVEPOINT') || sql.includes('SAVE TRANSACTION')) &&
+      !sql.includes('RELEASE') &&
+      !sql.includes('ROLLBACK');
+
+    const savepointCreations = vars.stub.args
+      .map(args => String(args[0]))
+      .filter(isSavepointCreation);
+
+    expect(savepointCreations).to.have.lengthOf(2);
+    // Both nested savepoints previously resolved to the same name (e.g.
+    // `<id>-sp-0`), so a rollback could target the wrong savepoint.
+    expect(new Set(savepointCreations).size).to.equal(2);
   });
 });
 

--- a/packages/core/test/unit/transaction.test.ts
+++ b/packages/core/test/unit/transaction.test.ts
@@ -87,14 +87,11 @@ describe('Transaction', () => {
     }
   });
 
-  // https://github.com/sequelize/sequelize/issues/18207
   it('uses a unique name for each nested savepoint', async function () {
     if (!sequelize.dialect.supports.savepoints) {
       return this.skip();
     }
 
-    // Hand out a distinct id on every call so the savepoint names can only
-    // collide if they are derived from something other than a fresh id.
     let counter = 0;
     vars.stubTransactionId.callsFake(() => `txn-${counter++}`);
 
@@ -120,8 +117,6 @@ describe('Transaction', () => {
       .filter(isSavepointCreation);
 
     expect(savepointCreations).to.have.lengthOf(2);
-    // Both nested savepoints previously resolved to the same name (e.g.
-    // `<id>-sp-0`), so a rollback could target the wrong savepoint.
     expect(new Set(savepointCreations).size).to.equal(2);
   });
 });


### PR DESCRIPTION
## Issue

Fixes #18207 (Bug 1 — the one still present on `main`/v7).

When nesting transactions with `TransactionNestMode.savepoint`, each savepoint's name was derived from a **per-parent counter**:

```ts
this.#name = `${this.id}-sp-${this.parent.#savepoints.size}`;
```

Because the counter resets for every parent, the *first* savepoint at every nesting level gets the **same** name (e.g. `<id>-sp-0`). Postgres (and others) resolve `ROLLBACK TO SAVEPOINT <name>` to the **most recently declared** savepoint of that name, so a rollback at one level could silently roll back to a deeper savepoint — committing writes that should have been undone. A maintainer confirmed the issue and favoured generating a fresh id per savepoint.

## Fix

Give each savepoint a fresh unique id from the dialect's `generateTransactionId()` (the same generator already used for root transaction ids), instead of a per-parent counter. The now-unused `#savepoints` map (its only purpose was the counter) is removed.

```ts
if (this.parent) {
  this.id = this.parent.id;
  this.#name = generateTransactionId();
} else {
  const id = generateTransactionId();
  this.id = id;
  this.#name = id;
}
```

`this.id` still tracks the root transaction (used for the connection uuid); only the savepoint `#name` changes.

## Tests

Added a unit test in `packages/core/test/unit/transaction.test.ts` (no DB — the existing `queryRaw` stub harness): it opens two levels of nested `savepoint`-mode transactions and asserts the two emitted `SAVEPOINT` statements use **distinct** names. Verified it fails on the previous code (`expected 1 to equal 2` — both savepoints shared `<id>-sp-0`) and passes with the fix. ESLint + Prettier clean.

> Scoped to Bug 1 only; Bugs 2 & 3 in the issue are v6-only and the maintainer indicated v6 won't be patched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested savepoint transactions that could reuse or collide identifiers, ensuring each nesting level generates distinct savepoint names.
* **Tests**
  * Added a regression test covering savepoint-based nested transactions and verifying unique savepoint creation statements across nesting levels (skipping when unsupported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->