### PR TITLE
fix(postgres): keep USING clause out of COMMENT ON COLUMN when altering ENUM

### DIFF
--- a/packages/core/test/integration/query-interface/add-column.test.ts
+++ b/packages/core/test/integration/query-interface/add-column.test.ts
@@ -30,7 +30,7 @@ describe('QueryInterface#addColumn', () => {
 
     const table = await queryInterface.describeTable('users');
 
-    expect(table.status.special).to.deep.equal(['active', 'pending']);
+    expect(table.status.type).to.equal('USER-DEFINED');
     expect(table.status.comment).to.equal('Status (active/pending)');
   });
 

--- a/packages/core/test/integration/query-interface/add-column.test.ts
+++ b/packages/core/test/integration/query-interface/add-column.test.ts
@@ -5,8 +5,6 @@ import { getTestDialect, sequelize } from '../support';
 const dialectName = getTestDialect();
 const queryInterface = sequelize.queryInterface;
 
-// Column comments have no `dialect.supports` flag; on PostgreSQL they are emitted as a
-// separate statement, which is what these tests cover.
 describe('QueryInterface#addColumn', () => {
   if (dialectName !== 'postgres') {
     return;

--- a/packages/core/test/integration/query-interface/add-column.test.ts
+++ b/packages/core/test/integration/query-interface/add-column.test.ts
@@ -1,0 +1,53 @@
+import { DataTypes } from '@sequelize/core';
+import { expect } from 'chai';
+import { getTestDialect, sequelize } from '../support';
+
+const dialectName = getTestDialect();
+const queryInterface = sequelize.queryInterface;
+
+// Column comments have no `dialect.supports` flag; on PostgreSQL they are emitted as a
+// separate statement, which is what these tests cover.
+describe('QueryInterface#addColumn', () => {
+  if (dialectName !== 'postgres') {
+    return;
+  }
+
+  beforeEach(async () => {
+    await queryInterface.createTable('users', {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+    });
+  });
+
+  it('adds an enum column with a comment containing parentheses', async () => {
+    await queryInterface.addColumn('users', 'status', {
+      type: DataTypes.ENUM(['active', 'pending']),
+      comment: 'Status (active/pending)',
+    });
+
+    const table = await queryInterface.describeTable('users');
+
+    expect(table.status.special).to.deep.equal(['active', 'pending']);
+    expect(table.status.comment).to.equal('Status (active/pending)');
+  });
+
+  const keywordComments = [
+    { keyword: 'SERIAL', type: DataTypes.INTEGER, comment: 'legacy SERIAL id' },
+    { keyword: 'PRIMARY KEY', type: DataTypes.STRING, comment: 'was PRIMARY KEY once' },
+    { keyword: 'NOT NULL', type: DataTypes.STRING, comment: 'do NOT NULL this' },
+  ];
+
+  for (const { comment, keyword, type } of keywordComments) {
+    it(`adds a column with a comment containing ${keyword}`, async () => {
+      await queryInterface.addColumn('users', 'value', { type, comment });
+
+      const table = await queryInterface.describeTable('users');
+
+      expect(table.value.comment).to.equal(comment);
+      expect(table.value.allowNull).to.be.true;
+    });
+  }
+});

--- a/packages/core/test/integration/query-interface/changeColumn.test.js
+++ b/packages/core/test/integration/query-interface/changeColumn.test.js
@@ -157,6 +157,26 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           );
         });
       }
+
+      if (dialect === 'postgres') {
+        it('should work with enums with comments containing parentheses', async function () {
+          await this.queryInterface.createTable('users', {
+            status: DataTypes.STRING,
+          });
+
+          await this.queryInterface.changeColumn('users', 'status', {
+            type: DataTypes.ENUM(['pending', 'complete']),
+            allowNull: false,
+            comment: 'Amount (in cents)',
+          });
+
+          const table = await this.queryInterface.describeTable('users');
+
+          expect(table.status.type).to.equal("ENUM('pending','complete')");
+          expect(table.status.allowNull).to.be.false;
+          expect(table.status.comment).to.equal('Amount (in cents)');
+        });
+      }
     }
 
     describe('should support foreign keys', () => {

--- a/packages/core/test/integration/query-interface/changeColumn.test.js
+++ b/packages/core/test/integration/query-interface/changeColumn.test.js
@@ -172,7 +172,8 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
 
           const table = await this.queryInterface.describeTable('users');
 
-          expect(table.status.type).to.equal("ENUM('pending','complete')");
+          expect(table.status.type).to.equal('USER-DEFINED');
+          expect(table.status.special).to.deep.equal(['pending', 'complete']);
           expect(table.status.allowNull).to.be.false;
           expect(table.status.comment).to.equal('Amount (in cents)');
         });

