### PR TITLE
fix(core): validate session variable assignments

### DIFF
--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -63,7 +63,7 @@ import { withSqliteForeignKeysOff } from './utils/sql.js';
 import { useInflection } from './utils/string';
 import { Validator } from './utils/validator-extras';
 
-const MYSQL_MARIADB_USER_VARIABLE_NAME = /^[a-zA-Z0-9_$.]{1,64}$/;
+const MYSQL_MARIADB_USER_VARIABLE_NAME = /^[a-zA-Z0-9_$.\u0080-\uFFFF]{1,64}$/;
 
 /**
  * This is the main class, the entry point to sequelize.
@@ -436,7 +436,7 @@ Use Sequelize#query if you wish to use replacements.`);
     const query = `SET ${map(variables, (value, key) => {
       if (!MYSQL_MARIADB_USER_VARIABLE_NAME.test(key)) {
         throw new TypeError(
-          `Invalid session variable name "${key}". Use 1-64 letters, numbers, "_", "$", or ".".`,
+          `Invalid session variable name "${key}". Use a 1-64 character unquoted user-variable name.`,
         );
       }
 

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -63,6 +63,8 @@ import { withSqliteForeignKeysOff } from './utils/sql.js';
 import { useInflection } from './utils/string';
 import { Validator } from './utils/validator-extras';
 
+const MYSQL_MARIADB_USER_VARIABLE_NAME = /^[a-zA-Z0-9_$.]{1,64}$/;
+
 /**
  * This is the main class, the entry point to sequelize.
  */
@@ -431,10 +433,21 @@ Use Sequelize#query if you wish to use replacements.`);
     options.type = 'SET';
 
     // Generate SQL Query
-    const query = `SET ${map(
-      variables,
-      (v, k) => `@${k} := ${typeof v === 'string' ? `"${v}"` : v}`,
-    ).join(', ')}`;
+    const query = `SET ${map(variables, (value, key) => {
+      if (!MYSQL_MARIADB_USER_VARIABLE_NAME.test(key)) {
+        throw new TypeError(
+          `Invalid session variable name "${key}". Use 1-64 letters, numbers, "_", "$", or ".".`,
+        );
+      }
+
+      if (value instanceof BaseSqlExpression || (isPlainObject(value) && Op.col in value)) {
+        throw new TypeError(
+          'sequelize.setSessionVariables does not accept SQL expressions as variable values',
+        );
+      }
+
+      return `@${key} := ${this.escape(value)}`;
+    }).join(', ')}`;
 
     return await this.query(query, options);
   }

--- a/packages/core/test/integration/sequelize/set-session-variables.test.ts
+++ b/packages/core/test/integration/sequelize/set-session-variables.test.ts
@@ -1,4 +1,4 @@
-import { QueryTypes } from '@sequelize/core';
+import { QueryTypes, sql } from '@sequelize/core';
 import { expect } from 'chai';
 import {
   createSingleTransactionalTestSequelizeInstance,
@@ -68,16 +68,70 @@ describe('sequelize.setSessionVariables', () => {
     });
   });
 
+  it('round-trips strings with quotes and backslashes', async () => {
+    const value = `single quote ', double quote ", backslash \\ value`;
+
+    await sequelize.withConnection(async connection => {
+      await sequelize.setSessionVariables({ text: value }, { connection });
+      const [data] = await sequelize.query<{ text: string }>('SELECT @text as `text`', {
+        type: QueryTypes.SELECT,
+        connection,
+      });
+      expect(data).to.be.ok;
+      expect(data.text).to.equal(value);
+    });
+  });
+
+  it('supports scalar values', async () => {
+    await sequelize.withConnection(async connection => {
+      await sequelize.setSessionVariables(
+        { count: 42, enabled: true, missing: null },
+        { connection },
+      );
+      const [data] = await sequelize.query<{
+        count: string | number;
+        enabled: string | number;
+        missing: string | number;
+      }>(
+        'SELECT @count + 1 as `count`, @enabled = true as `enabled`, @missing IS NULL as `missing`',
+        { type: QueryTypes.SELECT, connection },
+      );
+      expect(data).to.be.ok;
+      expect(Number(data.count)).to.equal(43);
+      expect(Number(data.enabled)).to.equal(1);
+      expect(Number(data.missing)).to.equal(1);
+    });
+  });
+
   it('supports setting multiple values', async () => {
     await sequelize.withConnection(async connection => {
-      await sequelize.setSessionVariables({ foo: 'bar', foos: 'bars' }, { connection });
-      const [data] = await sequelize.query<{ foo: string; foos: string }>(
-        'SELECT @foo as `foo`, @foos as `foos`',
+      await sequelize.setSessionVariables({ foo: 'bar', $foo: 'bars' }, { connection });
+      const [data] = await sequelize.query<{ foo: string; dollarFoo: string }>(
+        'SELECT @foo as `foo`, @$foo as `dollarFoo`',
         { type: QueryTypes.SELECT, connection },
       );
       expect(data).to.be.ok;
       expect(data.foo).to.equal('bar');
-      expect(data.foos).to.equal('bars');
+      expect(data.dollarFoo).to.equal('bars');
+    });
+  });
+
+  it('rejects invalid variable names', async () => {
+    await sequelize.withConnection(async connection => {
+      for (const name of ['', 'display-name', 'display name', 'foo/*comment*/', 'a'.repeat(65)]) {
+        // eslint-disable-next-line no-await-in-loop -- Reuse the held connection sequentially.
+        await expect(
+          sequelize.setSessionVariables({ [name]: 'value' }, { connection }),
+        ).to.be.rejectedWith(TypeError, 'Invalid session variable name');
+      }
+    });
+  });
+
+  it('rejects SQL expressions as values', async () => {
+    await sequelize.withConnection(async connection => {
+      await expect(
+        sequelize.setSessionVariables({ foo: sql.literal('1') }, { connection }),
+      ).to.be.rejectedWith(TypeError, 'does not accept SQL expressions as variable values');
     });
   });
 });

