### PR TITLE
fix(mysql): destroy connection when SET time_zone fails during connect

### DIFF
--- a/packages/mysql/src/connection-manager.test.ts
+++ b/packages/mysql/src/connection-manager.test.ts
@@ -1,0 +1,108 @@
+import type { ConnectionOptions } from '@sequelize/core';
+import { ConnectionError, Sequelize } from '@sequelize/core';
+import { MySqlDialect } from '@sequelize/mysql';
+import { expect } from 'chai';
+import { EventEmitter } from 'node:events';
+
+type QueryCallback = (error: Error | null) => void;
+
+class FakeMySqlConnection extends EventEmitter {
+  destroyCallCount = 0;
+  queries: string[] = [];
+
+  constructor(private readonly queryError: Error | null) {
+    super();
+
+    // mysql2 emits "connect" once the handshake succeeded.
+    process.nextTick(() => {
+      this.emit('connect');
+    });
+  }
+
+  query(sql: string, callback: QueryCallback): void {
+    this.queries.push(sql);
+    process.nextTick(() => {
+      callback(this.queryError);
+    });
+  }
+
+  destroy(): void {
+    this.destroyCallCount++;
+  }
+}
+
+function createSequelizeWithFakeMysql2(queryError: Error | null): {
+  sequelize: Sequelize<MySqlDialect>;
+  connectionConfig: ConnectionOptions<MySqlDialect>;
+  getConnections(): FakeMySqlConnection[];
+} {
+  const connections: FakeMySqlConnection[] = [];
+
+  const mysql2Module = {
+    createConnection() {
+      const connection = new FakeMySqlConnection(queryError);
+      connections.push(connection);
+
+      return connection;
+    },
+  } as any;
+
+  const sequelize = new Sequelize<MySqlDialect>({
+    dialect: MySqlDialect,
+    host: 'localhost',
+    port: 3306,
+    user: 'user',
+    password: 'password',
+    database: 'db',
+    timezone: '+05:30',
+    mysql2Module,
+  });
+
+  const connectionConfig: ConnectionOptions<MySqlDialect> = {
+    host: 'localhost',
+    port: 3306,
+    user: 'user',
+    password: 'password',
+    database: 'db',
+  };
+
+  return { sequelize, connectionConfig, getConnections: () => connections };
+}
+
+describe('MySqlConnectionManager#connect', () => {
+  it('sets the session time zone and resolves when the query succeeds', async () => {
+    const { sequelize, connectionConfig, getConnections } = createSequelizeWithFakeMysql2(null);
+
+    const connection = await sequelize.dialect.connectionManager.connect(connectionConfig);
+
+    const [fakeConnection] = getConnections();
+    expect(connection).to.equal(fakeConnection);
+    expect(fakeConnection.queries).to.deep.equal([`SET time_zone = '+05:30'`]);
+    expect(fakeConnection.destroyCallCount).to.equal(0);
+  });
+
+  // https://github.com/sequelize/sequelize/issues/18266
+  it('destroys the connection when the SET time_zone query fails', async () => {
+    const queryError = new Error(
+      'Query declined - system memory is critically low. This action was taken to protect system stability.',
+    );
+    const { sequelize, connectionConfig, getConnections } =
+      createSequelizeWithFakeMysql2(queryError);
+
+    let caughtError: unknown;
+    try {
+      await sequelize.dialect.connectionManager.connect(connectionConfig);
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).to.be.instanceOf(ConnectionError);
+    expect((caughtError as ConnectionError).cause).to.equal(queryError);
+
+    // The pool never receives a connection whose setup failed, so connect()
+    // must close it itself or the socket is orphaned.
+    const [fakeConnection] = getConnections();
+    expect(fakeConnection.queries).to.deep.equal([`SET time_zone = '+05:30'`]);
+    expect(fakeConnection.destroyCallCount).to.equal(1);
+  });
+});

