### PR TITLE
fix(mariadb):  do not automatically parse JSON fields by checking type format

### DIFF
--- a/packages/mariadb/src/query.js
+++ b/packages/mariadb/src/query.js
@@ -189,11 +189,10 @@ export class MariaDbQuery extends AbstractQuery {
         // Value is returned as String, not JSON
         rows = rows.map(row => {
           // JSON fields for MariaDB server 10.5.2+ already results in JSON format so we can skip JSON.parse
-          // In this case the column type field will be MYSQL_TYPE_STRING, but the extended type will indicate 'json'
           if (
             row[modelField.fieldName] &&
             typeof row[modelField.fieldName] === 'string' &&
-            (!meta[i] || meta[i].dataTypeFormat !== 'json')
+            !meta[i].isDataTypeFormatJson()
           ) {
             row[modelField.fieldName] = JSON.parse(row[modelField.fieldName]);
           }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

this is related to #15704 :

mariadb-connector already parse JSON field base, to have a deterministic way to check if the data are already parsed or not we have to use the `dataTypeFormat` of the field.


in a [recent commit](https://github.com/mariadb-corporation/mariadb-connector-nodejs/commit/dbd547268a5b06bed5a8294409a57255d166b3c4) mariadb-connector renamed the `dataTypeFormat` field we rely on into `_dataTypeFormat` field and expose `isDataTypeFormatJson`. This PR use this method instead of relying on the internal `_dataTypeFormat`.

Note that I don't know why the test we made to check for this specific issue still pass, I wrote a gist with the same code as the test to show the issue:

https://gist.github.com/lesion/0b3e001f75c1fa89593ff365c2e931f7?permalink_comment_id=6216115#gistcomment-6216115

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON values returned from MariaDB queries so string fields are parsed more reliably.
  * Reduced cases where JSON data could be skipped or misread when metadata is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->