### PR TITLE
fix: validate session variable assignments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn global add node-gyp --ignore-engines
       - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn add pg-native --ignore-engines
+      # pg-native 3.8.0 uses `??`, which Node 10 cannot parse - requiring it throws a SyntaxError
+      # before any test runs. Pin the last release Node 10 can load; newer Node versions keep
+      # testing against the current one.
+      - run: yarn add pg-native@${{ matrix.node-version == 10 && '3.7.0' || 'latest' }} --ignore-engines
         if: matrix.native
       - name: Unit Tests
         run: yarn test-unit

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -29,6 +29,11 @@ const { HasMany } = require('./associations/has-many');
 const { withSqliteForeignKeysOff } = require('./dialects/sqlite/sqlite-utils');
 const { injectReplacements } = require('./utils/sql');
 
+// MySQL 8's unquoted user-variable grammar: identifier characters plus `.`, including
+// U+0080-U+FFFF. The high range is written with explicit escapes on purpose: a literal U+0080 is
+// invisible in most editors and makes the class read as though it began at `.`.
+const MYSQL_MARIADB_USER_VARIABLE_NAME = /^[a-zA-Z0-9_$.\u0080-\uFFFF]{1,64}$/;
+
 /**
  * This is the main class, the entry point to sequelize.
  */
