### PR TITLE
fix(core): bound attribute syntax parser caches

### DIFF
--- a/packages/core/src/utils/attribute-syntax.ts
+++ b/packages/core/src/utils/attribute-syntax.ts
@@ -1,7 +1,6 @@
 import { pojo } from '@sequelize/utils';
 import type { SyntaxNode } from 'bnf-parser';
 import { BNF, Compile, ParseError } from 'bnf-parser';
-import memoize from 'lodash/memoize.js';
 import type { Class } from 'type-fest';
 import { AssociationPath } from '../expression-builders/association-path.js';
 import { Attribute } from '../expression-builders/attribute.js';
@@ -9,6 +8,12 @@ import { Cast } from '../expression-builders/cast.js';
 import type { DialectAwareFn } from '../expression-builders/dialect-aware-fn.js';
 import { Unquote } from '../expression-builders/dialect-aware-fn.js';
 import { JsonPath } from '../expression-builders/json-path.js';
+
+const ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE = 1000;
+
+type MemoizedParser<T> = ((key: string) => T) & {
+  cache: Map<string, T>;
+};
 
 /**
  * Parses the attribute syntax (the syntax of keys in WHERE POJOs) into its "BaseExpression" representation.
@@ -24,14 +29,46 @@ import { JsonPath } from '../expression-builders/json-path.js';
  *
  * @param attribute The syntax to parse
  */
-export const parseAttributeSyntax = memoize(parseAttributeSyntaxInternal);
+export const parseAttributeSyntax = memoizeWithBoundedCache(parseAttributeSyntaxInternal);
 
 /**
  * Parses the syntax supported by nested JSON properties.
  * This is a subset of {@link parseAttributeSyntax}, which does not parse associations, and returns raw data
  * instead of a BaseExpression.
  */
