### PR TITLE
fix(core): resolve VIRTUAL attributes on included models

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -612,6 +612,16 @@ ${associationOwner._getAssociationDebugList()}`);
         });
       }
     } else {
+      // No explicit attributes were requested for this include, so every attribute is selected.
+      // Mirror the top-level default (see _findAll) so that the built instance's `_options.attributes`
+      // lists the virtual attributes too; otherwise `get()` skips their getters and they are dropped
+      // from `toJSON()` output for included models.
+      if (!options.raw) {
+        include.originalAttributes = include.model._injectDependentVirtualAttributes(
+          Array.from(include.model.modelDefinition.attributes.keys()),
+        );
+      }
+
       include = mapFinderOptions(include, include.model);
     }
 

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -612,16 +612,6 @@ ${associationOwner._getAssociationDebugList()}`);
         });
       }
     } else {
-      // No explicit attributes were requested for this include, so every attribute is selected.
-      // Mirror the top-level default (see _findAll) so that the built instance's `_options.attributes`
-      // lists the virtual attributes too; otherwise `get()` skips their getters and they are dropped
-      // from `toJSON()` output for included models.
-      if (!options.raw) {
-        include.originalAttributes = include.model._injectDependentVirtualAttributes(
-          Array.from(include.model.modelDefinition.attributes.keys()),
-        );
-      }
-
       include = mapFinderOptions(include, include.model);
     }
 
@@ -684,6 +674,19 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     model._injectScope(include);
+
+    // When no explicit attributes were requested, mirror the top-level default (see _findAll) so the
+    // built instance's `_options.attributes` lists virtual attributes too — otherwise `get()` skips
+    // their getters and they are dropped from `toJSON()` output for included models. This must run
+    // after `_injectScope` (which may narrow `include.attributes` via a scope) and before the
+    // concrete-column default below, so a scoped include derives `originalAttributes` from the scoped
+    // list (not running getters whose dependencies the scope excluded) while an unscoped include falls
+    // back to the full attribute list, virtuals included.
+    if (include.originalAttributes === undefined && !options.raw) {
+      include.originalAttributes = include.model._injectDependentVirtualAttributes(
+        include.attributes ?? Array.from(include.model.modelDefinition.attributes.keys()),
+      );
+    }
 
     // This check should happen after injecting the scope, since the scope may contain a .attributes
     if (!include.attributes) {

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -683,6 +683,9 @@ ${associationOwner._getAssociationDebugList()}`);
     // list (not running getters whose dependencies the scope excluded) while an unscoped include falls
     // back to the full attribute list, virtuals included.
     if (include.originalAttributes === undefined && !options.raw) {
+      // A scope may supply `attributes` in the `{ include, exclude }` object form; expand it first so
+      // `originalAttributes` is always a list, which is what `_setInclude` expects.
+      include.model._expandAttributes(include);
       include.originalAttributes = include.model._injectDependentVirtualAttributes(
         include.attributes ?? Array.from(include.model.modelDefinition.attributes.keys()),
       );

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -675,16 +675,8 @@ ${associationOwner._getAssociationDebugList()}`);
 
     model._injectScope(include);
 
-    // When no explicit attributes were requested, mirror the top-level default (see _findAll) so the
-    // built instance's `_options.attributes` lists virtual attributes too — otherwise `get()` skips
-    // their getters and they are dropped from `toJSON()` output for included models. This must run
-    // after `_injectScope` (which may narrow `include.attributes` via a scope) and before the
-    // concrete-column default below, so a scoped include derives `originalAttributes` from the scoped
-    // list (not running getters whose dependencies the scope excluded) while an unscoped include falls
-    // back to the full attribute list, virtuals included.
+    // Mirror the top-level default from _findAll, so get() on the included instance also runs its virtual getters.
     if (include.originalAttributes === undefined && !options.raw) {
-      // A scope may supply `attributes` in the `{ include, exclude }` object form; expand it first so
-      // `originalAttributes` is always a list, which is what `_setInclude` expects.
       include.model._expandAttributes(include);
       include.originalAttributes = include.model._injectDependentVirtualAttributes(
         include.attributes ?? Array.from(include.model.modelDefinition.attributes.keys()),

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -132,6 +132,41 @@ Instead of specifying a Model, either:
       expect(user.toJSON().avatar.url).to.equal('/img/a.png');
     });
 
