### PR TITLE
feat: add VARBINARY data type

### DIFF
--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -485,9 +485,8 @@ export class STRING extends AbstractDataType<string | Buffer> {
   }
 
   escape(value: string | Buffer): string {
-    if (Buffer.isBuffer(value)) {
-      return this._getDialect().escapeBuffer(value);
-    }
+    return this._getDialect().escapeBuffer(this.sanitize(value) as Buffer);
+  }
 
     return this._getDialect().escapeString(value);
   }
@@ -1779,7 +1778,7 @@ export interface VarbinaryOptions {
   length?: number;
 }
 
-export class VARBINARY extends AbstractDataType<Buffer | string> {
+export class VARBINARY extends AbstractDataType<Buffer | string | Uint8Array | ArrayBuffer> {
   /** @hidden */
   static readonly [DataTypeIdentifier]: string = 'VARBINARY';
   readonly options: VarbinaryOptions;
@@ -1798,7 +1797,7 @@ export class VARBINARY extends AbstractDataType<Buffer | string> {
     return `VARBINARY(${this.options.length ?? 255})`;
   }
 
-  validate(value: any): asserts value is Buffer | string {
+  validate(value: any): asserts value is Buffer | string | Uint8Array | ArrayBuffer {
     if (Buffer.isBuffer(value)) {
       return;
     }
@@ -1831,12 +1830,10 @@ export class VARBINARY extends AbstractDataType<Buffer | string> {
   }
 
   escape(value: string | Buffer): string {
-    const buf = typeof value === 'string' ? Buffer.from(value, 'binary') : value;
-
-    return this._getDialect().escapeBuffer(buf);
+    return this._getDialect().escapeBuffer(this.sanitize(value) as Buffer);
   }
 
-  toBindableValue(value: Buffer | string): unknown {
+  toBindableValue(value: Buffer | string | Uint8Array | ArrayBuffer): unknown {
     return this.sanitize(value);
   }
 }

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -1774,6 +1774,71 @@ export interface BlobOptions {
  * @category DataTypes
  */
 // TODO: add FIXED_BINARY & VAR_BINARY data types. They are not the same as CHAR BINARY / VARCHAR BINARY.
+
+export interface VarbinaryOptions {
+  length?: number;
+}
+
+export class VARBINARY extends AbstractDataType<Buffer | string> {
+  /** @hidden */
+  static readonly [DataTypeIdentifier]: string = 'VARBINARY';
+  readonly options: VarbinaryOptions;
+
+  constructor(lengthOrOptions?: number | VarbinaryOptions) {
+    super();
+
+    if (typeof lengthOrOptions === 'object') {
+      this.options = { length: lengthOrOptions.length };
+    } else {
+      this.options = { length: lengthOrOptions };
+    }
+  }
+
+  toSql(): string {
+    return `VARBINARY(${this.options.length ?? 255})`;
+  }
+
+  validate(value: any): asserts value is Buffer | string {
+    if (Buffer.isBuffer(value)) {
+      return;
+    }
+
+    if (typeof value === 'string') {
+      return;
+    }
+
+    if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+      return;
+    }
+
+    ValidationErrorItem.throwDataTypeValidationError(
+      `${util.inspect(value)} is not a valid binary value: Only strings, Buffer, Uint8Array and ArrayBuffer are supported.`,
+    );
+  }
+
+  sanitize(value: unknown): unknown {
+    if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+      return makeBufferFromTypedArray(value);
+    }
+
+    if (typeof value === 'string') {
+      return Buffer.from(value);
+    }
+
+    return value;
+  }
+
+  escape(value: string | Buffer): string {
+    const buf = typeof value === 'string' ? Buffer.from(value, 'binary') : value;
+
+    return this._getDialect().escapeBuffer(buf);
+  }
+
+  toBindableValue(value: Buffer | string): unknown {
+    return this.sanitize(value);
+  }
+}
+
 export class BLOB extends AbstractDataType<AcceptedBlob> {
   /** @hidden */
   static readonly [DataTypeIdentifier]: string = 'BLOB';

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -1746,7 +1746,7 @@ export class NOW extends AbstractDataType<never> {
   }
 }
 
-export type AcceptedBlob = Buffer | string;
+export type AcceptedBlob = Buffer | string | Uint8Array | ArrayBuffer;
 
 export type BlobLength = 'tiny' | 'medium' | 'long';
 
@@ -1898,10 +1898,14 @@ export class BLOB extends AbstractDataType<AcceptedBlob> {
     return value;
   }
 
-  escape(value: string | Buffer) {
-    const buf = typeof value === 'string' ? Buffer.from(value, 'binary') : value;
+  escape(value: string | Buffer | Uint8Array | ArrayBuffer) {
+    const buf = this.sanitize(value) as Buffer;
 
     return this._getDialect().escapeBuffer(buf);
+  }
+
+  toBindableValue(value: AcceptedBlob): unknown {
+    return this.sanitize(value);
   }
 
   getBindParamSql(value: AcceptedBlob, options: BindParamOptions) {

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -1811,6 +1811,8 @@ export class VARBINARY extends AbstractDataType<Buffer | string> {
       return;
     }
 
+    rejectBlobs(value);
+
     ValidationErrorItem.throwDataTypeValidationError(
       `${util.inspect(value)} is not a valid binary value: Only strings, Buffer, Uint8Array and ArrayBuffer are supported.`,
     );

--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -485,10 +485,13 @@ export class STRING extends AbstractDataType<string | Buffer> {
   }
 
   escape(value: string | Buffer): string {
-    return this._getDialect().escapeBuffer(this.sanitize(value) as Buffer);
-  }
+    const sanitized = this.sanitize(value);
 
-    return this._getDialect().escapeString(value);
+    if (this.options.binary) {
+      return this._getDialect().escapeBuffer(sanitized as Buffer);
+    }
+
+    return this._getDialect().escapeString(sanitized as string);
   }
 
   toBindableValue(value: string | Buffer): unknown {
@@ -1829,7 +1832,7 @@ export class VARBINARY extends AbstractDataType<Buffer | string | Uint8Array | A
     return value;
   }
 
-  escape(value: string | Buffer): string {
+  escape(value: Buffer | string | Uint8Array | ArrayBuffer): string {
     return this._getDialect().escapeBuffer(this.sanitize(value) as Buffer);
   }
 
@@ -1909,7 +1912,7 @@ export class BLOB extends AbstractDataType<AcceptedBlob> {
   }
 
   getBindParamSql(value: AcceptedBlob, options: BindParamOptions) {
-    return options.bindParam(value);
+    return options.bindParam(this.toBindableValue(value));
   }
 }
 

--- a/packages/core/src/data-types.ts
+++ b/packages/core/src/data-types.ts
@@ -77,6 +77,8 @@ export const GEOMETRY = classToInvokable(DataTypes.GEOMETRY);
 /** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const GEOGRAPHY = classToInvokable(DataTypes.GEOGRAPHY);
 /** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
+export const VARBINARY = classToInvokable(DataTypes.VARBINARY);
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const CIDR = classToInvokable(DataTypes.CIDR);
 /** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const INET = classToInvokable(DataTypes.INET);


### PR DESCRIPTION
## Description
Adds native VARBINARY data type support. This maps to `VARBINARY(length)` in MySQL.

Fixes #5981

### Motivation
Sequelize currently doesn't have a native data type that maps to VARBINARY in MySQL. This is becoming increasingly important due to utf8mb4 charset limitations where VARCHAR(255) with InnoDB leads to indexes that are too large.

Note: `STRING.BINARY` does not work for this use case because it maps to `VARCHAR(255) BINARY` which still uses utf8mb4 and 4 bytes per character in indexes.

### Usage
```ts
// Default length (255)
const model = sequelize.define('User', {
  token: DataTypes.VARBINARY,
});

// Custom length
const model = sequelize.define('User', {
  token: DataTypes.VARBINARY(512),
});

// Or with options
const model = sequelize.define('User', {
  token: DataTypes.VARBINARY({ length: 1024 }),
});
```

### Changes
- Added `VARBINARY` class in `packages/core/src/abstract-dialect/data-types.ts`
- Exported `VARBINARY` from `packages/core/src/data-types.ts`
- Supports `length` parameter (default: 255)
- Validates Buffer, string, Uint8Array, and ArrayBuffer inputs
- Proper escape and bind parameter support

### MySQL SQL Output
```sql
CREATE TABLE users (
  token VARBINARY(255)  -- default
  token VARBINARY(512)  -- custom length
);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `VARBINARY` data type with configurable length (default: 255), exposed via the main data types API.
  * Accepts `Buffer`, `string`, `Uint8Array`, or `ArrayBuffer`, with consistent handling for both inline SQL and bind parameters.
* **Bug Fixes**
  * Improved `STRING` escaping behavior in binary mode by consistently sanitizing input before escaping.
  * Enhanced `BLOB` support to accept `Uint8Array` and `ArrayBuffer`, ensuring bind/inline values use the sanitized form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->