### PR TITLE
fix(cli): keep migrationFolder and seedFolder inside the project directory

### DIFF
--- a/packages/cli/src/_internal/config.ts
+++ b/packages/cli/src/_internal/config.ts
@@ -3,6 +3,7 @@ import { AbstractDialect } from '@sequelize/core';
 import { cosmiconfig } from 'cosmiconfig';
 import * as path from 'node:path';
 import { z } from 'zod/v3';
+import { resolveProjectFolder } from './utils.js';
 
 const explorer = cosmiconfig('sequelize');
 const result = await explorer.search();
@@ -60,15 +61,36 @@ const dialectInputSchema = z.union([
   z.string().min(1),
 ]);
 
+/**
+ * Builds the transform used by folder options: it resolves the folder against the project root and
+ * rejects any value that would escape it, so a config file cannot make the CLI create, read or
+ * execute files outside of the project.
+ *
+ * @param optionName The name of the config option, used in the error message.
+ */
+function projectFolderTransform(optionName: string) {
+  return (val: string, ctx: z.RefinementCtx): string => {
+    const resolved = resolveProjectFolder(projectRoot, val);
+
+    if (resolved == null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `"${optionName}" must stay inside the project directory (${projectRoot}), but ${JSON.stringify(val)} resolves outside of it.`,
+      });
+
+      return z.NEVER;
+    }
+
+    return resolved;
+  };
+}
+
 const configSchema = z.strictObject({
   migrationFolder: z
     .string()
     .default('/migrations')
-    .transform(val => path.join(projectRoot, val)),
-  seedFolder: z
-    .string()
-    .default('/seeds')
-    .transform(val => path.join(projectRoot, val)),
+    .transform(projectFolderTransform('migrationFolder')),
+  seedFolder: z.string().default('/seeds').transform(projectFolderTransform('seedFolder')),
   // Optional at the schema level so commands that do not need a database (e.g. migration generate)
   // can run without one. createUmzug() enforces its presence with a clear error at runtime.
   database: z.object({ dialect: dialectInputSchema }).passthrough().optional(),

--- a/packages/cli/src/_internal/utils.test.ts
+++ b/packages/cli/src/_internal/utils.test.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import * as path from 'node:path';
+import { resolveProjectFolder } from './utils.js';
+
+describe('resolveProjectFolder', () => {
+  const projectRoot = path.join(path.sep, 'home', 'me', 'project');
+  const absoluteRoot = path.resolve(projectRoot);
+
+  it('accepts the default option values', () => {
+    // These are the defaults of "migrationFolder" & "seedFolder". They start with a separator but
+    // are still project-relative: resolving them with path.resolve instead of path.join would
+    // discard the project root entirely and make even the default config fail.
+    expect(resolveProjectFolder(projectRoot, '/migrations')).to.equal(
+      path.join(absoluteRoot, 'migrations'),
+    );
+    expect(resolveProjectFolder(projectRoot, '/seeds')).to.equal(path.join(absoluteRoot, 'seeds'));
+  });
+
+  it('accepts folders nested in the project', () => {
+    expect(resolveProjectFolder(projectRoot, 'db/migrations')).to.equal(
+      path.join(absoluteRoot, 'db', 'migrations'),
+    );
+    expect(resolveProjectFolder(projectRoot, './migrations')).to.equal(
+      path.join(absoluteRoot, 'migrations'),
+    );
+    expect(resolveProjectFolder(projectRoot, 'db/../migrations')).to.equal(
+      path.join(absoluteRoot, 'migrations'),
+    );
+  });
+
+  it('accepts the project root itself', () => {
+    expect(resolveProjectFolder(projectRoot, '')).to.equal(absoluteRoot);
+    expect(resolveProjectFolder(projectRoot, '.')).to.equal(absoluteRoot);
+  });
+
+  it('rejects folders that traverse out of the project', () => {
+    expect(resolveProjectFolder(projectRoot, '../../../../etc/cron.d')).to.equal(null);
+    expect(resolveProjectFolder(projectRoot, 'migrations/../../../etc/cron.d')).to.equal(null);
+    expect(resolveProjectFolder(projectRoot, '/../../../etc/cron.d')).to.equal(null);
+  });
+
+  it('rejects the parent directory of the project', () => {
+    expect(resolveProjectFolder(projectRoot, '..')).to.equal(null);
+  });
+
+  it('rejects sibling directories whose name starts with the project name', () => {
+    // Guards against a prefix comparison that ignores the path separator: "/home/me/project-evil"
+    // starts with "/home/me/project" but is not inside of it.
+    expect(resolveProjectFolder(projectRoot, '../project-evil')).to.equal(null);
+    expect(resolveProjectFolder(projectRoot, '../project-evil/migrations')).to.equal(null);
+  });
+
+  it('treats absolute-looking values as project-relative', () => {
+    // Pre-existing behavior, kept for backwards compatibility: because the option values are joined
+    // with the project root, a leading separator does not escape the project.
+    expect(resolveProjectFolder(projectRoot, '/etc/cron.d')).to.equal(
+      path.join(absoluteRoot, 'etc', 'cron.d'),
+    );
+  });
+});

--- a/packages/cli/src/_internal/utils.ts
+++ b/packages/cli/src/_internal/utils.ts
@@ -1,3 +1,31 @@
+import * as path from 'node:path';
+
+/**
+ * Resolves a folder configured by the user against the project root, and asserts that the result
+ * stays inside that project root.
+ *
+ * Folder options are always interpreted as project-relative, including when they start with a
+ * separator (the documented default values are `/migrations` and `/seeds`). `path.join` is
+ * therefore used instead of `path.resolve`, which would discard the project root for such values.
+ *
+ * @param projectRoot The directory the config file was found in (or the cwd if there is none).
+ * @param folder The folder as configured by the user.
+ * @returns The resolved absolute path, or `null` if it points outside of `projectRoot`.
+ */
+export function resolveProjectFolder(projectRoot: string, folder: string): string | null {
+  const root = path.resolve(projectRoot);
+  // path.join normalizes, but a value such as "../../etc" can still climb out of the project.
+  const resolved = path.resolve(path.join(root, folder));
+
+  // The trailing separator matters: without it, "/home/me/project-evil" would be accepted as being
+  // inside "/home/me/project".
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    return null;
+  }
+
+  return resolved;
+}
+
 export function getCurrentYYYYMMDDHHmms() {
   const date = new Date();
 


### PR DESCRIPTION
### Problem

`migrationFolder` and `seedFolder` were taken from the config file and joined with the project root with no containment check:

```ts
migrationFolder: z.string().default('/migrations').transform(val => path.join(projectRoot, val)),
```

`path.join(projectRoot, '../../../../etc/cron.d')` resolves outside the project, and nothing downstream re-checked it. Those two values are used to:

- create directories and write files — `api/generate-migration.ts`, `api/generate-seed.ts` (`fs.mkdir(..., { recursive: true })` + write)
- read a directory and `import()` whatever is in it — `api/get-umzug.ts`

So a config file (a checked-in `sequelize.config.*`, a generated one, or one picked up by cosmiconfig from a parent directory) could make the CLI write into, or execute code from, arbitrary locations on disk.

### Change

Containment is asserted in the zod `transform` of both options, which is the single choke point every consumer goes through — `config.migrationFolder` / `config.seedFolder` are now guaranteed to be inside the project directory.

New helper in `_internal/utils.ts`:

```ts
const root = path.resolve(projectRoot);
const resolved = path.resolve(path.join(root, folder));
if (resolved !== root && !resolved.startsWith(root + path.sep)) return null;
```

Two details that are easy to get wrong and are covered by tests:

- The values must be **joined** with the project root, not `path.resolve`d against it. The schema defaults are `/migrations` and `/seeds`, i.e. absolute-looking; `path.resolve(projectRoot, '/migrations')` discards the base and yields `/migrations`, which would fail containment and throw for *every* config, including the default one.
- The prefix comparison needs the trailing `path.sep`, otherwise `/home/me/project-evil` passes as "inside" `/home/me/project`.

Behavior is unchanged for every valid config: leading-separator values remain project-relative (pre-existing behavior, kept for backwards compatibility — `/etc/cron.d` becomes `<project>/etc/cron.d`, still inside the project). Only values that actually escape the project now fail, with a message naming the option and the offending value.

### Known limitation (deliberate)

The check is on the resolved path string. A **symlink inside the project that points outward** is still followed — e.g. `<project>/migrations` symlinked to `/etc/cron.d`. Closing that would require `fs.realpath`, which needs the directory to already exist; `migration:generate` legitimately creates the folder on first use, so a realpath check would either break that flow or have to be conditional and racy. Left as-is: creating a symlink inside the project already requires write access to the project. Happy to add a realpath check on the read/execute path (`createUmzug`) in a follow-up if a reviewer prefers.

### Verification

- `mocha ./src/**/*.test.ts` in `packages/cli` — 34 passing (7 new, 27 pre-existing). The pre-existing command tests exercise the real config module, so they confirm the default config still parses.
- `tsc --noEmit` on `packages/cli`, plus eslint/prettier on the touched files.
- End-to-end sanity check with a scratch project: `{}` resolves to `<project>/migrations`; `{ migrationFolder: 'db/migrations' }` resolves to `<project>/db/migrations`; `{ migrationFolder: '../../../../tmp/evil-escape' }` fails at config load with `"migrationFolder" must stay inside the project directory (...), but "../../../../tmp/evil-escape" resolves outside of it.`

No integration/dialect suites were run — CI covers those.

---
*Created by Opus 5 with Claude Code, supervised by @WikiRik.*

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI configuration validation to prevent migration and seed folders from accessing locations outside the project directory.
  * Added safer handling for relative, normalized, and absolute-looking folder paths.
  * Improved path boundary checks to prevent traversal into similarly named neighboring directories.

* **Tests**
  * Added comprehensive coverage for valid project folders, path normalization, project-root handling, and blocked traversal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->