### PR TITLE
fix(core):  correctly set optional belongs to many subquery

### DIFF
--- a/packages/core/src/model-internals.ts
+++ b/packages/core/src/model-internals.ts
@@ -62,7 +62,7 @@ export function _validateIncludedElements(options: any, tableNames: any = {}) {
     if (include.subQuery !== false && options.hasDuplicating && options.topLimit) {
       if (include.duplicating) {
         include.subQuery = include.subQuery || false;
-        include.subQueryFilter = include.hasRequired;
+        include.subQueryFilter = include.required;
       } else {
         include.subQuery = include.hasRequired;
         include.subQueryFilter = false;

--- a/packages/core/test/integration/include/limit.test.js
+++ b/packages/core/test/integration/include/limit.test.js
@@ -159,6 +159,61 @@ describe(Support.getTestDialectTeaser('Include'), () => {
     /*
      * many-to-many
      */
+    describe('optional many-to-many association with a required nested include', () => {
+      async function findPostNames(Post, include, options = {}) {
+        const posts = await Post.findAll({
+          attributes: ['name'],
+          include,
+          limit: 10,
+          order: [['name', 'ASC']],
+          ...options,
+        });
+
+        return posts.map(post => post.name);
+      }
+
+      beforeEach(async function () {
+        await this.sequelize.sync({ force: true });
+
+        const [posts, tags, colors] = await Promise.all([
+          this.Post.bulkCreate(build('alpha', 'bravo')),
+          this.Tag.bulkCreate(build('tag')),
+          this.Color.bulkCreate(build('color')),
+        ]);
+
+        await Promise.all([posts[0].addTag(tags[0]), tags[0].setColor(colors[0])]);
+
+        this.include = [
+          {
+            model: this.Tag,
+            attributes: [],
+            through: { attributes: [] },
+            required: false,
+            include: [{ model: this.Color, attributes: [], required: true }],
+          },
+        ];
+        this.expectedPostNames = ['alpha', 'bravo'];
+      });
+
+      it('preserves root rows with subQuery false', async function () {
+        const names = await findPostNames(this.Post, this.include, { subQuery: false });
+
+        expect(names).to.deep.equal(this.expectedPostNames);
+      });
+
+      it('preserves root rows with subQuery true', async function () {
+        const names = await findPostNames(this.Post, this.include, { subQuery: true });
+
+        expect(names).to.deep.equal(this.expectedPostNames);
+      });
+
+      it('preserves root rows when the subquery is selected automatically', async function () {
+        const names = await findPostNames(this.Post, this.include);
+
+        expect(names).to.deep.equal(this.expectedPostNames);
+      });
+    });
+
     it('supports many-to-many association with where clause', async function () {
       await this.sequelize.sync({ force: true });
 

--- a/packages/core/test/unit/model/include.test.js
+++ b/packages/core/test/unit/model/include.test.js
@@ -412,6 +412,24 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(options.include[0].subQueryFilter).to.equal(true);
       });
 
+      it('should not tag an optional hasMany association with a required nested include', function () {
+        const options = _validateIncludedElements({
+          model: this.Company,
+          include: [
+            {
+              association: this.Company.Employees,
+              required: false,
+              include: [{ association: this.User.Tasks, required: true }],
+            },
+          ],
+          limit: 3,
+        });
+
+        expect(options.subQuery).to.equal(true);
+        expect(options.include[0].subQuery).to.equal(false);
+        expect(options.include[0].subQueryFilter).to.equal(false);
+      });
+
       it('should not tag a required hasMany association with duplicating false', function () {
         const options = _validateIncludedElements({
           model: this.User,


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?N/A
- [x] Did you update the typescript typings accordingly (if applicable)? 
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed limited queries involving optional associations with required nested associations.
  - Ensured root records are preserved consistently across automatic, enabled, and disabled subquery modes.

- **Tests**
  - Added coverage for optional many-to-many associations with required nested includes.
  - Added unit tests validating correct subquery filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->