--- a/packages/core/test/integration/query-interface/changeColumn.test.js
+++ b/packages/core/test/integration/query-interface/changeColumn.test.js
@@ -177,6 +177,42 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           expect(table.status.allowNull).to.be.false;
           expect(table.status.comment).to.equal('Amount (in cents)');
         });
+
+        const keywordComments = [
+          { keyword: 'NOT NULL', type: DataTypes.STRING, comment: 'do NOT NULL this' },
+          { keyword: 'PRIMARY KEY', type: DataTypes.STRING, comment: 'was PRIMARY KEY once' },
+          { keyword: 'DEFAULT', type: DataTypes.STRING, comment: 'the DEFAULT value' },
+          { keyword: 'REFERENCES', type: DataTypes.STRING, comment: 'REFERENCES other table' },
+          { keyword: 'UNIQUE', type: DataTypes.STRING, comment: 'must be UNIQUE' },
+          { keyword: 'SERIAL', type: DataTypes.INTEGER, comment: 'legacy SERIAL id' },
+        ];
+
+        for (const { comment, keyword, type } of keywordComments) {
+          it(`should not let a comment containing ${keyword} change the column definition`, async function () {
+            await this.queryInterface.createTable('users', { value: type });
+
+            await this.queryInterface.changeColumn('users', 'value', { type, comment });
+
+            const table = await this.queryInterface.describeTable('users');
+
+            expect(table.value.comment).to.equal(comment);
+            expect(table.value.allowNull).to.be.true;
+          });
+        }
+
+        it('should keep a comment containing REFERENCES intact on an enum column', async function () {
+          await this.queryInterface.createTable('users', { status: DataTypes.STRING });
+
+          await this.queryInterface.changeColumn('users', 'status', {
+            type: DataTypes.ENUM(['pending', 'complete']),
+            comment: 'REFERENCES the old (legacy) table',
+          });
+
+          const table = await this.queryInterface.describeTable('users');
+
+          expect(table.status.special).to.deep.equal(['pending', 'complete']);
+          expect(table.status.comment).to.equal('REFERENCES the old (legacy) table');
+        });
       }
     }
 

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -172,9 +172,7 @@ if (dialect.startsWith('postgres')) {
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
         {
-          // The USING clause must stay attached to the ALTER COLUMN ... TYPE statement
-          // and must not leak into the separate COMMENT ON COLUMN statement, which does
-          // not support USING (see https://github.com/sequelize/sequelize/issues/17894).
+          // #17894: USING must stay on ALTER COLUMN ... TYPE, not on COMMENT ON COLUMN
           arguments: [
             'myTable',
             {

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -171,6 +171,18 @@ if (dialect.startsWith('postgres')) {
           ],
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
+        {
+          // The USING clause must stay attached to the ALTER COLUMN ... TYPE statement
+          // and must not leak into the separate COMMENT ON COLUMN statement, which does
+          // not support USING (see https://github.com/sequelize/sequelize/issues/17894).
+          arguments: [
+            'myTable',
+            {
+              col_1: `ENUM('value 1', 'value 2') NOT NULL; COMMENT ON COLUMN "myTable"."col_1" IS 'my comment'`,
+            },
+          ],
+          expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1"); COMMENT ON COLUMN "myTable"."col_1" IS 'my comment';`,
+        },
       ],
 
       selectQuery: [

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -185,6 +185,18 @@ if (dialect.startsWith('postgres')) {
           ],
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
+        {
+          // The USING clause must stay attached to the ALTER COLUMN ... TYPE statement
+          // and must not leak into the separate COMMENT ON COLUMN statement, which does
+          // not support USING (see https://github.com/sequelize/sequelize/issues/17894).
+          arguments: [
+            'myTable',
+            {
+              col_1: `ENUM('value 1', 'value 2') NOT NULL; COMMENT ON COLUMN "myTable"."col_1" IS 'my comment'`,
+            },
+          ],
+          expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1"); COMMENT ON COLUMN "myTable"."col_1" IS 'my comment';`,
+        },
       ],
 
       selectQuery: [

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -186,7 +186,6 @@ if (dialect.startsWith('postgres')) {
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
         {
-          // #17894: USING must stay on ALTER COLUMN ... TYPE, not on COMMENT ON COLUMN
           arguments: [
             'myTable',
             {

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -186,9 +186,7 @@ if (dialect.startsWith('postgres')) {
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
         {
-          // The USING clause must stay attached to the ALTER COLUMN ... TYPE statement
-          // and must not leak into the separate COMMENT ON COLUMN statement, which does
-          // not support USING (see https://github.com/sequelize/sequelize/issues/17894).
+          // #17894: USING must stay on ALTER COLUMN ... TYPE, not on COMMENT ON COLUMN
           arguments: [
             'myTable',
             {

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -190,10 +190,10 @@ if (dialect.startsWith('postgres')) {
           arguments: [
             'myTable',
             {
-              col_1: `ENUM('value 1', 'value 2') NOT NULL; COMMENT ON COLUMN "myTable"."col_1" IS 'my comment'`,
+              col_1: `ENUM('value 1', 'value 2') NOT NULL; COMMENT ON COLUMN "myTable"."col_1" IS 'my comment (v2)'`,
             },
           ],
-          expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1"); COMMENT ON COLUMN "myTable"."col_1" IS 'my comment';`,
+          expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1"); COMMENT ON COLUMN "myTable"."col_1" IS 'my comment (v2)';`,
         },
       ],
 

--- a/packages/core/test/unit/sql/add-column.test.js
+++ b/packages/core/test/unit/sql/add-column.test.js
@@ -95,6 +95,25 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     }
 
+    if (current.dialect.name === 'postgres') {
+      it('keeps a column comment out of the type definition', () => {
+        return expectsql(
+          queryGenerator.addColumnQuery(
+            'Users',
+            'status',
+            current.normalizeAttribute({
+              type: DataTypes.ENUM(['active', 'pending']),
+              comment: 'Status (active/pending)',
+            }),
+          ),
+          {
+            postgres:
+              'DO \'BEGIN CREATE TYPE "public"."enum_Users_status" AS ENUM(\'\'active\'\', \'\'pending\'\'); EXCEPTION WHEN duplicate_object THEN null; END\';ALTER TABLE "Users" ADD COLUMN  "status" "public"."enum_Users_status"; COMMENT ON COLUMN "Users"."status" IS \'Status (active/pending)\';',
+          },
+        );
+      });
+    }
+
     it('defaults the schema to the one set in the Sequelize options', () => {
       const User = customSequelize.define('User', {}, { timestamps: false });
 

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -142,6 +142,17 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       let definition = this.dataTypeMapping(tableName, attributeName, attributes[attributeName]);
       let attrSql = '';
 
+      // Split off the trailing `; COMMENT ON COLUMN` statement (built the same way in
+      // attributesToSQL above) so the column-type rewrites below operate on the type only.
+      // It is re-appended after this column's ALTER statements; drop its leading `;` (the
+      // preceding statement already ends in one) and terminate it with its own `;`.
+      let columnComment = '';
+      const commentIndex = definition.indexOf('; COMMENT ON COLUMN');
+      if (commentIndex !== -1) {
+        columnComment = `${definition.slice(commentIndex + 1)};`;
+        definition = definition.slice(0, commentIndex).trimEnd();
+      }
+
       if (definition.includes('NOT NULL')) {
         attrSql += query(`${this.quoteIdentifier(attributeName)} SET NOT NULL`);
 
@@ -186,7 +197,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
         attrSql += query(`${this.quoteIdentifier(attributeName)} TYPE ${definition}`);
       }
 
-      sql.push(attrSql);
+      sql.push(attrSql + columnComment);
     }
 
     return sql.join('');

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -142,15 +142,12 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       let definition = this.dataTypeMapping(tableName, attributeName, attributes[attributeName]);
       let attrSql = '';
 
-      // Split off the trailing `; COMMENT ON COLUMN` statement (built the same way in
-      // attributesToSQL above) so the column-type rewrites below operate on the type only.
-      // It is re-appended after this column's ALTER statements; drop its leading `;` (the
-      // preceding statement already ends in one) and terminate it with its own `;`.
       let columnComment = '';
-      const commentIndex = definition.indexOf('; COMMENT ON COLUMN');
-      if (commentIndex !== -1) {
-        columnComment = `${definition.slice(commentIndex + 1)};`;
-        definition = definition.slice(0, commentIndex).trimEnd();
+      const i = definition.indexOf('; COMMENT ON COLUMN');
+      if (i !== -1) {
+        // Move comment to a separate query
+        columnComment = `${definition.slice(i + 1)};`;
+        definition = definition.slice(0, i);
       }
 
       if (definition.includes('NOT NULL')) {

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -139,16 +139,18 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     const query = subQuery => `ALTER TABLE ${this.quoteTable(tableName)} ALTER COLUMN ${subQuery};`;
     const sql = [];
     for (const attributeName in attributes) {
-      let definition = this.dataTypeMapping(tableName, attributeName, attributes[attributeName]);
-      let attrSql = '';
-
+      let rawDefinition = attributes[attributeName];
       let columnComment = '';
-      const i = definition.indexOf('; COMMENT ON COLUMN');
+      const commentPrefix = `; COMMENT ON COLUMN ${this.quoteTable(tableName)}.${this.quoteIdentifier(attributeName)} IS `;
+      const i = rawDefinition.indexOf(commentPrefix);
       if (i !== -1) {
         // Move comment to a separate query
-        columnComment = `${definition.slice(i + 1)};`;
-        definition = definition.slice(0, i);
+        columnComment = `${rawDefinition.slice(i + 1)};`;
+        rawDefinition = rawDefinition.slice(0, i);
       }
+
+      let definition = this.dataTypeMapping(tableName, attributeName, rawDefinition);
+      let attrSql = '';
 
       if (definition.includes('NOT NULL')) {
         attrSql += query(`${this.quoteIdentifier(attributeName)} SET NOT NULL`);
@@ -168,12 +170,8 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
         attrSql += query(`${this.quoteIdentifier(attributeName)} DROP DEFAULT`);
       }
 
-      if (attributes[attributeName].startsWith('ENUM(')) {
-        attrSql += this.pgEnum(tableName, attributeName, attributes[attributeName]);
-        definition = definition.replace(
-          /^ENUM\(.+\)/,
-          this.pgEnumName(tableName, attributeName, { schema: false }),
-        );
+      if (rawDefinition.startsWith('ENUM(')) {
+        attrSql += this.pgEnum(tableName, attributeName, rawDefinition);
         definition += ` USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(tableName, attributeName)})`;
       }
 

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -114,14 +114,24 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   addColumnQuery(table, key, attribute, options) {
     options ||= {};
 
-    const dbDataType = this.attributeToSQL(attribute, { context: 'addColumn', table, key });
+    let dbDataType = this.attributeToSQL(attribute, { context: 'addColumn', table, key });
     const dataType = attribute.type || attribute;
-    const definition = this.dataTypeMapping(table, key, dbDataType);
     const quotedKey = this.quoteIdentifier(key);
     const quotedTable = this.quoteTable(table);
     const ifNotExists = options.ifNotExists ? ' IF NOT EXISTS' : '';
 
-    let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${ifNotExists} ${quotedKey} ${definition};`;
+    let columnComment = '';
+    const commentPrefix = `; COMMENT ON COLUMN ${quotedTable}.${quotedKey} IS `;
+    const commentIndex = dbDataType.indexOf(commentPrefix);
+    if (commentIndex !== -1) {
+      // Move comment to a separate query
+      columnComment = `${dbDataType.slice(commentIndex + 1)};`;
+      dbDataType = dbDataType.slice(0, commentIndex);
+    }
+
+    const definition = this.dataTypeMapping(table, key, dbDataType);
+
+    let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${ifNotExists} ${quotedKey} ${definition};${columnComment}`;
 
     if (dataType instanceof DataTypes.ENUM) {
       query = this.pgEnum(table, key, dataType) + query;


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to the documentation repository? (Not needed for this bug fix.)
- [ ] Did you update the typescript typings accordingly (if applicable)? (No public type changes.)
- [x] Does the description below contain a link to an existing issue or a description of the issue you are solving?
- [x] Does the name of your PR follow our conventions?

## Description of Changes

PostgreSQL column comments were processed as part of the SQL type definition during `changeColumn` and `addColumn`. Parentheses in ENUM comments could corrupt type parsing, and SQL keywords inside comments could alter the generated column definition. The ENUM `USING` cast could also end up attached to `COMMENT ON COLUMN`, producing invalid SQL.

Separate the generated trailing comment statement before mapping the type or processing constraints, then append it after the column alteration. Comment text therefore stays out of type, default, nullability, and reference parsing.

The branch is synchronized with main through b856a0f22, preserving #18361's ENUM array casts, unique handling, and deferred default assignment. Two integration regressions combine comment handling with ENUM array conversion and changing an existing default. Both fail against main's query generator and pass with this fix.

Closes #17894.

Validation after synchronization:

- `yarn build`: all 13 packages passed.
- PostgreSQL query-generator and change-column SQL unit tests: 137 passed.
- `changeColumn` and `add-column` integration tests on an isolated PostgreSQL 18.4 instance: 25 passed, including both new regressions.
- Core and Postgres type checks passed.
- ESLint, Prettier, and `git diff --check` passed for the follow-up changes.

AI assistance: OpenAI Codex assisted with conflict resolution, regression tests, review, and validation.

## List of Breaking Changes

None.
