### PR TITLE
fix(core): make empty Op.notIn compose correctly under Op.or and Op.not

### DIFF
--- a/packages/core/src/abstract-dialect/where-sql-builder.ts
+++ b/packages/core/src/abstract-dialect/where-sql-builder.ts
@@ -370,7 +370,7 @@ export class WhereSqlBuilder {
         // - always false if the operator is IN
         // - always true if the operator is NOT IN
         if (operator === Op.notIn) {
-          return '';
+          return '1 = 1';
         }
 
         rightSql = '(NULL)';

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -124,8 +124,14 @@ describe(getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    it('returns an empty string if the input results in an empty query', () => {
+    it('returns WHERE 1 = 1 if the input is an always true Op.notIn: [] query', () => {
       expectsql(queryGen.whereQuery({ firstName: { [Op.notIn]: [] } }), {
+        default: 'WHERE 1 = 1',
+      });
+    });
+
+    it('returns an empty string if the input results in an empty query', () => {
+      expectsql(queryGen.whereQuery({}), {
         default: '',
       });
     });
@@ -1533,10 +1539,33 @@ Caused by: "undefined" cannot be escaped`),
     });
 
     describeInSuite(Op.notIn, 'NOT IN', () => {
+      // an empty Op.notIn produces the always-true condition `1 = 1`,
+      // because an empty string would be silently dropped under Op.or and Op.not
       testSql(
         { intAttr1: { [Op.notIn]: [] } },
         {
-          default: '',
+          default: '1 = 1',
+        },
+      );
+
+      testSql(
+        { [Op.or]: [{ intAttr1: { [Op.notIn]: [] } }, { intAttr2: 5 }] },
+        {
+          default: '1 = 1 OR [intAttr2] = 5',
+        },
+      );
+
+      testSql(
+        { [Op.not]: { intAttr1: { [Op.notIn]: [] } } },
+        {
+          default: 'NOT (1 = 1)',
+        },
+      );
+
+      testSql(
+        { [Op.and]: [{ intAttr1: { [Op.notIn]: [] } }, { intAttr2: 5 }] },
+        {
+          default: '1 = 1 AND [intAttr2] = 5',
         },
       );
     });

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -1539,8 +1539,6 @@ Caused by: "undefined" cannot be escaped`),
     });
 
     describeInSuite(Op.notIn, 'NOT IN', () => {
-      // an empty Op.notIn produces the always-true condition `1 = 1`,
-      // because an empty string would be silently dropped under Op.or and Op.not
       testSql(
         { intAttr1: { [Op.notIn]: [] } },
         {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Not needed: no documented behavior changes -->
- [x] Did you update the typescript typings accordingly (if applicable)? <!-- Not applicable -->
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Closes #18248

An empty `Op.notIn` array is logically always true (`NOT IN ()` matches every row), and Sequelize special-cased it by emitting an empty string. An empty fragment is a safe identity only for `AND`: both `joinWithLogicalOperator` (which filters out empty fragments) and `wrapWithNot` (which returns `''` for empty input) silently drop it, changing the meaning of the query when it is composed:

```js
// (age NOT IN ()) is always true, so OR should match every row:
User.findAll({ where: { [Op.or]: [{ age: { [Op.notIn]: [] } }, { name: 'zzz' }] } });
// before: WHERE `name` = 'zzz'          -> wrong rows
// after:  WHERE 1 = 1 OR `name` = 'zzz' -> all rows ✔

// NOT(always-true) should match no rows:
User.findAll({ where: { [Op.not]: { age: { [Op.notIn]: [] } } } });
// before: no WHERE clause    -> all rows
// after:  WHERE NOT (1 = 1)  -> no rows ✔
```

An empty `Op.notIn` now emits `1 = 1` — an always-true condition valid in every supported dialect — mirroring how an empty `Op.in` emits the always-false `IN (NULL)`.

Added regression tests covering the emitted fragment itself and its composition under `Op.or`, `Op.not` and `Op.and`.

Note: a top-level `{ [Op.notIn]: [] }` now generates `WHERE 1 = 1` instead of omitting the WHERE clause entirely. This is semantically identical (all rows, preserving #4859 / #4860), but code asserting on the exact generated SQL will see a difference.

Credit: root cause analysis and suggested approach by @tsushanth in #18248.

## List of Breaking Changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty `NOT IN` filters to emit a valid always-true predicate instead of being omitted from the query.
  * Improved consistency when empty `NOT IN` appears inside `AND`, `OR`, and `NOT` combinations.

* **Tests**
  * Updated SQL query expectations for empty `NOT IN`.
  * Added test coverage for nested empty `NOT IN` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->