+    it('does not run a scope-excluded VIRTUAL getter on an included model (#18059)', async function () {
+      const File = this.sequelize.define(
+        'File',
+        {
+          name: { type: DataTypes.STRING, allowNull: false },
+          path: { type: DataTypes.STRING, allowNull: false },
+          url: {
+            type: DataTypes.VIRTUAL(DataTypes.STRING, ['name', 'path']),
+            get() {
+              return `${this.path}/${this.name}`;
+            },
+          },
+        },
+        {
+          // The default scope narrows the selection to `name` only, so `path` (a dependency of the
+          // `url` virtual) is not loaded. The included instance must mirror a top-level scoped query
+          // and NOT expose `url`, rather than computing it from an unloaded `path`.
+          defaultScope: { attributes: ['id', 'name'] },
+        },
+      );
+      const User = this.sequelize.define('User', {});
+      User.belongsTo(File, { as: 'avatar', foreignKey: 'avatarFileId' });
+
+      await this.sequelize.sync({ force: true });
+
+      const file = await File.withoutScope().create({ name: 'a.png', path: '/img' });
+      await User.create({ avatarFileId: file.id });
+
+      const user = await User.findOne({ include: ['avatar'] });
+
+      // `path` was excluded by the scope, so the virtual `url` must not appear in the output.
+      expect(user.avatar.get('path')).to.be.undefined;
+      expect(user.toJSON().avatar).to.not.have.property('url');
+    });
+
     it('should support to use associations with Sequelize.col', async function () {
       const Table1 = this.sequelize.define('Table1');
       const Table2 = this.sequelize.define('Table2');

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -107,6 +107,31 @@ Instead of specifying a Model, either:
       expect(user).to.be.ok;
     });
 
+    it('resolves VIRTUAL attributes on an included model (#18059)', async function () {
+      const File = this.sequelize.define('File', {
+        name: { type: DataTypes.STRING, allowNull: false },
+        path: { type: DataTypes.STRING, allowNull: false },
+        url: {
+          type: DataTypes.VIRTUAL(DataTypes.STRING, ['name', 'path']),
+          get() {
+            return `${this.path}/${this.name}`;
+          },
+        },
+      });
+      const User = this.sequelize.define('User', {});
+      User.belongsTo(File, { as: 'avatar', foreignKey: 'avatarFileId' });
+
+      await this.sequelize.sync({ force: true });
+
+      const file = await File.create({ name: 'a.png', path: '/img' });
+      await User.create({ avatarFileId: file.id });
+
+      const user = await User.findOne({ include: ['avatar'] });
+
+      expect(user.avatar.get('url')).to.equal('/img/a.png');
+      expect(user.toJSON().avatar.url).to.equal('/img/a.png');
+    });
+
     it('should support to use associations with Sequelize.col', async function () {
       const Table1 = this.sequelize.define('Table1');
       const Table2 = this.sequelize.define('Table2');

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -167,6 +167,42 @@ Instead of specifying a Model, either:
       expect(user.toJSON().avatar).to.not.have.property('url');
     });
 