--- a/packages/mysql/src/connection-manager.test.ts
+++ b/packages/mysql/src/connection-manager.test.ts
@@ -8,6 +8,7 @@ type QueryCallback = (error: Error | null) => void;
 
 class FakeMySqlConnection extends EventEmitter {
   destroyCallCount = 0;
+  endCallCount = 0;
   queries: string[] = [];
 
   constructor(private readonly queryError: Error | null) {
@@ -28,6 +29,13 @@ class FakeMySqlConnection extends EventEmitter {
 
   destroy(): void {
     this.destroyCallCount++;
+  }
+
+  end(callback?: (error?: Error | null) => void): void {
+    this.endCallCount++;
+    process.nextTick(() => {
+      callback?.();
+    });
   }
 }
 
@@ -79,6 +87,7 @@ describe('MySqlConnectionManager#connect', () => {
     expect(connection).to.equal(fakeConnection);
     expect(fakeConnection.queries).to.deep.equal([`SET time_zone = '+05:30'`]);
     expect(fakeConnection.destroyCallCount).to.equal(0);
+    expect(fakeConnection.endCallCount).to.equal(0);
   });
 
   // https://github.com/sequelize/sequelize/issues/18266
@@ -104,5 +113,6 @@ describe('MySqlConnectionManager#connect', () => {
     const [fakeConnection] = getConnections();
     expect(fakeConnection.queries).to.deep.equal([`SET time_zone = '+05:30'`]);
     expect(fakeConnection.destroyCallCount).to.equal(1);
+    expect(fakeConnection.endCallCount).to.equal(0);
   });
 });

--- a/packages/mysql/src/connection-manager.ts
+++ b/packages/mysql/src/connection-manager.ts
@@ -128,7 +128,14 @@ export class MySqlConnectionManager extends AbstractConnectionManager<
         // but named timezone are not directly supported in mysql, so get its offset first
         let tzOffset = this.sequelize.options.timezone;
         tzOffset = tzOffset.includes('/') ? timeZoneToOffsetString(tzOffset) : tzOffset;
-        await promisify(cb => connection.query(`SET time_zone = '${tzOffset}'`, cb))();
+        try {
+          await promisify(cb => connection.query(`SET time_zone = '${tzOffset}'`, cb))();
+        } catch (error) {
+          // The pool never receives a connection whose setup failed, so it must
+          // be closed here or its socket would be leaked.
+          connection.destroy();
+          throw error;
+        }
       }
 
       return connection;

--- a/packages/mysql/src/connection-manager.ts
+++ b/packages/mysql/src/connection-manager.ts
@@ -132,7 +132,9 @@ export class MySqlConnectionManager extends AbstractConnectionManager<
           await promisify(cb => connection.query(`SET time_zone = '${tzOffset}'`, cb))();
         } catch (error) {
           // The pool never receives a connection whose setup failed, so it must
-          // be closed here or its socket would be leaked.
+          // be closed here or its socket would be leaked. Use destroy() rather
+          // than end(): the failed setup query leaves the connection state
+          // uncertain, and end() may reject and mask the original setup error.
           connection.destroy();
           throw error;
         }


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to the documentation repository? — n/a, no user-facing API change
- [ ] Did you update the typescript typings accordingly (if applicable)? — n/a
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow our conventions?

## Description of Changes

Closes #18266

When the mysql dialect's `connect()` successfully creates the mysql2 connection but the subsequent `SET time_zone` query fails (as reported against RDS Aurora returning `ER_OUT_OF_RESOURCES`), the error propagated through the outer catch without the socket ever being closed. The pool never receives the connection, so every failed attempt orphans a live connection — a leak that compounds under retry.

The fix wraps the timezone query in a try/catch that calls `connection.destroy()` before rethrowing; the outer catch still wraps the error into `ConnectionError` exactly as before, so error semantics are unchanged. The code also documents why this uses `destroy()` instead of `end()`: the setup query failure leaves the connection state uncertain, and `end()` could reject and mask the original error.

Adds `packages/mysql/src/connection-manager.test.ts` (first unit coverage for this connection manager), injecting a fake `mysql2Module` via the documented dialect option: the new test was red before the fix (`destroyCallCount` 0, expected 1) and green after. It also asserts that `end()` is not called on the failed setup path, locking in the destroy-not-end behavior. Whole mysql unit suite passing after `yarn build`; `tsc --noEmit`, eslint, prettier clean.

MariaDB was checked and is unaffected by this PR's MySQL-specific path: its timezone initialization is routed through the driver's `initSql`, and the driver handles socket cleanup on init-SQL failure.

## List of Breaking Changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL connection handling by ensuring connections are properly destroyed when session timezone initialization fails, preventing socket/resource leakage.
  * Preserved the original timezone setup error for clearer failure reporting.

* **Tests**
  * Added/expanded assertions to verify correct cleanup behavior for MySQL connection setup success and failure cases (including ensuring unintended `end()` isn’t called during failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
