### PR TITLE
docs(cli): document that config files are executed as code

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,63 @@ yarn add @sequelize/cli
 - If installed locally using `yarn`: `yarn sequelize --help`
 - If installed locally using `npm`: `npx sequelize --help`
 
+## Configuration
+
+The CLI uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) to find its configuration.
+It searches the current working directory (it does not walk up to parent directories) and uses the
+first of these that exists and is non-empty:
+
+1. `package.json` — the `sequelize` property
+2. `.sequelizerc` (parsed as YAML)
+3. `.sequelizerc.json`
+4. `.sequelizerc.yaml`
+5. `.sequelizerc.yml`
+6. `.sequelizerc.js`
+7. `.sequelizerc.ts`
+8. `.sequelizerc.cjs`
+9. `.sequelizerc.mjs`
+10. the same eight `sequelizerc` variants (2–9) again, inside a `.config` directory
+11. `sequelize.config.js`
+12. `sequelize.config.ts`
+13. `sequelize.config.cjs`
+14. `sequelize.config.mjs`
+
+The first match wins; the remaining locations are not read. The directory containing the config file
+is treated as the project root, and relative `migrationFolder` / `seedFolder` values are resolved
+against it.
+
+A JavaScript config file exports its configuration as the default export:
+
+```js
+// sequelize.config.mjs
+import { PostgresDialect } from '@sequelize/postgres';
+
+export default {
+  migrationFolder: '/migrations',
+  seedFolder: '/seeds',
+  database: {
+    dialect: PostgresDialect,
+    url: process.env.DATABASE_URL,
+  },
+};
+```
+
+### Config files are executed as code
+
+The `.js`, `.cjs`, `.mjs` and `.ts` entries above are modules: the CLI imports them, which runs
+whatever they contain, before the command you asked for does any work. This is deliberate — it is
+what lets a config read environment variables, import a dialect class, or compute paths, as in the
+example above.
+
+It does mean a project's CLI config carries the same trust as the project's source code. Running any
+`sequelize` command in a directory runs that directory's config file. Picking an inert format such
+as `.sequelizerc.json` for your own project does not opt out of this: whichever file is discovered
+first is the one that is used, and if it is a JavaScript or TypeScript module, it executes.
+
+This is worth keeping in mind in CI. A job that checks out a branch and runs a `sequelize` command
+executes that branch's config file, so treat it the way you already treat running that branch's
+build scripts or tests.
+
 ## Documentation
 
 The documentation can be found at https://sequelize.org/docs/v7/cli/


### PR DESCRIPTION
`@sequelize/cli` loads its configuration through cosmiconfig with the default options (`packages/cli/src/_internal/config.ts`). That means several of the discovered config formats are JavaScript/TypeScript modules, which get imported — and therefore executed — while the CLI loads its config, before the requested command does anything.

This is intended cosmiconfig behaviour and there is nothing to fix here. It is just undocumented, and "config file" reads as inert data unless something says otherwise. This PR says otherwise.

## What I verified

- The loader is `cosmiconfig('sequelize')` with no options, so the search places are cosmiconfig 9's defaults. I enumerated them rather than guessing (`getDefaultSearchPlaces('sequelize')`): `package.json#sequelize`, `.sequelizerc`, `.sequelizerc.{json,yaml,yml,js,ts,cjs,mjs}`, the same eight again under `.config/`, then `sequelize.config.{js,ts,cjs,mjs}`.
- `.sequelizerc` with no extension is parsed as YAML (cosmiconfig's `noExt` loader), not as JS.
- `searchStrategy` defaults to `'none'` here because no `stopDir` is passed, so only the working directory is searched — no upward traversal. The README says this explicitly so nobody over-reads the warning.
- First match wins. I confirmed by putting both `.sequelizerc.json` and `.sequelizerc.mjs` in a directory: the `.json` was used and the `.mjs` never ran.
- End-to-end: in a scratch directory containing a `.sequelizerc.mjs` that writes a file as a side effect, `sequelize migration generate --format=sql` produced that file. So the execution happens on a real command run, not only in an isolated cosmiconfig call. The scratch directory was deleted and is not part of this branch.
- The `sequelize.config.mjs` in this package is itself an example of why the executable formats exist (it computes a SQLite path from `import.meta.url`), so the docs frame it as intended rather than unfortunate.

## Where it went

`packages/cli/README.md`. The README had no configuration section at all, so I added one: the discovery order, a short example of a JS config, and then a subsection on execution.

I checked whether this belonged in `sequelize/website` instead. That repo's `docs/cli.md` still documents v6 `sequelize-cli` (config/config.json, `model:generate`, `db:migrate`, the v6 `.sequelizerc` option keys) and opens with a warning that the v7 CLI and its docs are not ready. There is no v7 CLI config documentation there to extend, so the package README is the only place this can currently live. If v7 CLI docs land on the website later, this section should move or be mirrored.

## Deliberately not in scope

No loader behaviour changed. I did not restrict formats, add an opt-in flag, or gate executable configs — if the project wants any of that, it is a separate design discussion and this PR is not it.

Unrelated observation, not touched: `packages/cli/src/_internal/config.ts` performs the cosmiconfig search at module top level with top-level `await`, so merely importing `@sequelize/cli` programmatically (via `index.ts` → `api/*`) also triggers config discovery. That is a design question rather than a docs one, so I left it alone.

## Testing

Docs-only. Ran `prettier --check` and `markdownlint` on the changed file; both pass. No unit tests were affected, so I did not run the CLI suite.

---
*Created by Opus 5 with Claude Code, supervised by @WikiRik.*

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CLI configuration guidance.
  * Documented supported configuration file names, extensions, search order, and matching behavior.
  * Clarified project-root detection and resolution of relative migration and seed folder paths.
  * Added a JavaScript configuration example.
  * Included security guidance about executing JavaScript and TypeScript configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->