### PR TITLE
fix(oracle): keep replacement strings out of date expressions

### DIFF
--- a/packages/core/test/integration/sequelize/query.test.js
+++ b/packages/core/test/integration/sequelize/query.test.js
@@ -837,6 +837,22 @@ describe(getTestDialectTeaser('Sequelize'), () => {
       ).to.eventually.deep.equal(expected);
     });
 
+    if (dialectName === 'oracle') {
+      it('treats TO_DATE-prefixed replacement values as strings', async function () {
+        const value = "TO_DATE(CASE WHEN 1=1 THEN '2024/01/01' ELSE '2024/01/02' END,'YYYY/MM/DD')";
+
+        const [row] = await this.sequelize.query(
+          `select :value as ${queryGenerator.quoteIdentifier('result')}${fromQuery()}`,
+          {
+            replacements: { value },
+            type: this.sequelize.QueryTypes.SELECT,
+          },
+        );
+
+        expect(row.result).to.equal(value);
+      });
+    }
+
     // IBM i cannot bind parameter markers for selecting values like in theses
     // tests
     if (dialectName !== 'ibmi') {

--- a/packages/core/test/unit/data-types/temporal-types.test.ts
+++ b/packages/core/test/unit/data-types/temporal-types.test.ts
@@ -1,6 +1,6 @@
 import { DataTypes, ValidationErrorItem } from '@sequelize/core';
 import { expect } from 'chai';
-import { sequelize } from '../../support';
+import { expectsql, sequelize } from '../../support';
 import { testDataTypeSql } from './_utils';
 
 const dialect = sequelize.dialect;
@@ -41,6 +41,42 @@ describe('DataTypes.DATE', () => {
   });
 
   const type = DataTypes.DATE().toDialectDataType(dialect);
+
+  // `escape` is the "inline value" code path, used whenever a value is embedded directly in the
+  // SQL string instead of being sent as a bind parameter (e.g. `where` clauses in `findAll`).
+  // It is a completely different code path from `getBindParamSql` / `toBindableValue`.
+  describe('escape (inline value)', () => {
+    it('escapes a Date object', () => {
+      expectsql(type.escape(new Date('2022-01-01T12:13:14.123Z')), {
+        default: `'2022-01-01 12:13:14.123 +00:00'`,
+        'mariadb mysql': `'2022-01-01 12:13:14'`,
+        'db2 ibmi snowflake': `'2022-01-01 12:13:14.123'`,
+        mssql: `N'2022-01-01 12:13:14.123 +00:00'`,
+        oracle: `TO_TIMESTAMP_TZ('2022-01-01 12:13:14.123 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+      });
+    });
+
+    it('escapes a date string', () => {
+      expectsql(type.escape('2022-01-01T12:13:14.123Z'), {
+        default: `'2022-01-01 12:13:14.123 +00:00'`,
+        'mariadb mysql': `'2022-01-01 12:13:14'`,
+        'db2 ibmi snowflake': `'2022-01-01 12:13:14.123'`,
+        mssql: `N'2022-01-01 12:13:14.123 +00:00'`,
+        oracle: `TO_TIMESTAMP_TZ('2022-01-01 12:13:14.123 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+      });
+    });
+
+    it('escapes the unix epoch', () => {
+      expectsql(type.escape(0), {
+        default: `'1970-01-01 00:00:00.000 +00:00'`,
+        'mariadb mysql': `'1970-01-01 00:00:00'`,
+        'db2 ibmi snowflake': `'1970-01-01 00:00:00.000'`,
+        mssql: `N'1970-01-01 00:00:00.000 +00:00'`,
+        oracle: `TO_TIMESTAMP_TZ('1970-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+      });
+    });
+  });
+
   describe('validate', () => {
     it('should throw an error if `value` is invalid', () => {
       expect(() => {
@@ -88,16 +124,6 @@ describe('DataTypes.DATE', () => {
       });
     }
   });
-
-  describe('escape', () => {
-    if (dialect.name === 'oracle') {
-      it('serializes inline dates as TO_TIMESTAMP_TZ expressions', () => {
-        expect(type.escape(new Date('2025-03-21T00:00:00.000Z'))).to.equal(
-          "TO_TIMESTAMP_TZ('2025-03-21 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')",
-        );
-      });
-    }
-  });
 });
 
 describe('DataTypes.DATEONLY', () => {
@@ -109,6 +135,35 @@ describe('DataTypes.DATEONLY', () => {
   });
 
   const type = DataTypes.DATEONLY().toDialectDataType(dialect);
+
+  // See the comment on DataTypes.DATE#escape above: this is the inline (non-bind) code path,
+  // which had no test coverage on any dialect prior to this suite.
+  describe('escape (inline value)', () => {
+    it('escapes a date-only string', () => {
+      expectsql(type.escape('2022-01-01'), {
+        default: `'2022-01-01'`,
+        mssql: `N'2022-01-01'`,
+        oracle: `TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+      });
+    });
+
+    it('escapes a Date object', () => {
+      expectsql(type.escape(new Date('2022-01-01T12:13:14.123Z')), {
+        default: `'2022-01-01'`,
+        mssql: `N'2022-01-01'`,
+        oracle: `TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+      });
+    });
+
+    it('escapes the unix epoch', () => {
+      expectsql(type.escape(0), {
+        default: `'1970-01-01'`,
+        mssql: `N'1970-01-01'`,
+        oracle: `TO_DATE('1970/01/01', 'YYYY/MM/DD')`,
+      });
+    });
+  });
+
   describe('validate', () => {
     if (dialect.supports.dataTypes.DATEONLY.infinity) {
       it('DATEONLY should stringify Infinity/-Infinity to infinity/-infinity', () => {
@@ -133,15 +188,6 @@ describe('DataTypes.DATEONLY', () => {
       it('sanitizes string Infinity/-Infinity to their numeric counterpart', () => {
         expect(type.sanitize('Infinity')).to.equal(Number.POSITIVE_INFINITY);
         expect(type.sanitize('-Infinity')).to.equal(Number.NEGATIVE_INFINITY);
-      });
-    }
-  });
-
-  describe('escape', () => {
-    if (dialect.name === 'oracle') {
-      it('serializes inline dates as TO_DATE expressions', () => {
-        expect(type.escape('2025-03-21')).to.equal("TO_DATE('2025/03/21', 'YYYY/MM/DD')");
-        expect(type.escape(0)).to.equal("TO_DATE('1970/01/01', 'YYYY/MM/DD')");
       });
     }
   });

--- a/packages/core/test/unit/data-types/temporal-types.test.ts
+++ b/packages/core/test/unit/data-types/temporal-types.test.ts
@@ -88,6 +88,16 @@ describe('DataTypes.DATE', () => {
       });
     }
   });
+
+  describe('escape', () => {
+    if (dialect.name === 'oracle') {
+      it('serializes inline dates as TO_TIMESTAMP_TZ expressions', () => {
+        expect(type.escape(new Date('2025-03-21T00:00:00.000Z'))).to.equal(
+          "TO_TIMESTAMP_TZ('2025-03-21 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')",
+        );
+      });
+    }
+  });
 });
 
 describe('DataTypes.DATEONLY', () => {
@@ -108,6 +118,14 @@ describe('DataTypes.DATEONLY', () => {
     }
   });
 
+  describe('toBindableValue', () => {
+    if (dialect.name === 'oracle') {
+      it('formats falsy numeric dates as bind values', () => {
+        expect(type.toBindableValue(0)).to.equal('1970/01/01');
+      });
+    }
+  });
+
   describe('sanitize', () => {
     it('sanitizes a Date object or string to a string', () => {
       expect(type.sanitize(now)).to.equal(nowDateOnly);
@@ -123,6 +141,14 @@ describe('DataTypes.DATEONLY', () => {
       it('sanitizes string Infinity/-Infinity to their numeric counterpart', () => {
         expect(type.sanitize('Infinity')).to.equal(Number.POSITIVE_INFINITY);
         expect(type.sanitize('-Infinity')).to.equal(Number.NEGATIVE_INFINITY);
+      });
+    }
+  });
+
+  describe('escape', () => {
+    if (dialect.name === 'oracle') {
+      it('serializes inline dates as TO_DATE expressions', () => {
+        expect(type.escape('2025-03-21')).to.equal("TO_DATE('2025/03/21', 'YYYY/MM/DD')");
       });
     }
   });

--- a/packages/core/test/unit/data-types/temporal-types.test.ts
+++ b/packages/core/test/unit/data-types/temporal-types.test.ts
@@ -118,14 +118,6 @@ describe('DataTypes.DATEONLY', () => {
     }
   });
 
-  describe('toBindableValue', () => {
-    if (dialect.name === 'oracle') {
-      it('formats falsy numeric dates as bind values', () => {
-        expect(type.toBindableValue(0)).to.equal('1970/01/01');
-      });
-    }
-  });
-
   describe('sanitize', () => {
     it('sanitizes a Date object or string to a string', () => {
       expect(type.sanitize(now)).to.equal(nowDateOnly);
@@ -149,6 +141,7 @@ describe('DataTypes.DATEONLY', () => {
     if (dialect.name === 'oracle') {
       it('serializes inline dates as TO_DATE expressions', () => {
         expect(type.escape('2025-03-21')).to.equal("TO_DATE('2025/03/21', 'YYYY/MM/DD')");
+        expect(type.escape(0)).to.equal("TO_DATE('1970/01/01', 'YYYY/MM/DD')");
       });
     }
   });

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -58,6 +58,7 @@ class TestModel extends Model<InferAttributes<TestModel>> {
   declare stringAttr: string;
   declare binaryAttr: Buffer;
   declare dateAttr: Date;
+  declare dateOnlyAttr: string;
   declare booleanAttr: boolean;
   declare bigIntAttr: bigint;
 
@@ -93,6 +94,7 @@ describe(getTestDialectTeaser('SQL'), () => {
         stringAttr: DataTypes.STRING,
         binaryAttr: DataTypes.BLOB,
         dateAttr: DataTypes.DATE(3),
+        dateOnlyAttr: DataTypes.DATEONLY,
         booleanAttr: DataTypes.BOOLEAN,
         ...(dialectSupportsBigInt() && { bigIntAttr: DataTypes.BIGINT }),
 
@@ -432,6 +434,15 @@ Caused by: "undefined" cannot be escaped`),
           mssql: `[dateAttr] = N'2013-01-01 00:00:00.000 +00:00'`,
           'db2 snowflake ibmi': `"dateAttr" = '2013-01-01 00:00:00.000'`,
           oracle: `"dateAttr" = TO_TIMESTAMP_TZ('2013-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+        },
+      );
+
+      testSql(
+        { dateOnlyAttr: '2025-03-21' },
+        {
+          default: `[dateOnlyAttr] = '2025-03-21'`,
+          mssql: `[dateOnlyAttr] = N'2025-03-21'`,
+          oracle: `"dateOnlyAttr" = TO_DATE('2025/03/21', 'YYYY/MM/DD')`,
         },
       );
 

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -58,7 +58,7 @@ class TestModel extends Model<InferAttributes<TestModel>> {
   declare stringAttr: string;
   declare binaryAttr: Buffer;
   declare dateAttr: Date;
-  declare dateOnlyAttr: string;
+  declare dateOnlyAttr: string | null;
   declare booleanAttr: boolean;
   declare bigIntAttr: bigint;
 
@@ -437,14 +437,101 @@ Caused by: "undefined" cannot be escaped`),
         },
       );
 
-      testSql(
-        { dateOnlyAttr: '2025-03-21' },
-        {
-          default: `[dateOnlyAttr] = '2025-03-21'`,
-          mssql: `[dateOnlyAttr] = N'2025-03-21'`,
-          oracle: `"dateOnlyAttr" = TO_DATE('2025/03/21', 'YYYY/MM/DD')`,
-        },
-      );
+      // Temporal values used inline (i.e. not as bind parameters) go through DataType#escape,
+      // which is a completely separate code path from DataType#getBindParamSql.
+      // The tests below pin the inline path down for both DATEONLY and DATE, on every dialect.
+      describe('DATEONLY', () => {
+        testSql(
+          { dateOnlyAttr: '2022-01-01' },
+          {
+            default: `[dateOnlyAttr] = '2022-01-01'`,
+            mssql: `[dateOnlyAttr] = N'2022-01-01'`,
+            oracle: `"dateOnlyAttr" = TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: new Date('2022-01-01T12:13:14.123Z') },
+          {
+            default: `[dateOnlyAttr] = '2022-01-01'`,
+            mssql: `[dateOnlyAttr] = N'2022-01-01'`,
+            oracle: `"dateOnlyAttr" = TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: { [Op.gt]: '2022-01-01' } },
+          {
+            default: `[dateOnlyAttr] > '2022-01-01'`,
+            mssql: `[dateOnlyAttr] > N'2022-01-01'`,
+            oracle: `"dateOnlyAttr" > TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: { [Op.between]: ['2022-01-01', '2022-12-31'] } },
+          {
+            default: `[dateOnlyAttr] BETWEEN '2022-01-01' AND '2022-12-31'`,
+            mssql: `[dateOnlyAttr] BETWEEN N'2022-01-01' AND N'2022-12-31'`,
+            oracle: `"dateOnlyAttr" BETWEEN TO_DATE('2022/01/01', 'YYYY/MM/DD') AND TO_DATE('2022/12/31', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: { [Op.in]: ['2022-01-01', '2022-12-31'] } },
+          {
+            default: `[dateOnlyAttr] IN ('2022-01-01', '2022-12-31')`,
+            mssql: `[dateOnlyAttr] IN (N'2022-01-01', N'2022-12-31')`,
+            oracle: `"dateOnlyAttr" IN (TO_DATE('2022/01/01', 'YYYY/MM/DD'), TO_DATE('2022/12/31', 'YYYY/MM/DD'))`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: null },
+          {
+            default: `[dateOnlyAttr] IS NULL`,
+          },
+        );
+      });
+
+      describe('DATE', () => {
+        testSql(
+          { dateAttr: { [Op.gt]: new Date('2021-01-01T00:00:00Z') } },
+          {
+            default: `[dateAttr] > '2021-01-01 00:00:00.000 +00:00'`,
+            mssql: `[dateAttr] > N'2021-01-01 00:00:00.000 +00:00'`,
+            'mariadb mysql': `\`dateAttr\` > '2021-01-01 00:00:00.000'`,
+            'db2 ibmi snowflake': `"dateAttr" > '2021-01-01 00:00:00.000'`,
+            oracle: `"dateAttr" > TO_TIMESTAMP_TZ('2021-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+          },
+        );
+
+        testSql(
+          {
+            dateAttr: {
+              [Op.between]: [new Date('2021-01-01T00:00:00Z'), new Date('2022-01-01T00:00:00Z')],
+            },
+          },
+          {
+            default: `[dateAttr] BETWEEN '2021-01-01 00:00:00.000 +00:00' AND '2022-01-01 00:00:00.000 +00:00'`,
+            mssql: `[dateAttr] BETWEEN N'2021-01-01 00:00:00.000 +00:00' AND N'2022-01-01 00:00:00.000 +00:00'`,
+            'mariadb mysql': `\`dateAttr\` BETWEEN '2021-01-01 00:00:00.000' AND '2022-01-01 00:00:00.000'`,
+            'db2 ibmi snowflake': `"dateAttr" BETWEEN '2021-01-01 00:00:00.000' AND '2022-01-01 00:00:00.000'`,
+            oracle: `"dateAttr" BETWEEN TO_TIMESTAMP_TZ('2021-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM') AND TO_TIMESTAMP_TZ('2022-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+          },
+        );
+
+        testSql(
+          { dateAttr: { [Op.in]: [new Date('2021-01-01T00:00:00Z')] } },
+          {
+            default: `[dateAttr] IN ('2021-01-01 00:00:00.000 +00:00')`,
+            mssql: `[dateAttr] IN (N'2021-01-01 00:00:00.000 +00:00')`,
+            'mariadb mysql': `\`dateAttr\` IN ('2021-01-01 00:00:00.000')`,
+            'db2 ibmi snowflake': `"dateAttr" IN ('2021-01-01 00:00:00.000')`,
+            oracle: `"dateAttr" IN (TO_TIMESTAMP_TZ('2021-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM'))`,
+          },
+        );
+      });
 
       describe('Buffer', () => {
         testSql(

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -447,6 +447,17 @@ SELECT * FROM users WHERE id = '\\\\\\' $id' OR id = $id`),
 });
 
 describe('injectReplacements (named replacements)', () => {
+  it('escapes values that resemble date expressions', () => {
+    const value = "TO_DATE(CASE WHEN :name = $1 THEN ? ELSE '2024/01/02' END,'YYYY/MM/DD')";
+    const sql = injectReplacements('SELECT :value', dialect, { value });
+
+    expectsql(sql, {
+      default: `SELECT 'TO_DATE(CASE WHEN :name = $1 THEN ? ELSE ''2024/01/02'' END,''YYYY/MM/DD'')'`,
+      'mariadb mysql': `SELECT 'TO_DATE(CASE WHEN :name = $1 THEN ? ELSE \\'2024/01/02\\' END,\\'YYYY/MM/DD\\')'`,
+      mssql: `SELECT N'TO_DATE(CASE WHEN :name = $1 THEN ? ELSE ''2024/01/02'' END,''YYYY/MM/DD'')'`,
+    });
+  });
+
   it('parses named replacements', () => {
     const sql = injectReplacements(
       `SELECT ${dialect.TICK_CHAR_LEFT}:id${dialect.TICK_CHAR_RIGHT} FROM users WHERE id = ':id' OR id = :id OR id = ''':id'''`,
@@ -734,6 +745,17 @@ SELECT * FROM users WHERE id = '\\\\\\' :id' OR id = :id`),
 });
 
 describe('injectReplacements (positional replacements)', () => {
+  it('escapes values that resemble date expressions', () => {
+    const value = "TO_TIMESTAMP_TZ(?,'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')";
+    const sql = injectReplacements('SELECT ?', dialect, [value]);
+
+    expectsql(sql, {
+      default: `SELECT 'TO_TIMESTAMP_TZ(?,''YYYY-MM-DD HH24:MI:SS.FFTZH:TZM'')'`,
+      'mariadb mysql': `SELECT 'TO_TIMESTAMP_TZ(?,\\'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM\\')'`,
+      mssql: `SELECT N'TO_TIMESTAMP_TZ(?,''YYYY-MM-DD HH24:MI:SS.FFTZH:TZM'')'`,
+    });
+  });
+
   it('parses positional replacements', () => {
     const sql = injectReplacements(
       `SELECT ${dialect.TICK_CHAR_LEFT}?${dialect.TICK_CHAR_RIGHT} FROM users WHERE id = '?' OR id = ? OR id = '''?''' OR id2 = ?`,

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -447,17 +447,6 @@ SELECT * FROM users WHERE id = '\\\\\\' $id' OR id = $id`),
 });
 
 describe('injectReplacements (named replacements)', () => {
-  it('escapes values that resemble date expressions', () => {
-    const value = "TO_DATE(CASE WHEN :name = $1 THEN ? ELSE '2024/01/02' END,'YYYY/MM/DD')";
-    const sql = injectReplacements('SELECT :value', dialect, { value });
-
-    expectsql(sql, {
-      default: `SELECT 'TO_DATE(CASE WHEN :name = $1 THEN ? ELSE ''2024/01/02'' END,''YYYY/MM/DD'')'`,
-      'mariadb mysql': `SELECT 'TO_DATE(CASE WHEN :name = $1 THEN ? ELSE \\'2024/01/02\\' END,\\'YYYY/MM/DD\\')'`,
-      mssql: `SELECT N'TO_DATE(CASE WHEN :name = $1 THEN ? ELSE ''2024/01/02'' END,''YYYY/MM/DD'')'`,
-    });
-  });
-
   it('parses named replacements', () => {
     const sql = injectReplacements(
       `SELECT ${dialect.TICK_CHAR_LEFT}:id${dialect.TICK_CHAR_RIGHT} FROM users WHERE id = ':id' OR id = :id OR id = ''':id'''`,
@@ -469,6 +458,53 @@ describe('injectReplacements (named replacements)', () => {
 
     expectsql(sql, {
       default: `SELECT [:id] FROM users WHERE id = ':id' OR id = 1 OR id = ''':id'''`,
+    });
+  });
+
+  // Replacement *values* must always be escaped as plain string literals, never re-interpreted as
+  // SQL. These guards cover values shaped like placeholders and like SQL function calls.
+  it('escapes replacement values that look like a named replacement', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE id = :id`, dialect, {
+      id: ':id',
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE id = ':id'`,
+      mssql: `SELECT * FROM users WHERE id = N':id'`,
+    });
+  });
+
+  it('escapes replacement values that look like a positional bind parameter', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE id = :id`, dialect, {
+      id: '$1',
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE id = '$1'`,
+      mssql: `SELECT * FROM users WHERE id = N'$1'`,
+    });
+  });
+
+  it('escapes replacement values that look like a positional replacement', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE id = :id`, dialect, {
+      id: '?',
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE id = '?'`,
+      mssql: `SELECT * FROM users WHERE id = N'?'`,
+    });
+  });
+
+  it('escapes replacement values that look like a SQL date expression', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE createdAt = :date`, dialect, {
+      date: `TO_DATE('2024/01/01','YYYY/MM/DD')`,
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE createdAt = 'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
+      'mariadb mysql': `SELECT * FROM users WHERE createdAt = 'TO_DATE(\\'2024/01/01\\',\\'YYYY/MM/DD\\')'`,
+      mssql: `SELECT * FROM users WHERE createdAt = N'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
     });
   });
 
@@ -765,6 +801,20 @@ describe('injectReplacements (positional replacements)', () => {
 
     expectsql(sql, {
       default: `SELECT [?] FROM users WHERE id = '?' OR id = 1 OR id = '''?''' OR id2 = 2`,
+    });
+  });
+
+  it('escapes replacement values that look like placeholders or SQL expressions', () => {
+    const sql = injectReplacements(
+      `SELECT * FROM users WHERE a = ? AND b = ? AND c = ? AND d = ?`,
+      dialect,
+      ['?', '$1', ':id', `TO_DATE('2024/01/01','YYYY/MM/DD')`],
+    );
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE a = '?' AND b = '$1' AND c = ':id' AND d = 'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
+      'mariadb mysql': `SELECT * FROM users WHERE a = '?' AND b = '$1' AND c = ':id' AND d = 'TO_DATE(\\'2024/01/01\\',\\'YYYY/MM/DD\\')'`,
+      mssql: `SELECT * FROM users WHERE a = N'?' AND b = N'$1' AND c = N':id' AND d = N'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
     });
   });
 

--- a/packages/oracle/src/_internal/data-types-overrides.ts
+++ b/packages/oracle/src/_internal/data-types-overrides.ts
@@ -155,17 +155,16 @@ export class DATE extends BaseTypes.DATE {
     return { type: oracledb.DB_TYPE_TIMESTAMP_LTZ };
   }
 
-  toBindableValue(date: AcceptedDate) {
-    const format = 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM';
-    date = this._applyTimezone(date);
+  escape(value: AcceptedDate): string {
+    const dialect = this._getDialect();
+    const date = this.toBindableValue(value);
+    const format = dialect.escapeString('YYYY-MM-DD HH24:MI:SS.FFTZH:TZM');
 
-    const formatedDate = date.format('YYYY-MM-DD HH:mm:ss.SSS Z');
-
-    return `TO_TIMESTAMP_TZ('${formatedDate}', '${format}')`;
+    return `TO_TIMESTAMP_TZ(${dialect.escapeString(date)}, ${format})`;
   }
 
   /**
-   * avoids appending TO_TIMESTAMP_TZ in toBindableValue()
+   * Uses native temporal binds instead of the inline TO_TIMESTAMP_TZ wrapper.
    *
    * @override
    */
@@ -384,14 +383,16 @@ export class DOUBLE extends BaseTypes.DOUBLE {
 }
 
 export class DATEONLY extends BaseTypes.DATEONLY {
+  escape(value: AcceptedDate): string {
+    const dialect = this._getDialect();
+    const date = this.toBindableValue(value);
+    const format = dialect.escapeString('YYYY/MM/DD');
+
+    return `TO_DATE(${dialect.escapeString(date)}, ${format})`;
+  }
+
   toBindableValue(date: AcceptedDate) {
-    if (date) {
-      const format = 'YYYY/MM/DD';
-
-      return this.escape(`TO_DATE('${date}','${format}')`);
-    }
-
-    return this.escape(date);
+    return super.toBindableValue(date).replaceAll('-', '/');
   }
 
   parseDatabaseValue(value: any) {
@@ -407,7 +408,7 @@ export class DATEONLY extends BaseTypes.DATEONLY {
   }
 
   /**
-   * avoids appending TO_DATE in toBindableValue()
+   * Uses native temporal binds instead of the inline TO_DATE wrapper.
    *
    * @override
    */

--- a/packages/oracle/src/_internal/data-types-overrides.ts
+++ b/packages/oracle/src/_internal/data-types-overrides.ts
@@ -385,14 +385,10 @@ export class DOUBLE extends BaseTypes.DOUBLE {
 export class DATEONLY extends BaseTypes.DATEONLY {
   escape(value: AcceptedDate): string {
     const dialect = this._getDialect();
-    const date = this.toBindableValue(value);
+    const date = this.toBindableValue(value).replaceAll('-', '/');
     const format = dialect.escapeString('YYYY/MM/DD');
 
     return `TO_DATE(${dialect.escapeString(date)}, ${format})`;
-  }
-
-  toBindableValue(date: AcceptedDate) {
-    return super.toBindableValue(date).replaceAll('-', '/');
   }
 
   parseDatabaseValue(value: any) {

--- a/packages/oracle/src/dialect.ts
+++ b/packages/oracle/src/dialect.ts
@@ -116,12 +116,6 @@ export class OracleDialect extends AbstractDialect<OracleDialectOptions, OracleC
   }
 
   escapeString(val: string): string {
-    if (val.startsWith('TO_TIMESTAMP_TZ') || val.startsWith('TO_DATE')) {
-      this.assertDate(val);
-
-      return val;
-    }
-
     val = val.replaceAll("'", "''");
 
     return `'${val}'`;
@@ -131,55 +125,6 @@ export class OracleDialect extends AbstractDialect<OracleDialectOptions, OracleC
     const hex = buffer.toString('hex');
 
     return `'${hex}'`;
-  }
-
-  // assert date to avoid SQL injections.
-  assertDate(val: string): void {
-    // Split the string using parentheses to isolate the function name, parameters, and potential extra parts
-    const splitVal = val.split(/\(|\)/);
-
-    // Validate that the split result has exactly three parts (function name, parameters, and an empty string)
-    // and that there are no additional SQL commands after the function call (indicated y the last empty string).
-    if (splitVal.length !== 3 || splitVal[2] !== '') {
-      throw new Error('Invalid SQL function call.'); // Error if function call has unexpected format
-    }
-
-    // Extract the function name (either 'TO_TIMESTAMP_TZ' or 'TO_DATE') and the contents inside the parentheses
-    const functionName = splitVal[0].trim(); // Function name should be 'TO_TIMESTAMP_TZ' or 'TO_DATE'
-    const insideParens = splitVal[1].trim(); // This contains the parameters (date value and format string)
-
-    if (!['TO_TIMESTAMP_TZ', 'TO_DATE'].includes(functionName)) {
-      throw new Error('Invalid SQL function call. Expected TO_TIMESTAMP_TZ or TO_DATE.');
-    }
-
-    // Split the parameters inside the parentheses by commas (should contain exactly two: date and format)
-    const params = insideParens.split(',');
-
-    // Validate that the parameters contain exactly two parts (date value and format string)
-    if (params.length !== 2) {
-      throw new Error(
-        'Unexpected input received.\nSequelize supports TO_TIMESTAMP_TZ or TO_DATE exclusively with a combination of value and format.',
-      );
-    }
-
-    // Extract the format value (second parameter) and remove single quotes around it
-    const formatValue = params[1].trim();
-
-    if (functionName === 'TO_TIMESTAMP_TZ') {
-      const expectedFormat = "'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM'";
-      // Validate that the formatValue is equal to expectedFormat since that is the only format used within sequelize
-      if (formatValue !== expectedFormat) {
-        throw new Error(
-          `Invalid format string for TO_TIMESTAMP_TZ. Expected format: ${expectedFormat}`,
-        );
-      }
-    } else if (functionName === 'TO_DATE') {
-      const expectedFormat = "'YYYY/MM/DD'";
-      // Validate that the formatValue is equal to expectedFormat since that is the only format used within sequelize
-      if (formatValue !== expectedFormat) {
-        throw new Error(`Invalid format string for TO_DATE. Expected format: ${expectedFormat}`);
-      }
-    }
   }
 
   static getSupportedOptions() {


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

This fixes two Oracle v7 regressions introduced by #18050:

1. Generic string escaping treated strings beginning with `TO_DATE` or `TO_TIMESTAMP_TZ` as SQL
   expressions. The validation checked the wrapper shape and format literal but did not validate the
   first argument, allowing constrained raw SQL to reach the query.
2. Inline `DATEONLY` escaping recursed between `escape()` and `toBindableValue()`, causing typed
   predicates such as `where` comparisons to throw `RangeError: Maximum call stack size exceeded`.

Oracle's generic string escaping now always escapes strings. Inline `DATE` and `DATEONLY` values use
their data type `escape()` implementations to generate `TO_TIMESTAMP_TZ(...)` and `TO_DATE(...)`.
Bind values remain plain ISO-form values.

This supersedes #18216 and removes the unsafe raw string handling instead of trying to validate SQL
expression text.

Added coverage for:

- Named and positional replacement values shaped like placeholders and SQL date expressions
- Inline `DATE` and `DATEONLY` escaping across every dialect, including Unix epoch values
- Typed temporal `where` predicates covering equality, comparisons, ranges, membership, and nulls
- An Oracle integration regression for `TO_DATE`-prefixed replacement values

Tests run:

- The affected `where`, temporal datatype, and replacement unit files under all nine dialects
- `DIALECT=oracle yarn workspace @sequelize/core mocha "test/integration/sequelize/query.test.js" --grep "TO_DATE-prefixed replacement values"`
- `tsc --noEmit --project packages/oracle/tsconfig.json`
- `tsc -b packages/core/test/tsconfig.json`
- `eslint` and `prettier --check` on changed files

## List of Breaking Changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle handling for DATE and DATEONLY literals, with consistent `TO_TIMESTAMP_TZ(...)` / `TO_DATE(...)` SQL generation and safer inline serialization.
  * Corrected how escaped query replacement values are quoted so date-like expressions (e.g., `TO_DATE(...)`, `TO_TIMESTAMP_TZ(...)`) are treated as plain strings, not reinterpreted as SQL.
  * Ensured DATEONLY comparisons and filtering serialize reliably across supported dialects, including epoch inputs.
* **Tests**
  * Added/expanded unit and integration coverage for Oracle date construction, replacement escaping, and DATE/DATEONLY SQL serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->