### PR TITLE
meta: probe databases over TCP in container healthchecks

### DIFF
--- a/dev/mariadb/latest/docker-compose.yml
+++ b/dev/mariadb/latest/docker-compose.yml
@@ -12,10 +12,23 @@ services:
     volumes:
       - mariadb-latest:/var/lib/mysql
     healthcheck:
-      test: ['CMD', 'mariadb-admin', '-usequelize_test', '-psequelize_test', 'status']
+      # --protocol=TCP forces a TCP probe. During initialisation the entrypoint runs a temporary
+      # server with --skip-networking, so a socket probe reports healthy before the real server is up.
+      test:
+        [
+          'CMD',
+          'mariadb-admin',
+          '--protocol=TCP',
+          '-h',
+          '127.0.0.1',
+          '-usequelize_test',
+          '-psequelize_test',
+          'status',
+        ]
       interval: 3s
-      timeout: 1s
-      retries: 10
+      timeout: 5s
+      retries: 20
+      start_period: 60s
 
 networks:
   default:

--- a/dev/mariadb/oldest/docker-compose.yml
+++ b/dev/mariadb/oldest/docker-compose.yml
@@ -12,10 +12,23 @@ services:
     volumes:
       - mariadb-oldest:/var/lib/mysql
     healthcheck:
-      test: ['CMD', 'mariadb-admin', '-usequelize_test', '-psequelize_test', 'status']
+      # --protocol=TCP forces a TCP probe. During initialisation the entrypoint runs a temporary
+      # server with --skip-networking, so a socket probe reports healthy before the real server is up.
+      test:
+        [
+          'CMD',
+          'mariadb-admin',
+          '--protocol=TCP',
+          '-h',
+          '127.0.0.1',
+          '-usequelize_test',
+          '-psequelize_test',
+          'status',
+        ]
       interval: 3s
-      timeout: 1s
-      retries: 10
+      timeout: 5s
+      retries: 20
+      start_period: 60s
 
 networks:
   default:

--- a/dev/mysql/latest/docker-compose.yml
+++ b/dev/mysql/latest/docker-compose.yml
@@ -12,10 +12,23 @@ services:
     volumes:
       - mysql-latest:/var/lib/mysql
     healthcheck:
-      test: ['CMD', 'mysqladmin', '-usequelize_test', '-psequelize_test', 'status']
+      # --protocol=TCP forces a TCP probe. During initialisation the entrypoint runs a temporary
+      # server with --skip-networking, so a socket probe reports healthy before the real server is up.
+      test:
+        [
+          'CMD',
+          'mysqladmin',
+          '--protocol=TCP',
+          '-h',
+          '127.0.0.1',
+          '-usequelize_test',
+          '-psequelize_test',
+          'status',
+        ]
       interval: 3s
-      timeout: 1s
-      retries: 10
+      timeout: 5s
+      retries: 20
+      start_period: 60s
 
 networks:
   default:

--- a/dev/mysql/oldest/docker-compose.yml
+++ b/dev/mysql/oldest/docker-compose.yml
@@ -12,10 +12,23 @@ services:
     volumes:
       - mysql-oldest:/var/lib/mysql
     healthcheck:
-      test: ['CMD', 'mysqladmin', '-usequelize_test', '-psequelize_test', 'status']
+      # --protocol=TCP forces a TCP probe. During initialisation the entrypoint runs a temporary
+      # server with --skip-networking, so a socket probe reports healthy before the real server is up.
+      test:
+        [
+          'CMD',
+          'mysqladmin',
+          '--protocol=TCP',
+          '-h',
+          '127.0.0.1',
+          '-usequelize_test',
+          '-psequelize_test',
+          'status',
+        ]
       interval: 3s
-      timeout: 1s
-      retries: 10
+      timeout: 5s
+      retries: 20
+      start_period: 60s
 
 networks:
   default:

--- a/dev/postgres/latest/docker-compose.yml
+++ b/dev/postgres/latest/docker-compose.yml
@@ -11,10 +11,13 @@ services:
     volumes:
       - postgres-latest:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD', 'pg_isready', '-U', 'sequelize_test']