@@ -689,7 +694,17 @@ class Sequelize {
     // Generate SQL Query
     const query =
       `SET ${
-        _.map(variables, (v, k) => `@${k} := ${typeof v === 'string' ? `"${v}"` : v}`).join(', ')}`;
+        _.map(variables, (v, k) => {
+          if (!MYSQL_MARIADB_USER_VARIABLE_NAME.test(k)) {
+            throw new TypeError(`Invalid session variable name "${k}". Use a 1-64 character unquoted user-variable name.`);
+          }
+
+          if (v instanceof Utils.SequelizeMethod) {
+            throw new TypeError('sequelize.set does not accept SQL expressions as variable values');
+          }
+
+          return `@${k} := ${this.escape(v)}`;
+        }).join(', ')}`;
 
     return await this.query(query, options);
   }

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -330,6 +330,42 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         expect(data.foos).to.be.equal('bars');
         await this.t.commit();
       });
+
+      it('stores a value containing quotes and backslashes verbatim', async function() {
+        const t = await this.sequelize.transaction();
+        this.t = t;
+        const value = 'apostrophe \', quote ", backslash \\';
+
+        await this.sequelize.set({ foo: value }, { transaction: t });
+
+        const data = await this.sequelize.query('SELECT @foo as `foo`', { plain: true, transaction: this.t });
+        expect(data.foo).to.be.equal(value);
+        await this.t.commit();
+      });
+
+      it('does not let a value add further assignments', async function() {
+        const t = await this.sequelize.transaction();
+        this.t = t;
+
+        await this.sequelize.set({
+          foo: '", @injected := 1, @z := "'
+        }, { transaction: t });
+
+        const data = await this.sequelize.query('SELECT @foo as `foo`, @injected as `injected`', { plain: true, transaction: this.t });
+        expect(data.foo).to.be.equal('", @injected := 1, @z := "');
+        expect(data.injected).to.be.equal(null);
+        await this.t.commit();
+      });
+
+      it('rejects a name that is not a plain user-variable name', async function() {
+        const t = await this.sequelize.transaction();
+        this.t = t;
+
+        await expect(this.sequelize.set({ 'x := (SELECT 1);-- ': 'bar' }, { transaction: t }))
+          .to.be.rejectedWith(TypeError, 'Invalid session variable name');
+
+        await this.t.commit();
+      });
     });
   }
 

--- a/test/unit/sequelize/set.test.js
+++ b/test/unit/sequelize/set.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+
+const expect = chai.expect;
+const Support = require('../../support');
+const Sequelize = require('sequelize');
+
+const Transaction = Sequelize.Transaction;
+const dialect = Support.getTestDialect();
+
+if (['mysql', 'mariadb'].includes(dialect)) {
+  describe(`[${dialect.toUpperCase()}] Sequelize#set`, () => {
+    const sequelize = Support.sequelize;
+
+    let stub;
+    beforeEach(() => {
+      stub = sinon.stub(sequelize, 'query').resolves({});
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    // `set` builds a single SET statement, so an unescaped value can append further assignments
+    // or subqueries without needing `multipleStatements`.
+    const setVariables = async variables => {
+      await sequelize.set(variables, { transaction: new Transaction(sequelize, {}) });
+
+      return stub.getCall(0).args[0];
+    };
+
+    describe('values', () => {
+      it('escapes a value that tries to append an assignment', async () => {
+        const sql = await setVariables({
+          foo: '", @is_admin := 1, @leak := (SELECT password FROM users LIMIT 1), @z := "'
+        });
+
+        expect(sql).to.equal(
+          String.raw`SET @foo := '\", @is_admin := 1, @leak := (SELECT password FROM users LIMIT 1), @z := \"'`
+        );
+      });
+
+      it('escapes apostrophes and backslashes', async () => {
+        // A raw `'` would close the literal; a raw `\` would escape whatever follows it.
+        const sql = await setVariables({ foo: "apostrophe ', backslash \\" });
+
+        expect(sql).to.equal("SET @foo := 'apostrophe \\', backslash \\\\'");
+      });
+
+      it('rejects SQL expressions', async () => {
+        await expect(
+          sequelize.set(
+            { foo: Sequelize.literal('(SELECT password FROM users LIMIT 1)') },
+            { transaction: new Transaction(sequelize, {}) }
+          )
+        ).to.be.rejectedWith(TypeError, 'does not accept SQL expressions as variable values');
+      });
+
+      it('keeps non-string values inline', async () => {
+        const sql = await setVariables({ num: 1, nil: null, bool: true });
+
+        expect(sql).to.equal('SET @num := 1, @nil := NULL, @bool := true');
+      });
+
+      it('sets multiple variables', async () => {
+        const sql = await setVariables({ foo: 'bar', foos: 'bars' });
+
+        expect(sql).to.equal("SET @foo := 'bar', @foos := 'bars'");
+      });
+    });
+
+    describe('names', () => {
+      for (const name of ['foo', 'foo.bar', '$foo', 'foo_1', 'café']) {
+        it(`accepts ${name}`, async () => {
+          const sql = await setVariables({ [name]: 'bar' });
+
+          expect(sql).to.equal(`SET @${name} := 'bar'`);
+        });
+      }
+
+      for (const name of [
+        'x:=(select username from Users limit 1);-- -',
+        '@global.general_log_file',
+        'my var',
+        '`my var`',
+        "'x'",
+        '"x"',
+        'foo\nbar',
+        'foo\0bar',
+        '',
+        'f'.repeat(65)
+      ]) {
+        it(`rejects ${JSON.stringify(name)}`, async () => {
+          await expect(
+            sequelize.set({ [name]: 'bar' }, { transaction: new Transaction(sequelize, {}) })
+          ).to.be.rejectedWith(TypeError, 'Invalid session variable name');
+
+          expect(sequelize.query).not.to.have.been.called;
+        });
+      }
+    });
+  });
+}


### PR DESCRIPTION
Backport of #18272 to v6.

`sequelize.set()` builds its `SET` statement by interpolating both keys and values directly. Values now go through the normal escaping path, and names are validated against the 1-64 character unquoted user-variable grammar.

Added unit coverage for the generated SQL and integration coverage for the round-trip.

Also pins `pg-native` to 3.7.0 on the Node 10 legs of the Postgres matrix. 3.8.0 uses `??`, which Node 10 cannot parse, so requiring it throws a `SyntaxError` before any test runs. This is unrelated to the backport and was already failing on `v6`.

## List of Breaking Changes

Quoted user-variable names, such as `` `my var` ``, `'x'`, or `"x"`, are now rejected. Use an unquoted name matching the supported grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)