### PR TITLE
feat(core): add Node.js native UUIDv7 generation with fallback

### DIFF
--- a/packages/core/src/expression-builders/uuid.ts
+++ b/packages/core/src/expression-builders/uuid.ts
@@ -1,5 +1,4 @@
 import * as crypto from 'node:crypto';
-import semver from 'semver';
 import { v1 as generateUuidV1, v4 as generateUuidV4, v7 as generateUuidV7Fallback } from 'uuid';
 import type { AbstractDialect } from '../abstract-dialect/dialect.js';
 import { DialectAwareFn } from './dialect-aware-fn.js';

--- a/packages/core/src/expression-builders/uuid.ts
+++ b/packages/core/src/expression-builders/uuid.ts
@@ -1,6 +1,20 @@
-import { v1 as generateUuidV1, v4 as generateUuidV4, v7 as generateUuidV7 } from 'uuid';
+import * as crypto from 'node:crypto';
+import semver from 'semver';
+import { v1 as generateUuidV1, v4 as generateUuidV4, v7 as generateUuidV7Fallback } from 'uuid';
 import type { AbstractDialect } from '../abstract-dialect/dialect.js';
 import { DialectAwareFn } from './dialect-aware-fn.js';
+
+type UuidV7Generator = (() => string | undefined) | undefined;
+
+function getNativeUuidV7(): string | undefined {
+  const nativeUuidV7 = (crypto as typeof crypto & { randomUUIDv7?: unknown }).randomUUIDv7;
+
+  return typeof nativeUuidV7 === 'function' ? nativeUuidV7() : undefined;
+}
+
+export function generateUuidV7(nativeUuidV7: UuidV7Generator = getNativeUuidV7): string {
+  return nativeUuidV7?.() ?? generateUuidV7Fallback();
+}
 
 export class SqlUuidV7 extends DialectAwareFn {
   get maxArgCount() {

--- a/packages/core/test/unit/expression-builders/uuid.test.ts
+++ b/packages/core/test/unit/expression-builders/uuid.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { generateUuidV7 } from '../../../lib/expression-builders/uuid.js';
+
+describe('generateUuidV7', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('uses the provided native fn when available', () => {
+    const nativeUuidV7 = sinon.stub().returns('native-uuidv7');
+
+    expect(generateUuidV7(nativeUuidV7)).to.equal('native-uuidv7');
+    expect(nativeUuidV7.callCount).to.equal(1);
+  });
+
+  it('falls back to uuid.v7 when the native fn is unavailable', () => {
+    const generatedUuidV7 = generateUuidV7(() => undefined);
+
+    expect(generatedUuidV7).to.match(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+});


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to the documentation repository?
- [ ] Did you update the typescript typings accordingly (not applicable)
- [x] Does the description below contain a link to an existing issue or a description of the issue you are solving?
- [x] Does the name of your PR follow our conventions?

## Description of Changes

This PR adds runtime support for native UUIDv7 generation in Node.js.

### Changes

- Uses `crypto.randomUUIDv7()` when available.
- Falls back to the `uuid` package's `v7()` implementation when the native API is unavailable.
- Adds unit tests covering both the native implementation and fallback behavior.

This PR is focused only on the Node.js runtime support for UUIDv7 generation.

The PostgreSQL-specific UUIDv7 support has been moved to a separate PR as requested during review.

## List of Breaking Changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UUID v7 generation now prefers the platform’s native UUIDv7 implementation when available, with an automatic fallback to the existing generator.

* **Bug Fixes**
  * Improved reliability and compatibility for UUID v7 creation across supported runtime environments.

* **Tests**
  * Added unit tests covering native UUIDv7 usage (including call count) and the fallback path with UUID format/version validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->