+      # -h forces a TCP probe. During initdb the entrypoint runs a temporary server that only
+      # listens on the unix socket, so a socket probe reports healthy before the real server is up.
+      test: ['CMD', 'pg_isready', '-h', '127.0.0.1', '-U', 'sequelize_test', '-d', 'sequelize_test']
       interval: 3s
-      timeout: 1s
-      retries: 10
+      timeout: 5s
+      retries: 20
+      start_period: 60s
 
 networks:
   default:

--- a/dev/postgres/oldest/docker-compose.yml
+++ b/dev/postgres/oldest/docker-compose.yml
@@ -11,10 +11,13 @@ services:
     volumes:
       - postgres-oldest:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD', 'pg_isready', '-U', 'sequelize_test']
+      # -h forces a TCP probe. During initdb the entrypoint runs a temporary server that only
+      # listens on the unix socket, so a socket probe reports healthy before the real server is up.
+      test: ['CMD', 'pg_isready', '-h', '127.0.0.1', '-U', 'sequelize_test', '-d', 'sequelize_test']
       interval: 3s
-      timeout: 1s
-      retries: 10
+      timeout: 5s
+      retries: 20
+      start_period: 60s
 
 networks:
   default:

--- a/dev/wait-until-healthy.sh
+++ b/dev/wait-until-healthy.sh
@@ -23,7 +23,12 @@ while [ -z "$failure" ]; do
     break
   fi
 
-  health=$(docker inspect -f '{{ if .State.Health }}{{ .State.Health.Status }}{{ else }}none{{ end }}' "$container")
+  # the container can still go away between the two inspections
+  if ! health=$(docker inspect -f '{{ if .State.Health }}{{ .State.Health.Status }}{{ else }}none{{ end }}' "$container" 2>/dev/null); then
+    >&2 echo "No such container: $container"
+    exit 1
+  fi
+
   if [ "$health" == "none" ]; then
     >&2 echo "Container $container has no healthcheck to wait for"
     exit 1

--- a/dev/wait-until-healthy.sh
+++ b/dev/wait-until-healthy.sh
@@ -1,28 +1,56 @@
 #!/usr/bin/env bash
+set -uo pipefail
 
 if [ "$#" -ne 1 ]; then
   >&2 echo "Please provide the container name or hash"
   exit 1
 fi
 
-for _ in {1..50}
-do
-  state=$(docker inspect -f '{{ .State.Health.Status }}' $1 2>&1)
-  echo -ne "$state.\r"
-  sleep 1
-  echo -ne "$state..\r"
-  sleep 1
-  echo -ne "$state...\r"
-  sleep 1
-  echo -ne '\033[K'
+container=$1
+timeout=${HEALTHCHECK_TIMEOUT:-180}
+deadline=$((SECONDS + timeout))
+failure=""
+reported=""
 
-  return_code=$?
-  if [ ${return_code} -eq 0 ] && [ "$state" == "healthy" ]; then
-    echo "$1 is healthy!"
+while [ -z "$failure" ]; do
+  if ! state=$(docker inspect -f '{{ .State.Status }}' "$container" 2>/dev/null); then
+    >&2 echo "No such container: $container"
+    exit 1
+  fi
+
+  if [ "$state" == "exited" ] || [ "$state" == "dead" ]; then
+    failure="Container $container $state before it became healthy"
+    break
+  fi
+
+  health=$(docker inspect -f '{{ if .State.Health }}{{ .State.Health.Status }}{{ else }}none{{ end }}' "$container")
+  if [ "$health" == "none" ]; then
+    >&2 echo "Container $container has no healthcheck to wait for"
+    exit 1
+  fi
+
+  if [ "$health" == "healthy" ]; then
+    echo "$container is healthy!"
     exit 0
   fi
-  sleep 0.4
+
+  if [ $SECONDS -ge $deadline ]; then
+    failure="Timeout of ${timeout}s exceeded when waiting for container to be healthy: $container (last state: $health)"
+    break
+  fi
+
+  # only on change, so CI logs get two lines instead of one per second
+  if [ "$health" != "$reported" ]; then
+    echo "waiting for $container to become healthy (currently: $health)"
+    reported=$health
+  fi
+
+  sleep 1
 done
 
