### PR TITLE
feat(core,postgres): native UUIDv7 generation with fallback

### DIFF
--- a/packages/core/src/abstract-dialect/dialect.ts
+++ b/packages/core/src/abstract-dialect/dialect.ts
@@ -246,7 +246,7 @@ export type DialectSupports = {
   /** Whether this dialect provides a native way to generate UUID v4 values */
   uuidV4Generation: boolean;
   /** Whether this dialect provides a native way to generate UUID v7 values */
-  uuidV7Generation: boolean;
+  uuidV7Generation: boolean | { minimumDatabaseVersion: string };
   /** Whether this dialect provides a native way to generate random values between 0 and 1 */
   randomFloatGeneration: boolean;
 

--- a/packages/core/src/expression-builders/uuid.ts
+++ b/packages/core/src/expression-builders/uuid.ts
@@ -1,6 +1,20 @@
-import { v1 as generateUuidV1, v4 as generateUuidV4, v7 as generateUuidV7 } from 'uuid';
+import * as crypto from 'node:crypto';
+import semver from 'semver';
+import { v1 as generateUuidV1, v4 as generateUuidV4, v7 as generateUuidV7Fallback } from 'uuid';
 import type { AbstractDialect } from '../abstract-dialect/dialect.js';
 import { DialectAwareFn } from './dialect-aware-fn.js';
+
+type UuidV7Generator = (() => string | undefined) | undefined;
+
+function getNativeUuidV7(): string | undefined {
+  const nativeUuidV7 = (crypto as typeof crypto & { randomUUIDv7?: unknown }).randomUUIDv7;
+
+  return typeof nativeUuidV7 === 'function' ? nativeUuidV7() : undefined;
+}
+
+export function generateUuidV7(nativeUuidV7: UuidV7Generator = getNativeUuidV7): string {
+  return nativeUuidV7?.() ?? generateUuidV7Fallback();
+}
 
 export class SqlUuidV7 extends DialectAwareFn {
   get maxArgCount() {
@@ -20,7 +34,22 @@ export class SqlUuidV7 extends DialectAwareFn {
   }
 
   supportsDialect(dialect: AbstractDialect): boolean {
-    return dialect.supports.uuidV7Generation;
+    const { uuidV7Generation } = dialect.supports;
+
+    if (uuidV7Generation === false) {
+      return false;
+    }
+
+    if (uuidV7Generation === true) {
+      return true;
+    }
+
+    const databaseVersion = dialect.sequelize.getDatabaseVersionIfExist();
+
+    return (
+      databaseVersion != null &&
+      semver.gte(databaseVersion, uuidV7Generation.minimumDatabaseVersion)
+    );
   }
 
   applyForDialect(dialect: AbstractDialect): string {

--- a/packages/core/test/unit/expression-builders/uuid.test.ts
+++ b/packages/core/test/unit/expression-builders/uuid.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { generateUuidV7 } from '../../../lib/expression-builders/uuid.js';
+
+describe('generateUuidV7', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('uses the provided native fn when available', () => {
+    const nativeUuidV7 = sinon.stub().returns('native-uuidv7');
+
+    expect(generateUuidV7(nativeUuidV7)).to.equal('native-uuidv7');
+    expect(nativeUuidV7.callCount).to.equal(1);
+  });
+
+  it('falls back to uuid.v7 when the native fn is unavailable', () => {
+    const generatedUuidV7 = generateUuidV7(() => undefined);
+
+    expect(generatedUuidV7).to.match(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+});

--- a/packages/core/test/unit/query-interface/create-table.test.ts
+++ b/packages/core/test/unit/query-interface/create-table.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { createSequelizeInstance, expectsql, sequelize } from '../../support';
 
-const dialect = sequelize.dialect;
+const { dialect } = sequelize;
 
 describe('QueryInterface#createTable', () => {
   afterEach(() => {
@@ -91,6 +91,51 @@ describe('QueryInterface#createTable', () => {
       expectsql(firstCall.args[0], {
         postgres:
           'CREATE TABLE IF NOT EXISTS "table" ("id" UUID DEFAULT uuid_generate_v4(), PRIMARY KEY ("id"));',
+      });
+    });
+
+    it('supports sql.uuidV7 default values (postgres >= 18)', async () => {
+      const localSequelize = createSequelizeInstance({
+        databaseVersion: '18.0.0',
+      });
+
+      const stub = sinon.stub(localSequelize, 'queryRaw');
+
+      await localSequelize.queryInterface.createTable('table', {
+        id: {
+          type: DataTypes.UUID,
+          primaryKey: true,
+          defaultValue: sql.uuidV7,
+        },
+      });
+
+      expect(stub.callCount).to.eq(1);
+      const firstCall = stub.getCall(0);
+      expectsql(firstCall.args[0], {
+        postgres:
+          'CREATE TABLE IF NOT EXISTS "table" ("id" UUID DEFAULT uuidv7(), PRIMARY KEY ("id"));',
+      });
+    });
+
+    it('supports sql.uuidV7 default values (postgres < 18)', async () => {
+      const localSequelize = createSequelizeInstance({
+        databaseVersion: '17.0.0',
+      });
+
+      const stub = sinon.stub(localSequelize, 'queryRaw');
+
+      await localSequelize.queryInterface.createTable('table', {
+        id: {
+          type: DataTypes.UUID,
+          primaryKey: true,
+          defaultValue: sql.uuidV7,
+        },
+      });
+
+      expect(stub.callCount).to.eq(1);
+      const firstCall = stub.getCall(0);
+      expectsql(firstCall.args[0], {
+        postgres: 'CREATE TABLE IF NOT EXISTS "table" ("id" UUID, PRIMARY KEY ("id"));',
       });
     });
   }

--- a/packages/postgres/src/dialect.ts
+++ b/packages/postgres/src/dialect.ts
@@ -137,6 +137,9 @@ export class PostgresDialect extends AbstractDialect<
     globalTimeZoneConfig: true,
     uuidV1Generation: true,
     uuidV4Generation: true,
+    uuidV7Generation: {
+      minimumDatabaseVersion: '18.0.0',
+    },
     dropTable: {
       cascade: true,
     },

--- a/packages/postgres/src/query-generator-typescript.internal.ts
+++ b/packages/postgres/src/query-generator-typescript.internal.ts
@@ -284,6 +284,10 @@ export class PostgresQueryGeneratorTypeScript extends AbstractQueryGenerator {
     return 'gen_random_uuid()';
   }
 
+  getUuidV7FunctionCall(): string {
+    return 'uuidv7()';
+  }
+
   getRandomFloatFunctionCall(): string {
     return 'RANDOM()';
   }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->
## Pull Request Checklist
<!-- Please make sure to review and check all of these items: -->
- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes
Closes #18253. Related to #17832.

Adds native UUIDv7 generation support:
- `node:crypto`'s `randomUUIDv7()` is used when available (Node 26+), falling back to the `uuid` package's `v7()` otherwise. The native detection is guarded with an explicit `typeof === 'function'` check.
- PostgreSQL now advertises UUIDv7 database-level generation as version-gated (`minimumDatabaseVersion: '18.0.0'`) instead of a static boolean. On Postgres 18+, `sql.uuidV7` produces a column default of `uuidv7()`. On Postgres <18 (or when the database version is unknown), Sequelize falls back to JavaScript-side generation instead of emitting a SQL default.

**Files changed:**
- `packages/core/src/expression-builders/uuid.ts` — injectable native UUIDv7 detection + version-aware `supportsDialect()`
- `packages/core/src/abstract-dialect/dialect.ts` — widened `uuidV7Generation` to `boolean | { minimumDatabaseVersion: string }`
- `packages/postgres/src/dialect.ts` — declared Postgres UUIDv7 support starting at `18.0.0`
- `packages/postgres/src/query-generator-typescript.internal.ts` — added `getUuidV7FunctionCall()` returning `uuidv7()`
- `packages/core/test/unit/query-interface/create-table.test.ts` — added Postgres 18 (`uuidv7()` default) and Postgres 17 (JS fallback, no default) cases
- `packages/core/test/unit/expression-builders/uuid.test.ts` — new tests for native-injected and fallback UUIDv7 generation
- `.github/workflows/ci.yml` — added Node 26 to the CI matrix
- `dev/postgres/latest/docker-compose.yml` — bumped the latest Postgres image to 18

**Notes for reviewers:**
- Per WikiRik's comment on #18253, the CI workflow and Postgres image changes may need to land in a separate PR first. Happy to split these out if preferred — just let me know.
- Unit tests cover the version-gating logic against mocked database versions (PG17/PG18 in `create-table.test.ts`), and the native/fallback selection is covered in `uuid.test.ts`. I was unable to bring up a local Postgres 18 environment to run the integration path directly, so I'd appreciate confirmation from CI or a maintainer that the live `uuidv7()` SQL path behaves as expected against a real database.

## List of Breaking Changes
None. `uuidV7Generation` widened from `boolean` to `boolean | { minimumDatabaseVersion: string }`, but this is an internal `DialectSupports` capability type, not part of the public API, and all existing dialects other than Postgres remain unaffected (default stays `false`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UUIDv7 generation for supported PostgreSQL databases.
  * PostgreSQL 18 and later can automatically use `uuidv7()` for UUID defaults.
  * UUIDv7 generation now prefers native runtime support when available, with a compatible fallback.

* **Bug Fixes**
  * UUIDv7 defaults are no longer applied to PostgreSQL versions that do not support them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->