### PR TITLE
fix(core): stop Op.is from mutating shared options and stripping bindParam

### DIFF
--- a/packages/core/src/abstract-dialect/where-sql-builder.ts
+++ b/packages/core/src/abstract-dialect/where-sql-builder.ts
@@ -406,12 +406,12 @@ export class WhereSqlBuilder {
       );
     }
 
-    // "IS" operator does not accept bind parameters, only literals
-    if (options.bindParam) {
-      delete options.bindParam;
-    }
+    // "IS" operator does not accept bind parameters, only literals.
+    // Use a local copy so we do not mutate the shared options object (which would silently
+    // strip bindParam from every subsequent sibling condition in the same WHERE clause).
+    const isOptions = options.bindParam ? { ...options, bindParam: undefined } : options;
 
-    return this.formatBinaryOperation(left, undefined, operator, right, undefined, options);
+    return this.formatBinaryOperation(left, undefined, operator, right, undefined, isOptions);
   }
 
   protected [Op.notBetween](...args: Parameters<WhereSqlBuilder[typeof Op.between]>): string {

--- a/packages/core/src/abstract-dialect/where-sql-builder.ts
+++ b/packages/core/src/abstract-dialect/where-sql-builder.ts
@@ -409,7 +409,8 @@ export class WhereSqlBuilder {
     // "IS" operator does not accept bind parameters, only literals.
     // Use a local copy so we do not mutate the shared options object (which would silently
     // strip bindParam from every subsequent sibling condition in the same WHERE clause).
-    const isOptions = options.bindParam ? { ...options, bindParam: undefined } : options;
+    const isOptions: FormatWhereOptions = { ...options };
+    delete isOptions.bindParam;
 
     return this.formatBinaryOperation(left, undefined, operator, right, undefined, isOptions);
   }

--- a/packages/core/test/unit/query-generator/update-query.test.ts
+++ b/packages/core/test/unit/query-generator/update-query.test.ts
@@ -66,6 +66,27 @@ describe('QueryGenerator#updateQuery', () => {
     });
   });
 
+  it('preserves bind params for all WHERE conditions when one condition is IS NULL', () => {
+    // Regression: Op.is (triggered automatically for null) used to mutate the shared
+    // options object by deleting bindParam, which caused sibling conditions to emit
+    // inline literals instead of bind parameters.
+    const { query, bind } = queryGenerator.updateQuery(
+      'myTable',
+      { status: 'active' },
+      { deletedAt: null, name: 'Alice' },
+    );
+
+    expectsql(query, {
+      default:
+        'UPDATE [myTable] SET [status]=$sequelize_1 WHERE [deletedAt] IS NULL AND [name] = $sequelize_2',
+      db2: `SELECT * FROM FINAL TABLE (UPDATE "myTable" SET "status"=$sequelize_1 WHERE "deletedAt" IS NULL AND "name" = $sequelize_2);`,
+    });
+    expect(bind).to.deep.eq({
+      sequelize_1: 'active',
+      sequelize_2: 'Alice',
+    });
+  });
+
   it('throws an error if the bindParam option is used', () => {
     const { User } = vars;
 


### PR DESCRIPTION
## Problem

`WhereSqlBuilder[Op.is]` (and `Op.isNot`, which delegates to it) contained:

```ts
if (options.bindParam) {
  delete options.bindParam;
}
```

`options` is the **same object reference** that is closed over by `formatWhereOptions` and threaded through every condition in the WHERE clause. Deleting `bindParam` from it mid-loop caused every sibling condition processed afterwards to fall through to inline escaping instead of emitting a bind parameter.

This fires silently for any `updateQuery` / `selectQuery` call whose WHERE clause mixes a `null` check with other values, because `null` on the RHS is automatically coerced to `Op.is` (see `formatPojoWhere` lines 311–316 and 320–327).

**Before (broken):**
```sql
-- WHERE { deletedAt: null, name: 'Alice' }
WHERE `deletedAt` IS NULL AND `name` = 'Alice'  -- 'Alice' inlined, not bound
-- bind = { sequelize_1: 'active' }              -- sequelize_2 never emitted
```

**After (fixed):**
```sql
WHERE `deletedAt` IS NULL AND `name` = $sequelize_2
-- bind = { sequelize_1: 'active', sequelize_2: 'Alice' }
```

## Fix

Shallow-copy `options` with `bindParam` set to `undefined` for the IS sub-call, leaving the shared reference untouched. This matches the pattern already used by `Op.in` and `Op.between`, which both do `{ ...options, ... }` before passing to sub-calls.

```ts
const isOptions = options.bindParam ? { ...options, bindParam: undefined } : options;
return this.formatBinaryOperation(left, undefined, operator, right, undefined, isOptions);
```

## Test

Added a case to `update-query.test.ts` that calls `updateQuery` with `WHERE { deletedAt: null, name: 'Alice' }` and asserts that `name` produces a bind parameter (`$sequelize_2`), not an inline literal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UPDATE query SQL generation to preserve bind parameters when combining multiple WHERE conditions with `IS NULL`, preventing incorrect inlining caused by shared formatting options.

* **Tests**
  * Added a regression unit test covering multiple dialects to verify generated UPDATE SQL and the resulting bind values when `IS NULL` is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->