->&2 echo "Timeout of 20s exceeded when waiting for container to be healthy: $1"
+>&2 echo "$failure"
+>&2 echo "--- healthcheck probes ---"
+>&2 docker inspect -f '{{ json .State.Health }}' "$container" 2>&1
+>&2 echo "--- container logs ---"
+>&2 docker logs --tail 50 "$container" 2>&1
 exit 1


### PR DESCRIPTION
## Problem

`yarn start-postgres-{oldest,latest}` fails intermittently in CI — roughly one job in twenty-four, always exactly one job of the postgres matrix. Recent examples: [30449391928](https://github.com/sequelize/sequelize/actions/runs/30449391928), [30446403587](https://github.com/sequelize/sequelize/actions/runs/30446403587), [30446392962](https://github.com/sequelize/sequelize/actions/runs/30446392962), [30165843220](https://github.com/sequelize/sequelize/actions/runs/30165843220).

All four failed with **exit code 7**, which is what Node produces when `dev/check-connection.ts` dies on `ECONNREFUSED`. The failing steps ran 24–36s against 16–22s for successful ones, so it is not the `wait-until-healthy.sh` timeout (that would be ~170s): the healthcheck *passes*, and then the connection is refused.

## Cause

`pg_isready -U sequelize_test` has no `-h`, so it probes the **unix socket**. During `initdb` the postgres entrypoint runs a temporary bootstrap server that listens on the socket only, with an empty `listen_addresses`. The probe passes, the container is marked healthy, and nothing is listening on TCP yet.

Measured at the instant docker reported `healthy`, 4 runs out of 4:

```
init-complete=NO | TCP: 127.0.0.1:5432 - no response
                 | socket: /var/run/postgresql:5432 - accepting connections
```

CI volumes always start empty, so every job runs `initdb` and every job races. Whether the first probe lands inside that ~1–2s window is pure timing.

## Fix

Probe over TCP, which the bootstrap server genuinely does not answer. Throttling the container to 0.15 CPU — what a loaded runner effectively looks like — makes the flake deterministic:

| | before | after |
|---|---|---|
| postgres oldest | 3/3 failed | 0/3 failed |
| postgres latest | 3/3 failed | 0/3 failed |

mysql and mariadb have the same defect: their entrypoints start the temporary server on the *same* socket path with `--skip-networking`, and `sequelize_test` is created while it is running. The window is far narrower — polling both probes across a full startup catches `socket=ok tcp=fail` for only 2 samples out of ~2200 — but it is real, so they get `--protocol=TCP` too. All four containers were confirmed to still reach healthy and connect.

The probe timeout also goes to 5s and gains a `start_period`, so a slow runner cannot mark a container unhealthy while it is legitimately still starting.

## `wait-until-healthy.sh`

Three separate problems, all of which made these failures harder to diagnose than they should have been:

- `return_code=$?` captured the exit status of the preceding `echo`, so it was always `0` and the check was dead code.
- The timeout message claimed 20s; the loop actually ran for about 170s.
- It waited out the full timeout even when the container had already exited, and printed nothing at all on failure — no logs, no probe output. This is why the CI job logs said nothing useful.

It now fails fast on an exited or missing container, reports the real timeout, and dumps `.State.Health` plus the last 50 log lines when it gives up. Output is also one line per state change rather than a `\r` redraw every second, which renders badly in Actions logs.

## Reproducing locally

```bash
# override.yml:  services: {postgres-latest: {cpus: 0.15}}
docker volume rm -f sequelize-postgres-latest-volume
docker compose -p sequelize-postgres-latest -f docker-compose.yml -f override.yml up -d
dev/wait-until-healthy.sh sequelize-postgres-latest
DIALECT=postgres yarn ts-node dev/check-connection.ts   # exit 7 before this PR
```

The volume must be removed between runs, otherwise `initdb` is skipped and it always passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database container health checks across supported MySQL, MariaDB, and PostgreSQL environments.
  * Made health checks more reliable by using explicit TCP-based readiness checks and updated timing behavior (longer timeouts, more retries, and added startup grace periods).
  * Strengthened the “wait for healthy” script with stricter validation, clearer failure modes, and less repetitive output.
  * On startup failure, now surfaces healthcheck results and recent container logs to speed up troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->