### PR TITLE
fix(sqlite3): preserve autoincrement on alter sync

### DIFF
--- a/packages/core/test/integration/query-interface/createTable.test.js
+++ b/packages/core/test/integration/query-interface/createTable.test.js
@@ -25,7 +25,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
 
       const result = await this.queryInterface.describeTable('TableWithPK');
 
-      if (['mssql', 'mysql', 'mariadb'].includes(dialect)) {
+      if (['mssql', 'mysql', 'mariadb', 'sqlite3'].includes(dialect)) {
         expect(result.table_id.autoIncrement).to.be.true;
       } else if (dialect === 'postgres') {
         expect(result.table_id.defaultValue).to.equal(

--- a/packages/core/test/integration/query-interface/createTable.test.js
+++ b/packages/core/test/integration/query-interface/createTable.test.js
@@ -34,6 +34,29 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       }
     });
 
+    if (dialect === 'sqlite3') {
+      it('does not mistake a CHECK constraint literal for the AUTOINCREMENT keyword', async function () {
+        await this.sequelize.query(
+          `CREATE TABLE "TableWithCheckLiteral" ("id" INTEGER PRIMARY KEY, "note" TEXT CHECK ("note" != 'AUTOINCREMENT'))`,
+        );
+
+        const result = await this.queryInterface.describeTable('TableWithCheckLiteral');
+
+        expect(result.id.autoIncrement).to.be.false;
+        expect(result.note.autoIncrement).to.be.false;
+      });
+
+      it('does not lose a later column autoIncrement when an earlier column default contains `--`', async function () {
+        await this.sequelize.query(
+          `CREATE TABLE "TableWithDashesInDefault" ("note" TEXT DEFAULT 'a--b', "id" INTEGER PRIMARY KEY AUTOINCREMENT)`,
+        );
+
+        const result = await this.queryInterface.describeTable('TableWithDashesInDefault');
+
+        expect(result.id.autoIncrement).to.be.true;
+      });
+    }
+
     // SQLITE does not respect the index name when the index is created through CREATE TABLE
     // As such, Sequelize's createTable does not add the constraint in the Sequelize Dialect.
     // Instead, `sequelize.sync` calls CREATE INDEX after the table has been created,

--- a/packages/core/test/integration/sequelize.test.js
+++ b/packages/core/test/integration/sequelize.test.js
@@ -471,6 +471,35 @@ describe(getTestDialectTeaser('Sequelize'), () => {
       });
     });
 