+    it('hydrates an included model whose scope excludes attributes with an object (#18059)', async function () {
+      const File = this.sequelize.define(
+        'File',
+        {
+          name: { type: DataTypes.STRING, allowNull: false },
+          path: { type: DataTypes.STRING, allowNull: false },
+          secret: DataTypes.STRING,
+          url: {
+            type: DataTypes.VIRTUAL(DataTypes.STRING, ['name', 'path']),
+            get() {
+              return `${this.path}/${this.name}`;
+            },
+          },
+        },
+        {
+          // The object form of `attributes` must be expanded before it is recorded as the included
+          // instance's attribute list, otherwise the association is not hydrated at all.
+          defaultScope: { attributes: { exclude: ['secret'] } },
+        },
+      );
+      const User = this.sequelize.define('User', {});
+      User.belongsTo(File, { as: 'avatar', foreignKey: 'avatarFileId' });
+
+      await this.sequelize.sync({ force: true });
+
+      const file = await File.withoutScope().create({ name: 'a.png', path: '/img', secret: 's' });
+      await User.create({ avatarFileId: file.id });
+
+      const user = await User.findOne({ include: ['avatar'] });
+
+      expect(user.avatar).to.be.ok;
+      expect(user.avatar.get('secret')).to.be.undefined;
+      expect(user.avatar.get('url')).to.equal('/img/a.png');
+      expect(user.toJSON().avatar.url).to.equal('/img/a.png');
+    });
+
     it('should support to use associations with Sequelize.col', async function () {
       const Table1 = this.sequelize.define('Table1');
       const Table2 = this.sequelize.define('Table2');

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -146,9 +146,6 @@ Instead of specifying a Model, either:
           },
         },
         {
-          // The default scope narrows the selection to `name` only, so `path` (a dependency of the
-          // `url` virtual) is not loaded. The included instance must mirror a top-level scoped query
-          // and NOT expose `url`, rather than computing it from an unloaded `path`.
           defaultScope: { attributes: ['id', 'name'] },
         },
       );
@@ -162,7 +159,6 @@ Instead of specifying a Model, either:
 
       const user = await User.findOne({ include: ['avatar'] });
 
-      // `path` was excluded by the scope, so the virtual `url` must not appear in the output.
       expect(user.avatar.get('path')).to.be.undefined;
       expect(user.toJSON().avatar).to.not.have.property('url');
     });
@@ -182,8 +178,6 @@ Instead of specifying a Model, either:
           },
         },
         {
-          // The object form of `attributes` must be expanded before it is recorded as the included
-          // instance's attribute list, otherwise the association is not hydrated at all.
           defaultScope: { attributes: { exclude: ['secret'] } },
         },
       );


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to the documentation repository?
- [x] Did you update the typescript typings accordingly (if applicable)? — no typings change needed.
- [x] Does the description below contain a link to an existing issue (Closes #issue)?
- [x] Does the name of your PR follow our conventions?

## Description of Changes

Closes #18059.

When a model with a `DataTypes.VIRTUAL(type, [deps])` attribute is loaded through an association `include` (e.g. `User.findAll({ include: ['avatar'] })`), the virtual attribute was missing from `get()` / `toJSON()` output, even though it resolves correctly at the top level (`File.findAll()`).

### Root cause

`Model#get` only computes an attribute's getter when the attribute is present in `this._options.attributes`:

```js
for (const attributeName of attributesWithGetters) {
  if (!this._options.attributes?.includes(attributeName)) {
    continue;
  }
  values[attributeName] = this.get(attributeName, options);
}
```

For a top-level query without explicit `attributes`, `_findAll` defaults `options.attributes` to the full attribute list (virtuals included), so the getters run. The include path had no equivalent default: when an `include` selects all attributes, `include.originalAttributes` was left `undefined`, so the built child instance's `_options.attributes` was `undefined` and every getter — including the virtual one — was skipped.

### Fix

Mirror the top-level default in `_validateIncludedElement`: when an include has no explicit `attributes` (and isn't `raw`), populate `include.originalAttributes` with the full attribute list via `_injectDependentVirtualAttributes`, so the included instance exposes its virtual getters. SQL is unaffected — `originalAttributes` only drives instance construction, not column selection.

### Test

Added an integration test under `Include > find` that defines a `File` with a `VIRTUAL(STRING, ['name','path'])` `url` getter, associates it via `belongsTo` as `avatar`, and asserts the included `avatar.url` resolves through both `get()` and `toJSON()`. Verified it fails on `main` and passes with this change. Full include + associations integration suites pass (343 tests, sqlite3).

## List of Breaking Changes

None.

---

AI assistance: this change was developed with the help of an AI coding assistant (disclosed via the `Co-Authored-By` trailer). I have reviewed and understand every line and can defend the reasoning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed virtual attributes on included associated records so their getters are correctly evaluated when dependencies are available.
  * Preserved expected behavior when virtual attribute dependencies are excluded by a scope.

* **Tests**
  * Added integration coverage for virtual attributes on aliased included associations.
  * Added scenarios covering dependency exclusions and object-form scope attribute exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->