### PR TITLE
test(core): cover DATEONLY and DATE in where clauses across dialects

### DIFF
--- a/packages/core/test/unit/data-types/temporal-types.test.ts
+++ b/packages/core/test/unit/data-types/temporal-types.test.ts
@@ -1,6 +1,6 @@
 import { DataTypes, ValidationErrorItem } from '@sequelize/core';
 import { expect } from 'chai';
-import { sequelize } from '../../support';
+import { expectsql, sequelize } from '../../support';
 import { testDataTypeSql } from './_utils';
 
 const dialect = sequelize.dialect;
@@ -41,6 +41,42 @@ describe('DataTypes.DATE', () => {
   });
 
   const type = DataTypes.DATE().toDialectDataType(dialect);
+
+  // `escape` is the "inline value" code path, used whenever a value is embedded directly in the
+  // SQL string instead of being sent as a bind parameter (e.g. `where` clauses in `findAll`).
+  // It is a completely different code path from `getBindParamSql` / `toBindableValue`.
+  describe('escape (inline value)', () => {
+    it('escapes a Date object', () => {
+      expectsql(type.escape(new Date('2022-01-01T12:13:14.123Z')), {
+        default: `'2022-01-01 12:13:14.123 +00:00'`,
+        'mariadb mysql': `'2022-01-01 12:13:14'`,
+        'db2 ibmi snowflake': `'2022-01-01 12:13:14.123'`,
+        mssql: `N'2022-01-01 12:13:14.123 +00:00'`,
+        oracle: `TO_TIMESTAMP_TZ('2022-01-01 12:13:14.123 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+      });
+    });
+
+    it('escapes a date string', () => {
+      expectsql(type.escape('2022-01-01T12:13:14.123Z'), {
+        default: `'2022-01-01 12:13:14.123 +00:00'`,
+        'mariadb mysql': `'2022-01-01 12:13:14'`,
+        'db2 ibmi snowflake': `'2022-01-01 12:13:14.123'`,
+        mssql: `N'2022-01-01 12:13:14.123 +00:00'`,
+        oracle: `TO_TIMESTAMP_TZ('2022-01-01 12:13:14.123 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+      });
+    });
+
+    it('escapes the unix epoch', () => {
+      expectsql(type.escape(0), {
+        default: `'1970-01-01 00:00:00.000 +00:00'`,
+        'mariadb mysql': `'1970-01-01 00:00:00'`,
+        'db2 ibmi snowflake': `'1970-01-01 00:00:00.000'`,
+        mssql: `N'1970-01-01 00:00:00.000 +00:00'`,
+        oracle: `TO_TIMESTAMP_TZ('1970-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+      });
+    });
+  });
+
   describe('validate', () => {
     it('should throw an error if `value` is invalid', () => {
       expect(() => {
@@ -99,6 +135,35 @@ describe('DataTypes.DATEONLY', () => {
   });
 
   const type = DataTypes.DATEONLY().toDialectDataType(dialect);
+
+  // See the comment on DataTypes.DATE#escape above: this is the inline (non-bind) code path,
+  // which had no test coverage on any dialect prior to this suite.
+  describe('escape (inline value)', () => {
+    it('escapes a date-only string', () => {
+      expectsql(type.escape('2022-01-01'), {
+        default: `'2022-01-01'`,
+        mssql: `N'2022-01-01'`,
+        oracle: `TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+      });
+    });
+
+    it('escapes a Date object', () => {
+      expectsql(type.escape(new Date('2022-01-01T12:13:14.123Z')), {
+        default: `'2022-01-01'`,
+        mssql: `N'2022-01-01'`,
+        oracle: `TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+      });
+    });
+
+    it('escapes the unix epoch', () => {
+      expectsql(type.escape(0), {
+        default: `'1970-01-01'`,
+        mssql: `N'1970-01-01'`,
+        oracle: `TO_DATE('1970/01/01', 'YYYY/MM/DD')`,
+      });
+    });
+  });
+
   describe('validate', () => {
     if (dialect.supports.dataTypes.DATEONLY.infinity) {
       it('DATEONLY should stringify Infinity/-Infinity to infinity/-infinity', () => {

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -58,6 +58,7 @@ class TestModel extends Model<InferAttributes<TestModel>> {
   declare stringAttr: string;
   declare binaryAttr: Buffer;
   declare dateAttr: Date;
+  declare dateOnlyAttr: string | null;
   declare booleanAttr: boolean;
   declare bigIntAttr: bigint;
 
@@ -93,6 +94,7 @@ describe(getTestDialectTeaser('SQL'), () => {
         stringAttr: DataTypes.STRING,
         binaryAttr: DataTypes.BLOB,
         dateAttr: DataTypes.DATE(3),
+        dateOnlyAttr: DataTypes.DATEONLY,
         booleanAttr: DataTypes.BOOLEAN,
         ...(dialectSupportsBigInt() && { bigIntAttr: DataTypes.BIGINT }),
 
@@ -434,6 +436,102 @@ Caused by: "undefined" cannot be escaped`),
           oracle: `"dateAttr" = TO_TIMESTAMP_TZ('2013-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
         },
       );
+
+      // Temporal values used inline (i.e. not as bind parameters) go through DataType#escape,
+      // which is a completely separate code path from DataType#getBindParamSql.
+      // The tests below pin the inline path down for both DATEONLY and DATE, on every dialect.
+      describe('DATEONLY', () => {
+        testSql(
+          { dateOnlyAttr: '2022-01-01' },
+          {
+            default: `[dateOnlyAttr] = '2022-01-01'`,
+            mssql: `[dateOnlyAttr] = N'2022-01-01'`,
+            oracle: `"dateOnlyAttr" = TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: new Date('2022-01-01T12:13:14.123Z') },
+          {
+            default: `[dateOnlyAttr] = '2022-01-01'`,
+            mssql: `[dateOnlyAttr] = N'2022-01-01'`,
+            oracle: `"dateOnlyAttr" = TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: { [Op.gt]: '2022-01-01' } },
+          {
+            default: `[dateOnlyAttr] > '2022-01-01'`,
+            mssql: `[dateOnlyAttr] > N'2022-01-01'`,
+            oracle: `"dateOnlyAttr" > TO_DATE('2022/01/01', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: { [Op.between]: ['2022-01-01', '2022-12-31'] } },
+          {
+            default: `[dateOnlyAttr] BETWEEN '2022-01-01' AND '2022-12-31'`,
+            mssql: `[dateOnlyAttr] BETWEEN N'2022-01-01' AND N'2022-12-31'`,
+            oracle: `"dateOnlyAttr" BETWEEN TO_DATE('2022/01/01', 'YYYY/MM/DD') AND TO_DATE('2022/12/31', 'YYYY/MM/DD')`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: { [Op.in]: ['2022-01-01', '2022-12-31'] } },
+          {
+            default: `[dateOnlyAttr] IN ('2022-01-01', '2022-12-31')`,
+            mssql: `[dateOnlyAttr] IN (N'2022-01-01', N'2022-12-31')`,
+            oracle: `"dateOnlyAttr" IN (TO_DATE('2022/01/01', 'YYYY/MM/DD'), TO_DATE('2022/12/31', 'YYYY/MM/DD'))`,
+          },
+        );
+
+        testSql(
+          { dateOnlyAttr: null },
+          {
+            default: `[dateOnlyAttr] IS NULL`,
+          },
+        );
+      });
+
+      describe('DATE', () => {
+        testSql(
+          { dateAttr: { [Op.gt]: new Date('2021-01-01T00:00:00Z') } },
+          {
+            default: `[dateAttr] > '2021-01-01 00:00:00.000 +00:00'`,
+            mssql: `[dateAttr] > N'2021-01-01 00:00:00.000 +00:00'`,
+            'mariadb mysql': `\`dateAttr\` > '2021-01-01 00:00:00.000'`,
+            'db2 ibmi snowflake': `"dateAttr" > '2021-01-01 00:00:00.000'`,
+            oracle: `"dateAttr" > TO_TIMESTAMP_TZ('2021-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+          },
+        );
+
+        testSql(
+          {
+            dateAttr: {
+              [Op.between]: [new Date('2021-01-01T00:00:00Z'), new Date('2022-01-01T00:00:00Z')],
+            },
+          },
+          {
+            default: `[dateAttr] BETWEEN '2021-01-01 00:00:00.000 +00:00' AND '2022-01-01 00:00:00.000 +00:00'`,
+            mssql: `[dateAttr] BETWEEN N'2021-01-01 00:00:00.000 +00:00' AND N'2022-01-01 00:00:00.000 +00:00'`,
+            'mariadb mysql': `\`dateAttr\` BETWEEN '2021-01-01 00:00:00.000' AND '2022-01-01 00:00:00.000'`,
+            'db2 ibmi snowflake': `"dateAttr" BETWEEN '2021-01-01 00:00:00.000' AND '2022-01-01 00:00:00.000'`,
+            oracle: `"dateAttr" BETWEEN TO_TIMESTAMP_TZ('2021-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM') AND TO_TIMESTAMP_TZ('2022-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM')`,
+          },
+        );
+
+        testSql(
+          { dateAttr: { [Op.in]: [new Date('2021-01-01T00:00:00Z')] } },
+          {
+            default: `[dateAttr] IN ('2021-01-01 00:00:00.000 +00:00')`,
+            mssql: `[dateAttr] IN (N'2021-01-01 00:00:00.000 +00:00')`,
+            'mariadb mysql': `\`dateAttr\` IN ('2021-01-01 00:00:00.000')`,
+            'db2 ibmi snowflake': `"dateAttr" IN ('2021-01-01 00:00:00.000')`,
+            oracle: `"dateAttr" IN (TO_TIMESTAMP_TZ('2021-01-01 00:00:00.000 +00:00', 'YYYY-MM-DD HH24:MI:SS.FFTZH:TZM'))`,
+          },
+        );
+      });
 
       describe('Buffer', () => {
         testSql(

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -461,6 +461,53 @@ describe('injectReplacements (named replacements)', () => {
     });
   });
 
+  // Replacement *values* must always be escaped as plain string literals, never re-interpreted as
+  // SQL. These guards cover values shaped like placeholders and like SQL function calls.
+  it('escapes replacement values that look like a named replacement', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE id = :id`, dialect, {
+      id: ':id',
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE id = ':id'`,
+      mssql: `SELECT * FROM users WHERE id = N':id'`,
+    });
+  });
+
+  it('escapes replacement values that look like a positional bind parameter', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE id = :id`, dialect, {
+      id: '$1',
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE id = '$1'`,
+      mssql: `SELECT * FROM users WHERE id = N'$1'`,
+    });
+  });
+
+  it('escapes replacement values that look like a positional replacement', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE id = :id`, dialect, {
+      id: '?',
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE id = '?'`,
+      mssql: `SELECT * FROM users WHERE id = N'?'`,
+    });
+  });
+
+  it('escapes replacement values that look like a SQL date expression', () => {
+    const sql = injectReplacements(`SELECT * FROM users WHERE createdAt = :date`, dialect, {
+      date: `TO_DATE('2024/01/01','YYYY/MM/DD')`,
+    });
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE createdAt = 'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
+      'mariadb mysql': `SELECT * FROM users WHERE createdAt = 'TO_DATE(\\'2024/01/01\\',\\'YYYY/MM/DD\\')'`,
+      mssql: `SELECT * FROM users WHERE createdAt = N'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
+    });
+  });
+
   it('throws if a named replacement is not provided as an own property', () => {
     expect(() => {
       injectReplacements(`SELECT * FROM users WHERE id = :toString`, dialect, {
@@ -743,6 +790,20 @@ describe('injectReplacements (positional replacements)', () => {
 
     expectsql(sql, {
       default: `SELECT [?] FROM users WHERE id = '?' OR id = 1 OR id = '''?''' OR id2 = 2`,
+    });
+  });
+
+  it('escapes replacement values that look like placeholders or SQL expressions', () => {
+    const sql = injectReplacements(
+      `SELECT * FROM users WHERE a = ? AND b = ? AND c = ? AND d = ?`,
+      dialect,
+      ['?', '$1', ':id', `TO_DATE('2024/01/01','YYYY/MM/DD')`],
+    );
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE a = '?' AND b = '$1' AND c = ':id' AND d = 'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
+      'mariadb mysql': `SELECT * FROM users WHERE a = '?' AND b = '$1' AND c = ':id' AND d = 'TO_DATE(\\'2024/01/01\\',\\'YYYY/MM/DD\\')'`,
+      mssql: `SELECT * FROM users WHERE a = N'?' AND b = N'$1' AND c = N':id' AND d = N'TO_DATE(''2024/01/01'',''YYYY/MM/DD'')'`,
     });
   });
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

**Tests only. This PR intentionally does not fix any behaviour** — it adds the coverage that
should have caught an already-reported Oracle bug, which is fixed by #18270.

### The gap

No test anywhere in the repo put a `DATEONLY` value in a `where` clause, on any dialect. More
broadly, nothing exercised temporal types through the *inline* escape path (`DataType#escape`) at
all — the only `DATEONLY` coverage goes through the **bind** path (`create`, `findByPk`,
`findOne({ where: { id } })`), which never reaches inline escaping.

That is a structural gap, not an Oracle-specific one, which is why it stayed invisible: on `main`
today, `Model.findAll({ where: { someDateOnlyCol: value } })` against Oracle throws
`RangeError: Maximum call stack size exceeded` (unconditional infinite recursion in
`escape` → `toBindableValue` → `escape`). A unit test in that shape would have caught it
immediately, with no database involved.

### What was added

All of it runs in the always-on unit job — no database, no `DIALECT=` integration run.

1. `packages/core/test/unit/sql/where.test.ts` — a `dateOnlyAttr` (`DataTypes.DATEONLY`) on the
   test model, plus `expectsql` snapshots for `DATEONLY` in `where` clauses (`=`, `Op.gt`,
   `Op.between`, `Op.in`, `IS NULL`) and the equivalent `DATE` cases (`Op.gt`, `Op.between`,
   `Op.in`), across every dialect.
2. `packages/core/test/unit/data-types/temporal-types.test.ts` — per-dialect `escape (inline value)`
   coverage for `DataTypes.DATE` and `DataTypes.DATEONLY` (Date object, date string, unix epoch).
   This is the code path that had zero tests.
3. `packages/core/test/unit/utils/sql.test.ts` — guards that replacement *values* shaped like
   `:name`, `$1`, `?`, or like a SQL date expression (`TO_DATE('…','…')`) are escaped as plain
   string literals and never re-interpreted as SQL. This behaviour was previously only protected by
   an Oracle *integration* job, which does not run on every PR.

### ⚠️ Some of these tests fail on `main` — this is expected

On `main`, **10 tests fail under `DIALECT=oracle`** (all other dialects are green):

- 5× `where.test.ts` `DATEONLY` cases — `RangeError: Maximum call stack size exceeded`
- 3× `temporal-types.test.ts` `DATEONLY` inline `escape` cases — same recursion
- 2× `sql.test.ts` replacement-value cases — the `TO_DATE(…)` value is injected into the SQL raw
  instead of being escaped as a string

**All 10 pass once #18270 merges.** I verified this locally by applying only the
`packages/oracle/src/**` part of that PR's diff, rebuilding `@sequelize/oracle`, and re-running:
452/452 pass. The expectations here were written against the post-#18270 output, and no test was
weakened to make it green.

If it is preferred to have this branch green on its own, the maintainers' call would be either to
merge #18270 first and rebase this, or to fold these tests into #18270 — happy either way.

## How this was verified

- `DIALECT=<d> yarn workspace @sequelize/core mocha "test/unit/sql/where.test.ts" "test/unit/data-types/temporal-types.test.ts" "test/unit/utils/sql.test.ts"` for all 9 dialects — green everywhere except the 10 known Oracle failures listed above
- `DIALECT=postgres yarn workspace @sequelize/core _test-unit` — 2820 passing
- `DIALECT=oracle yarn workspace @sequelize/core _test-unit` — 2346 passing, 10 failing (the ones above)
- with #18270's `packages/oracle/src/**` applied: `DIALECT=oracle` on the three files — 452 passing, 0 failing
- `npx tsc -b packages/core/test/tsconfig.json`
- `npx eslint` on the three changed files

## Deliberately left out

- **The fix itself.** #18270 already fixes the recursion and the replacement escaping; this PR is
  the regression net only, so it can land independently of that fix.
- Integration-level coverage. The whole point is that this shape of bug is catchable without a
  database, in the job that runs on every PR.
- #18270 also touches `test/unit/data-types/temporal-types.test.ts` (adding Oracle-only `escape`
  assertions). The two sets of additions are placed in different spots in the file, but a small
  textual conflict on merge is possible — trivial to resolve, both sets should be kept.

## List of Breaking Changes

None.

---
*Created by Opus 5 with Claude Code, supervised by @WikiRik.*

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL handling for inline date and date-only values across supported database dialects.
  * Ensured replacement values resembling SQL expressions or placeholders are safely treated as quoted string literals.

* **Tests**
  * Added coverage for date escaping, comparison operators, ranges, lists, null values, and dialect-specific formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->