-export const parseNestedJsonKeySyntax = memoize(parseJsonPropertyKeyInternal);
+export const parseNestedJsonKeySyntax = memoizeWithBoundedCache(parseJsonPropertyKeyInternal);
+
+function memoizeWithBoundedCache<T>(fn: (key: string) => T): MemoizedParser<T> {
+  const cache = new Map<string, T>();
+
+  const memoized = (key: string): T => {
+    if (cache.has(key)) {
+      const result = cache.get(key)!;
+
+      // Reinsert cache hits so untouched entries are evicted first.
+      cache.delete(key);
+      cache.set(key, result);
+
+      return result;
+    }
+
+    const result = fn(key);
+
+    if (cache.size >= ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE) {
+      const oldestKey = cache.keys().next().value;
+
+      if (oldestKey !== undefined) {
+        cache.delete(oldestKey);
+      }
+    }
+
+    cache.set(key, result);
+
+    return result;
+  };
+
+  return Object.assign(memoized, { cache });
+}
 
 /**
  * List of supported attribute modifiers.

--- a/packages/core/src/utils/attribute-syntax.ts
+++ b/packages/core/src/utils/attribute-syntax.ts
@@ -9,7 +9,8 @@ import type { DialectAwareFn } from '../expression-builders/dialect-aware-fn.js'
 import { Unquote } from '../expression-builders/dialect-aware-fn.js';
 import { JsonPath } from '../expression-builders/json-path.js';
 
-const ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE = 1000;
+// Defensive upper bound; not derived from workload measurements.
+export const ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE = 1000;
 
 type MemoizedParser<T> = ((key: string) => T) & {
   cache: Map<string, T>;

--- a/packages/core/test/unit/utils/attribute-syntax.test.ts
+++ b/packages/core/test/unit/utils/attribute-syntax.test.ts
@@ -1,22 +1,16 @@
 import { AssociationPath, Attribute, sql } from '@sequelize/core';
 import { Unquote } from '@sequelize/core/_non-semver-use-at-your-own-risk_/expression-builders/dialect-aware-fn.js';
 import {
+  ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE,
   parseAttributeSyntax,
   parseNestedJsonKeySyntax,
 } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/attribute-syntax.js';
 import { expect } from 'chai';
 
-const ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE = 1000;
-
-function clearParserCaches(): void {
-  parseAttributeSyntax.cache.clear();
-  parseNestedJsonKeySyntax.cache.clear();
-}
-
-beforeEach(clearParserCaches);
-afterEach(clearParserCaches);
-
 describe('parseAttributeSyntax', () => {
+  beforeEach(() => parseAttributeSyntax.cache.clear());
+  afterEach(() => parseAttributeSyntax.cache.clear());
+
   it('parses simple attributes', () => {
     expect(parseAttributeSyntax('foo')).to.deep.eq(new Attribute('foo'));
   });
@@ -135,6 +129,9 @@ textAttr:json.property
 });
 
 describe('parseNestedJsonKeySyntax', () => {
+  beforeEach(() => parseNestedJsonKeySyntax.cache.clear());
+  afterEach(() => parseNestedJsonKeySyntax.cache.clear());
+
   it('parses JSON paths', () => {
     expect(parseNestedJsonKeySyntax('foo.bar')).to.deep.eq({
       pathSegments: ['foo', 'bar'],

--- a/packages/core/test/unit/utils/attribute-syntax.test.ts
+++ b/packages/core/test/unit/utils/attribute-syntax.test.ts
@@ -6,6 +6,16 @@ import {
 } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/attribute-syntax.js';
 import { expect } from 'chai';
 
+const ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE = 1000;
+
+function clearParserCaches(): void {
+  parseAttributeSyntax.cache.clear();
+  parseNestedJsonKeySyntax.cache.clear();
+}
+
+beforeEach(clearParserCaches);
+afterEach(clearParserCaches);
+
 describe('parseAttributeSyntax', () => {
   it('parses simple attributes', () => {
     expect(parseAttributeSyntax('foo')).to.deep.eq(new Attribute('foo'));
@@ -100,6 +110,28 @@ textAttr:json.property
       sql.jsonPath(new Attribute('foo'), ['abc', 0, 'def', 1]),
     );
   });
+
+  it('keeps recently used attributes cached within a fixed bound', () => {
+    const syntaxes = Array.from(
+      { length: ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE },
+      (_, index) => `field${index}`,
+    );
+
+    for (const syntax of syntaxes) {
+      parseAttributeSyntax(syntax);
+    }
+
+    const firstSyntax = syntaxes[0];
+    const secondSyntax = syntaxes[1];
+    const firstResult = parseAttributeSyntax(firstSyntax);
+
+    parseAttributeSyntax('nextField');
+
+    expect(parseAttributeSyntax.cache.size).to.equal(ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE);
+    expect(parseAttributeSyntax.cache.has(firstSyntax)).to.be.true;
+    expect(parseAttributeSyntax.cache.has(secondSyntax)).to.be.false;
+    expect(parseAttributeSyntax(firstSyntax)).to.equal(firstResult);
+  });
 });
 
 describe('parseNestedJsonKeySyntax', () => {
@@ -130,5 +162,27 @@ describe('parseNestedJsonKeySyntax', () => {
       pathSegments: [0],
       castsAndModifiers: [Unquote, 'text', Unquote, 'text'],
     });
+  });
+
+  it('keeps recently used JSON keys cached within a fixed bound', () => {
+    const syntaxes = Array.from(
+      { length: ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE },
+      (_, index) => `property${index}`,
+    );
+
+    for (const syntax of syntaxes) {
+      parseNestedJsonKeySyntax(syntax);
+    }
+
+    const firstSyntax = syntaxes[0];
+    const secondSyntax = syntaxes[1];
+    const firstResult = parseNestedJsonKeySyntax(firstSyntax);
+
+    parseNestedJsonKeySyntax('nextProperty');
+
+    expect(parseNestedJsonKeySyntax.cache.size).to.equal(ATTRIBUTE_SYNTAX_CACHE_MAX_SIZE);
+    expect(parseNestedJsonKeySyntax.cache.has(firstSyntax)).to.be.true;
+    expect(parseNestedJsonKeySyntax.cache.has(secondSyntax)).to.be.false;
+    expect(parseNestedJsonKeySyntax(firstSyntax)).to.equal(firstResult);
   });
 });


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Not needed: internal implementation only -->
- [ ] Did you update the typescript typings accordingly (if applicable)? <!-- Not applicable -->
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

The attribute syntax parsers currently retain every successfully parsed string in a process-wide
memoization cache.

This change replaces the unbounded memoization with an LRU cache that retains up to 1000 parsed
entries per parser. Cache hits are reinserted so recently used entries remain cached. The limit is a
defensive bound and is not derived from workload measurements.

Eviction is behavior-preserving because callers do not mutate parser results or rely on reference
identity across calls.

Added unit coverage for both parsers to verify the bound and LRU behavior.

Tests run:

- `DIALECT=sqlite3 yarn workspace @sequelize/core mocha --require ./test/support.ts "test/unit/utils/attribute-syntax.test.ts"`
- `tsc --noEmit -p packages/core/tsconfig.json`
- `eslint` and `prettier --check` on changed files

## List of Breaking Changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribute syntax parsing by replacing unbounded memoization with a bounded, recently-used cache.
  * Prevents uncontrolled memory growth during long-running or heavy use.
  * Ensures older cached entries are evicted once the cache reaches the fixed maximum size.
* **Tests**
  * Added coverage to verify correct cache sizing, eviction behavior, and result reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->