+    if (dialect === 'sqlite3') {
+      it('preserves AUTOINCREMENT after sync alter recreates a sqlite table', async function () {
+        this.sequelize.define(
+          'auto_increment_alter',
+          {
+            id: {
+              type: DataTypes.INTEGER,
+              primaryKey: true,
+              autoIncrement: true,
+            },
+            name: DataTypes.STRING,
+          },
+          {
+            tableName: 'auto_increment_alter',
+            timestamps: false,
+          },
+        );
+
+        await this.sequelize.sync({ force: true });
+        await this.sequelize.sync({ alter: true });
+
+        const [rows] = await this.sequelize.query(
+          "SELECT sql FROM sqlite_master WHERE tbl_name='auto_increment_alter'",
+        );
+
+        expect(rows[0].sql).to.include('AUTOINCREMENT');
+      });
+    }
+
     describe("doesn't emit logging when explicitly saying not to", () => {
       const vars = beforeEach2(() => {
         const spy = sinon.spy();

--- a/packages/sqlite3/src/query-interface.ts
+++ b/packages/sqlite3/src/query-interface.ts
@@ -29,6 +29,27 @@ import type { SqliteDialect } from './dialect.js';
 import { SqliteQueryInterfaceInternal } from './query-interface.internal.js';
 import type { SqliteColumnsDescription } from './query-interface.types.js';
 
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function columnDefinitionHasAutoIncrement(createTableSql: string, columnName: string): boolean {
+  const escapedColumnName = escapeRegExp(columnName);
+  const escapedDoubleQuotedColumnName = escapeRegExp(columnName.replaceAll('"', '""'));
+  const escapedBacktickQuotedColumnName = escapeRegExp(columnName.replaceAll('`', '``'));
+  const escapedBracketQuotedColumnName = escapeRegExp(columnName.replaceAll(']', ']]'));
+  const columnIdentifier = [
+    `"${escapedDoubleQuotedColumnName}"`,
+    `\`${escapedBacktickQuotedColumnName}\``,
+    `\\[${escapedBracketQuotedColumnName}\\]`,
+    escapedColumnName,
+  ].join('|');
+
+  return new RegExp(`(?:^|[(,])\\s*(?:${columnIdentifier})\\s+[^,]*\\bAUTOINCREMENT\\b`, 'i').test(
+    createTableSql,
+  );
+}
+
 export class SqliteQueryInterface<
   Dialect extends SqliteDialect = SqliteDialect,
 > extends AbstractQueryInterface<Dialect> {
@@ -99,6 +120,21 @@ export class SqliteQueryInterface<
       // we can't control
       for (const column of Object.values(data)) {
         column.unique = false;
+      }
+
+      const describeCreateTableSql = this.queryGenerator.describeCreateTableQuery(table);
+      const describeCreateTable = await this.sequelize.queryRaw(describeCreateTableSql, {
+        ...options,
+        raw: true,
+        type: QueryTypes.SELECT,
+      });
+      const createTableSql =
+        describeCreateTable.length > 0 && 'sql' in describeCreateTable[0]
+          ? (describeCreateTable[0].sql as string)
+          : '';
+
+      for (const [columnName, column] of Object.entries(data)) {
+        column.autoIncrement = columnDefinitionHasAutoIncrement(createTableSql, columnName);
       }
 
       const indexes = await this.showIndex(tableName, options);

--- a/packages/sqlite3/src/query-interface.ts
+++ b/packages/sqlite3/src/query-interface.ts
@@ -33,7 +33,27 @@ function escapeRegExp(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Removes SQL comments and single-quoted string literals from a `CREATE TABLE` statement,
+ * so that literal text (e.g. a `CHECK` constraint or `DEFAULT` comparing against the string
+ * `'AUTOINCREMENT'`) can't be mistaken for the `AUTOINCREMENT` keyword itself.
+ *
+ * This must be done in a single scan rather than as separate comment/string passes: if string
+ * literals were stripped last, a literal that happens to contain `--` or `/*` (e.g.
+ * `DEFAULT 'a--b'`) would be misread as starting a comment by an earlier pass, which can
+ * swallow the rest of a single-line `CREATE TABLE` statement, including a later column's
+ * genuine `AUTOINCREMENT` keyword.
+ *
+ * @param sql The raw `CREATE TABLE` statement, as read from `sqlite_master`.
+ */
+function stripSqlStringLiteralsAndComments(sql: string): string {
+  return sql.replaceAll(/\/\*[\s\S]*?\*\/|--[^\n]*|'(?:[^']|'')*'/g, match => {
+    return match.startsWith(`'`) ? `''` : ' ';
+  });
+}
+
 function columnDefinitionHasAutoIncrement(createTableSql: string, columnName: string): boolean {
+  const sanitizedCreateTableSql = stripSqlStringLiteralsAndComments(createTableSql);
   const escapedColumnName = escapeRegExp(columnName);
   const escapedDoubleQuotedColumnName = escapeRegExp(columnName.replaceAll('"', '""'));
   const escapedBacktickQuotedColumnName = escapeRegExp(columnName.replaceAll('`', '``'));
@@ -46,7 +66,7 @@ function columnDefinitionHasAutoIncrement(createTableSql: string, columnName: st
   ].join('|');
 
   return new RegExp(`(?:^|[(,])\\s*(?:${columnIdentifier})\\s+[^,]*\\bAUTOINCREMENT\\b`, 'i').test(
-    createTableSql,
+    sanitizedCreateTableSql,
   );
 }
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to the documentation repository? Not needed.
- [x] Did you update the typescript typings accordingly (if applicable)? Not applicable.
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow our conventions?

## Description of Changes

Closes #18265.

SQLite's `PRAGMA TABLE_INFO` does not report whether an integer primary key was created with `AUTOINCREMENT`.

`sync({ alter: true })` uses `describeTable()` before recreating SQLite tables, so the recreated table lost that flag and changed `INTEGER PRIMARY KEY AUTOINCREMENT` into `INTEGER PRIMARY KEY`.

This checks the original `CREATE TABLE` SQL from `sqlite_master` when describing SQLite tables and restores `autoIncrement` for affected columns.

Tests cover `describeTable()` and the `sync({ alter: true })` recreation path.

## List of Breaking Changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite table metadata parsing to more reliably detect whether an auto-incrementing primary key is truly present.
  * Ensured `AUTOINCREMENT` is preserved correctly when syncing existing SQLite tables with alteration enabled.
* **Tests**
  * Expanded auto-increment behavior assertions to include SQLite dialect coverage.
  * Added new SQLite integration tests covering both table metadata detection and `sync({ alter: true })` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->