### PR TITLE
fix(core): keep root rows for optional belongsToMany with a required nested include

### DIFF
--- a/packages/core/src/model-internals.ts
+++ b/packages/core/src/model-internals.ts
@@ -62,7 +62,7 @@ export function _validateIncludedElements(options: any, tableNames: any = {}) {
     if (include.subQuery !== false && options.hasDuplicating && options.topLimit) {
       if (include.duplicating) {
         include.subQuery = include.subQuery || false;
-        include.subQueryFilter = include.hasRequired;
+        include.subQueryFilter = include.required;
       } else {
         include.subQuery = include.hasRequired;
         include.subQueryFilter = false;

--- a/packages/core/test/integration/include/limit.test.js
+++ b/packages/core/test/integration/include/limit.test.js
@@ -395,6 +395,37 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       expect(result[0].name).to.equal('charlie');
     });
 
+    it('supports optional many-to-many association with nested required association', async function () {
+      await this.sequelize.sync({ force: true });
+
+      const [posts, tags, colors] = await Promise.all([
+        this.Post.bulkCreate(build('alpha', 'bravo')),
+        this.Tag.bulkCreate(build('atag')),
+        this.Color.bulkCreate(build('red')),
+      ]);
+
+      await Promise.all([posts[0].addTag(tags[0]), tags[0].setColor(colors[0])]);
+
+      const result = await this.Post.findAll({
+        include: [
+          {
+            model: this.Tag,
+            required: false,
+            include: [
+              {
+                model: this.Color,
+                required: true,
+              },
+            ],
+          },
+        ],
+        order: ['name'],
+        limit: 10,
+      });
+
+      expect(result.map(post => post.name)).to.deep.equal(['alpha', 'bravo']);
+    });
+
     it('supports 2 required many-to-many association', async function () {
       await this.sequelize.sync({ force: true });
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Fixes #18255.

An optional `belongsToMany` include (`required: false`) that contains a required nested include was dropping root rows with no matching association when the query ran in `subQuery` mode, which `limit` forces on a duplicating association. The required descendant caused a root-level `EXISTS` filter to be added, so the optional association behaved as if it were required.

The subquery filter now keys off the include's own `required` flag instead of `hasRequired`, so it no longer fires for an optional parent and the result matches the non-`subQuery` case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filtered eager-loading queries with limits so optional associations containing required nested associations return the correct records.

* **Tests**
  * Added coverage for limited queries involving optional many-to-many associations and required nested includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->