--- a/packages/core/test/unit/sequelize.test.ts
+++ b/packages/core/test/unit/sequelize.test.ts
@@ -47,11 +47,13 @@ describe('Sequelize', () => {
 
     it('escapes an injection value in the generated assignment', async () => {
       const query = sinon.stub(sequelize, 'query').resolves([[], 0]);
-      const value = `", @is_admin := 1, @leak := (SELECT password FROM users LIMIT 1), @z := "`;
+      const value = `", @is_admin := 1, apostrophe ', backslash \\`;
 
       await sequelize.setSessionVariables({ café: value }, { connection: {} });
 
-      expect(query).to.have.been.calledWith(`SET @café := '${value}'`);
+      expect(query).to.have.been.calledWith(
+        String.raw`SET @café := '", @is_admin := 1, apostrophe \', backslash \\'`,
+      );
     });
   });
 

--- a/packages/core/test/unit/sequelize.test.ts
+++ b/packages/core/test/unit/sequelize.test.ts
@@ -38,6 +38,23 @@ describe('Sequelize', () => {
     });
   });
 
+  describe('setSessionVariables', () => {
+    afterEach(() => sinon.restore());
+
+    if (!['mysql', 'mariadb'].includes(sequelize.dialect.name)) {
+      return;
+    }
+
+    it('escapes an injection value in the generated assignment', async () => {
+      const query = sinon.stub(sequelize, 'query').resolves([[], 0]);
+      const value = `", @is_admin := 1, @leak := (SELECT password FROM users LIMIT 1), @z := "`;
+
+      await sequelize.setSessionVariables({ café: value }, { connection: {} });
+
+      expect(query).to.have.been.calledWith(`SET @café := '${value}'`);
+    });
+  });
+
   describe('close', () => {
     it('clears the pool & closes Sequelize', async () => {
       const options = {


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Not needed: behavior fix only -->
- [ ] Did you update the typescript typings accordingly (if applicable)? <!-- Not applicable -->
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

`Sequelize#setSessionVariables` interpolated variable names and values directly into a single
`SET` statement. An attacker-controlled value could add assignments or subqueries without
requiring `multipleStatements`.

Values now pass through Sequelize's normal MySQL/MariaDB escaping path. This closes the injection
under the default SQL modes. The shared escaper's pre-existing `NO_BACKSLASH_ESCAPES` limitation is
outside this PR.

Names are validated against the supported 1-64 character unquoted user-variable grammar,
including `.` and U+0080-U+FFFF. SQL expressions are rejected because this API accepts values,
not raw SQL fragments.

Added integration coverage for normal values, valid and invalid names, and expression rejection,
plus an always-on unit assertion that the generated SQL keeps an injection value inert.

Tests run:

- `DIALECT=mariadb yarn workspace @sequelize/core mocha "test/unit/sequelize.test.ts" "test/integration/sequelize/set-session-variables.test.ts"`
- `DIALECT=mysql yarn workspace @sequelize/core mocha "test/unit/sequelize.test.ts"`
- `tsc -b packages/core/test/tsconfig.json`
- `eslint` and `prettier --check` on changed files

## List of Breaking Changes

Quoted user-variable names, such as `` `my var` ``, `'x'`, or `"x"`, are now rejected. Use an
unquoted name matching the supported grammar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL/MariaDB `SET` session-variable handling with stricter validation of variable names.
  * Rejects invalid session variable names and prevents SQL-expression-like values from being used as values.
  * Produces safer `SET` statements for string values, correctly escaping quotes and backslashes (including `null` and scalar values).
* **Tests**
  * Expanded unit and integration coverage for single/multiple variables, dollar-prefixed keys, escaping round-trips, and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->