### PR TITLE
fix(core): recognise / as a valid named replacement terminator

### DIFF
--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -197,7 +197,7 @@ function mapBindParametersAndReplacements(
 
       const remainingString = sqlString.slice(i, sqlString.length);
 
-      const match = remainingString.match(/^:(?<name>[a-z_][0-9a-z_]*)(?:\)|,|$|\s|::|;|])/i);
+      const match = remainingString.match(/^:(?<name>[a-z_][0-9a-z_]*)(?:\/|\)|,|$|\s|::|;|])/i);
       const replacementName = match?.groups?.name;
       if (!replacementName) {
         continue;

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -731,6 +731,18 @@ SELECT * FROM users WHERE id = '\\\\\\' :id' OR id = :id`),
   it('does not interpret ::x as a replacement, as it is a cast', () => {
     expect(injectReplacements(`('foo')::string`, dialect, [0])).to.equal(`('foo')::string`);
   });
+
+  it('parses named replacements followed by a division operator', () => {
+    const sql = injectReplacements(
+      `SELECT ACOS(SIN(PI() * :lat/ 180) * SIN(PI() * :lat/ 180)) FROM jobs`,
+      dialect,
+      { lat: 28.5 },
+    );
+
+    expectsql(sql, {
+      default: `SELECT ACOS(SIN(PI() * 28.5/ 180) * SIN(PI() * 28.5/ 180)) FROM jobs`,
+    });
+  });
 });
 
 describe('injectReplacements (positional replacements)', () => {


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does the description below contain a link to an existing issue (Closes #18242) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Named replacements are not substituted when immediately followed by a division operator `/`.

**Example:**

```sql
SELECT ACOS(SIN(PI() * :user_lat/ 180)) FROM jobs
```

MySQL receives `:user_lat` as a literal string and throws a syntax error.

**Root cause:** The `injectReplacements` regex does not include `/` in its terminator group:

```
/^:(?<name>[a-z_][0-9a-z_]*)(?:\)|,|$|\s|::|;|])/i
```

`/` is missing from the alternation, so `:user_lat/ 180` never matches.

**Fix:** Add `\/` to the terminator group — one character change in `packages/core/src/utils/sql.ts`.

**Workaround:** Insert a space before `/` — `:user_lat / 180` works because `\s` is already a valid terminator.

**Regression since v6** — Sequelize 5 handled this differently.

A unit test covering `:param/ value` arithmetic is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL named replacement parsing to correctly handle placeholders followed by division operators.

* **Tests**
  * Added test coverage for named replacement parsing with division operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->