### PR TITLE
fix(core): preserve belongsToMany source keys in subqueries

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -2247,7 +2247,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
   generateThroughJoin(include, includeAs, parentTableName, topLevelInfo, options) {
     const isRootParent =
-      !include.parent.association && include.parent.model.name === topLevelInfo.options.model.name;
+      !include.parent.association && include.parent.model.name === topLevelInfo.names.model.name;
     const isMinified = topLevelInfo.options.minifyAliases;
 
     const through = include.through;
@@ -2318,12 +2318,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       attrSource = association.sourceKeyField;
     }
 
-    if (
-      topLevelInfo.subQuery &&
-      !include.subQuery &&
-      !include.parent.subQuery &&
-      include.parent.model !== topLevelInfo.options.mainModel
-    ) {
+    if (topLevelInfo.subQuery && !include.subQuery && !include.parent.subQuery && !isRootParent) {
       attrSource = association.sourceKeyField;
     }
 

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -2327,6 +2327,22 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       attrSource = association.sourceKeyField;
     }
 
+    if (topLevelInfo.subQuery && !include.subQuery && isRootParent) {
+      const sourceKeyAttribute = this._getAliasForFieldFromQueryOptions(
+        association.sourceKeyField,
+        topLevelInfo.options,
+      );
+
+      if (sourceKeyAttribute) {
+        attrSource = sourceKeyAttribute[1];
+      } else {
+        attrSource = association.sourceKeyField;
+        attributes.subQuery.push(
+          `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(attrSource)}`,
+        );
+      }
+    }
+
     // Build source side of the JOIN predicate for the through association.
     // This condition is reused by the actual JOIN and any subquery WHERE filters.
 
@@ -2365,7 +2381,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         const joinColumn = association.sourceKeyField || attrSource || identSource;
 
         if (isRootParent) {
-          sourceJoinOn = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(joinColumn)} = `;
+          sourceJoinOn = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(attrSource)} = `;
         } else {
           const aliasBase = `${dottedTableSource}.${joinColumn}`;
 

--- a/packages/core/test/integration/include/source-key.test.ts
+++ b/packages/core/test/integration/include/source-key.test.ts
@@ -25,10 +25,20 @@ describe('Include', () => {
   const vars = beforeEach2(async () => {
     const User = sequelize.define(
       'User',
-      { uuid: { type: DataTypes.STRING, unique: true } },
+      {
+        uuid: {
+          type: DataTypes.STRING,
+          unique: true,
+          columnName: 'user_uuid',
+        },
+      },
       { timestamps: false },
     );
     const Tag = sequelize.define('Tag', {}, { timestamps: false });
+    const parent = User.belongsTo(User, {
+      as: 'parent',
+      foreignKey: 'parentId',
+    });
     const tags = User.belongsToMany(Tag, {
       through: 'UserTags',
       sourceKey: 'uuid',
@@ -37,7 +47,9 @@ describe('Include', () => {
     await sequelize.sync({ force: true });
 
     const user = await User.create({ uuid: 'user-1' });
+    const child = await User.create({ uuid: 'user-2' });
     const tag = await Tag.create();
+    await parent.set(child, user);
     await tags.add(user, tag);
 
     const include: Includeable[] = [
@@ -49,7 +61,30 @@ describe('Include', () => {
       },
     ];
 
-    return { User, include, expectedIds: [user.get('id')] };
+    const nestedInclude: Includeable[] = [
+      {
+        association: parent,
+        attributes: [],
+        required: true,
+        subQuery: false,
+        include: [
+          {
+            association: tags,
+            attributes: [],
+            through: { attributes: [] },
+            required: true,
+          },
+        ],
+      },
+    ];
+
+    return {
+      User,
+      include,
+      nestedInclude,
+      expectedIds: [user.get('id')],
+      expectedNestedIds: [child.get('id')],
+    };
   });
 
   it('uses the sourceKey with subQuery false', async () => {
@@ -77,5 +112,11 @@ describe('Include', () => {
     });
 
     expect(ids).to.deep.equal(vars.expectedIds);
+  });
+
+  it('uses the sourceKey column for a nested self-association', async () => {
+    const ids = await findUserIds(vars.User, vars.nestedInclude, { subQuery: true });
+
+    expect(ids).to.deep.equal(vars.expectedNestedIds);
   });
 });

--- a/packages/core/test/integration/include/source-key.test.ts
+++ b/packages/core/test/integration/include/source-key.test.ts
@@ -1,0 +1,81 @@
+import type { FindOptions, Includeable, Model, ModelStatic } from '@sequelize/core';
+import { DataTypes } from '@sequelize/core';
+import { expect } from 'chai';
+import { beforeEach2, sequelize } from '../support';
+
+type QueryOptions = Pick<FindOptions, 'minifyAliases' | 'subQuery'>;
+
+async function findUserIds(
+  User: ModelStatic<Model>,
+  include: Includeable[],
+  options: QueryOptions = {},
+): Promise<unknown[]> {
+  const users = await User.findAll({
+    attributes: ['id'],
+    include,
+    limit: 10,
+    order: [['id', 'ASC']],
+    ...options,
+  });
+
+  return users.map(user => user.get('id'));
+}
+
+describe('Include', () => {
+  const vars = beforeEach2(async () => {
+    const User = sequelize.define(
+      'User',
+      { uuid: { type: DataTypes.STRING, unique: true } },
+      { timestamps: false },
+    );
+    const Tag = sequelize.define('Tag', {}, { timestamps: false });
+    const tags = User.belongsToMany(Tag, {
+      through: 'UserTags',
+      sourceKey: 'uuid',
+    });
+
+    await sequelize.sync({ force: true });
+
+    const user = await User.create({ uuid: 'user-1' });
+    const tag = await Tag.create();
+    await tags.add(user, tag);
+
+    const include: Includeable[] = [
+      {
+        association: tags,
+        attributes: [],
+        through: { attributes: [] },
+        required: true,
+      },
+    ];
+
+    return { User, include, expectedIds: [user.get('id')] };
+  });
+
+  it('uses the sourceKey with subQuery false', async () => {
+    const ids = await findUserIds(vars.User, vars.include, { subQuery: false });
+
+    expect(ids).to.deep.equal(vars.expectedIds);
+  });
+
+  it('keeps the sourceKey available with subQuery true', async () => {
+    const ids = await findUserIds(vars.User, vars.include, { subQuery: true });
+
+    expect(ids).to.deep.equal(vars.expectedIds);
+  });
+
+  it('keeps the sourceKey available when the subquery is selected automatically', async () => {
+    const ids = await findUserIds(vars.User, vars.include);
+
+    expect(ids).to.deep.equal(vars.expectedIds);
+  });
+
+  it('keeps the sourceKey available when aliases are minified', async () => {
+    const ids = await findUserIds(vars.User, vars.include, {
+      subQuery: true,
+      minifyAliases: true,
+    });
+
+    expect(ids).to.deep.equal(vars.expectedIds);
+  });
+});


### PR DESCRIPTION

## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? N/A
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? 
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Correctly grab the custom sourceKey when including beyond the root.

https://github.com/sequelize/sequelize/issues/18256

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JOIN generation for through (many-to-many) includes so `sourceKey` columns are correctly resolved and carried through root-parent + subquery scenarios, including aliased projections.
  * Improved correctness of the join condition when determining root-parent joins, improving results consistency across `subQuery` and alias-minification modes.
* **Tests**
  * Added integration tests validating `Include` with `sourceKey` across `subQuery` false/true/default and `minifyAliases: true`, including nested self-association coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->