### PR TITLE
fix(mssql): make Unicode strings configurable

### DIFF
--- a/packages/mssql/src/dialect.test.ts
+++ b/packages/mssql/src/dialect.test.ts
@@ -1,7 +1,12 @@
 import { Sequelize } from '@sequelize/core';
 import type { MsSqlConnectionOptions } from '@sequelize/mssql';
-import { MsSqlDialect } from '@sequelize/mssql';
+import { MsSqlDialect, MsSqlQuery } from '@sequelize/mssql';
 import { expect } from 'chai';
+import { TYPES } from 'tedious';
+
+type TestableMsSqlQuery = MsSqlQuery & {
+  getSQLTypeFromJsType(value: unknown, types: typeof TYPES): unknown;
+};
 
 describe('MsSqlDialect#parseConnectionUrl', () => {
   const dialect = new Sequelize({ dialect: MsSqlDialect }).dialect;
@@ -23,6 +28,58 @@ describe('MsSqlDialect#parseConnectionUrl', () => {
           password: 'password',
         },
       },
+    });
+  });
+});
+
+describe('MsSqlDialect#escapeString', () => {
+  it('uses Unicode string literals by default', () => {
+    const dialect = new Sequelize({ dialect: MsSqlDialect }).dialect;
+
+    expect(dialect.escapeString("O'Brien")).to.equal("N'O''Brien'");
+  });
+
+  it('uses non-Unicode string literals when useUnicodeStrings is disabled', () => {
+    const dialect = new Sequelize({
+      dialect: MsSqlDialect,
+      useUnicodeStrings: false,
+    }).dialect;
+
+    expect(dialect.escapeString("O'Brien")).to.equal("'O''Brien'");
+  });
+});
+
+describe('MsSqlQuery#getSQLTypeFromJsType', () => {
+  it('uses NVarChar for strings by default', () => {
+    const sequelize = new Sequelize({ dialect: MsSqlDialect });
+    const query = new MsSqlQuery({} as never, sequelize, {
+      logging: false,
+      plain: false,
+      raw: false,
+    }) as TestableMsSqlQuery;
+
+    expect(query.getSQLTypeFromJsType('a string', TYPES)).to.deep.equal({
+      type: TYPES.NVarChar,
+      typeOptions: {},
+      value: 'a string',
+    });
+  });
+
+  it('uses VarChar for strings when useUnicodeStrings is disabled', () => {
+    const sequelize = new Sequelize({
+      dialect: MsSqlDialect,
+      useUnicodeStrings: false,
+    });
+    const query = new MsSqlQuery({} as never, sequelize, {
+      logging: false,
+      plain: false,
+      raw: false,
+    }) as TestableMsSqlQuery;
+
+    expect(query.getSQLTypeFromJsType('a string', TYPES)).to.deep.equal({
+      type: TYPES.VarChar,
+      typeOptions: {},
+      value: 'a string',
     });
   });
 });

--- a/packages/mssql/src/dialect.ts
+++ b/packages/mssql/src/dialect.ts
@@ -29,10 +29,24 @@ export interface MsSqlDialectOptions {
    * as the Sequelize team cannot guarantee its compatibility.
    */
   tediousModule?: TediousModule;
+
+  /**
+   * Whether string literals should be prefixed with `N` and string bind parameters
+   * should use Tedious' `NVarChar` type.
+   *
+   * Disable this only when the target schema uses `VARCHAR` columns and the values
+   * are compatible with the database collation's code page. Disabling this option
+   * can prevent SQL Server from converting indexed `VARCHAR` columns to `NVARCHAR`
+   * during comparisons.
+   *
+   * @default true
+   */
+  useUnicodeStrings?: boolean;
 }
 
 const DIALECT_OPTION_NAMES = getSynchronizedTypeKeys<MsSqlDialectOptions>({
   tediousModule: undefined,
+  useUnicodeStrings: undefined,
 });
 
 export class MsSqlDialect extends AbstractDialect<MsSqlDialectOptions, MsSqlConnectionOptions> {
@@ -148,7 +162,9 @@ export class MsSqlDialect extends AbstractDialect<MsSqlDialectOptions, MsSqlConn
     // http://stackoverflow.com/q/603572/130598
     value = value.replaceAll("'", "''");
 
-    return `N'${value}'`;
+    const prefix = this.options.useUnicodeStrings === false ? '' : 'N';
+
+    return `${prefix}'${value}'`;
   }
 
   getDefaultSchema(): string {

--- a/packages/mssql/src/query.js
+++ b/packages/mssql/src/query.js
@@ -41,7 +41,9 @@ export class MsSqlQuery extends AbstractQuery {
 
   getSQLTypeFromJsType(value, TYPES) {
     const paramType = { type: TYPES.NVarChar, typeOptions: {}, value };
-    if (typeof value === 'number') {
+    if (typeof value === 'string' && this.sequelize.dialect.options.useUnicodeStrings === false) {
+      paramType.type = TYPES.VarChar;
+    } else if (typeof value === 'number') {
       if (Number.isInteger(value)) {
         if (value >= -2_147_483_648 && value <= 2_147_483_647) {
           paramType.type = TYPES.Int;


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? (Not necessary: the new dialect option is documented in its public TypeScript definition.)
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Relates to #18260.

This adds a `useUnicodeStrings` MSSQL dialect option. Its default remains `true`, preserving the existing `N'...'` literal and `TYPES.NVarChar` bind behavior for all current deployments.

Applications whose schemas intentionally use code-page-compatible `VARCHAR` columns can explicitly set `useUnicodeStrings: false`. In that mode, string literals omit the `N` prefix and string bind parameters use Tedious' `TYPES.VarChar`; non-string bind types are unchanged.

The tests cover both the backward-compatible default and the explicit opt-out for literals and bound strings.

Validation performed:

- `NX_DAEMON=false yarn build`
- `yarn workspace @sequelize/mssql test-unit` (10 passing)
- `yarn exec tsc --noEmit --project packages/mssql/tsconfig.json`
- ESLint and Prettier checks for all changed files
- `git diff --check`

## List of Breaking Changes

None. Unicode strings remain enabled by default; behavior changes only when the new option is explicitly set to `false`.
