### PR TITLE
fix: avoid wrong primary keys from bulkCreate with updateOnDuplicate/ignoreDuplicates

### DIFF
--- a/packages/core/test/unit/dialects/mysql/query.test.js
+++ b/packages/core/test/unit/dialects/mysql/query.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { MySqlQuery } = require('@sequelize/mysql');
+const { MariaDbQuery } = require('@sequelize/mariadb');
+const { DataTypes, QueryTypes } = require('@sequelize/core');
 
 const Support = require('../../../support');
 const chai = require('chai');
@@ -32,5 +34,70 @@ describe('[MYSQL/MARIADB Specific] Query', () => {
       expect('dummy-results').to.equal(results);
       expect(true).to.equal(console.debug.calledOnce);
     });
+  });
+
+  describe('formatResults primary keys for bulkCreate', () => {
+    // `ResultSetHeader` is the name MySQL's driver gives its metadata object; the MySQL
+    // formatResults path only synthesises ids for objects with that constructor name.
+    class ResultSetHeader {}
+
+    // A dedicated instance keeps this model out of the shared `sequelize`, whose models
+    // other suites reset via `resetSequelizeInstance`.
+    let model;
+    before(() => {
+      model = Support.createSequelizeInstance().define(
+        'formatResultsBulkCreate',
+        {
+          id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+          name: DataTypes.STRING,
+        },
+        { timestamps: false },
+      );
+    });
+
+    // MariaDB's driver returns insertId as a BigInt (the range arithmetic depends on it);
+    // MySQL's returns a plain number. Otherwise the two paths behave identically.
+    const dialects = [
+      { name: 'MySqlQuery', Query: MySqlQuery, insertId: 10, id: n => n },
+      { name: 'MariaDbQuery', Query: MariaDbQuery, insertId: 10n, id: n => BigInt(n) },
+    ];
+
+    for (const { id, insertId, name, Query } of dialects) {
+      describe(name, () => {
+        const header = affectedRows =>
+          Object.assign(new ResultSetHeader(), { insertId, affectedRows });
+
+        it('synthesises a contiguous id range for a plain bulkCreate', () => {
+          const query = new Query({}, current, { type: QueryTypes.INSERT, model });
+
+          expect(query.formatResults(header(3))).to.deep.equal([
+            [{ id: id(10) }, { id: id(11) }, { id: id(12) }],
+            3,
+          ]);
+        });
+
+        it('does not fabricate ids when updateOnDuplicate is set', () => {
+          const query = new Query({}, current, {
+            type: QueryTypes.INSERT,
+            model,
+            updateOnDuplicate: ['name'],
+          });
+
+          // affectedRows is weighted (2 per updated row) under updateOnDuplicate, so the
+          // synthesised range would be wrong; the raw insertId is returned instead. #18281
+          expect(query.formatResults(header(3))).to.deep.equal([insertId, 3]);
+        });
+
+        it('does not fabricate ids when ignoreDuplicates is set', () => {
+          const query = new Query({}, current, {
+            type: QueryTypes.INSERT,
+            model,
+            ignoreDuplicates: true,
+          });
+
+          expect(query.formatResults(header(3))).to.deep.equal([insertId, 3]);
+        });
+      });
+    }
   });
 });

--- a/packages/mariadb/src/query.js
+++ b/packages/mariadb/src/query.js
@@ -106,7 +106,14 @@ export class MariaDbQuery extends AbstractQuery {
         // handle bulkCreate AI primary key
         if (
           modelDefinition?.autoIncrementAttributeName &&
-          modelDefinition?.autoIncrementAttributeName === this.model.primaryKeyAttribute
+          modelDefinition?.autoIncrementAttributeName === this.model.primaryKeyAttribute &&
+          // `updateOnDuplicate`/`ignoreDuplicates` break the `insertId` + `affectedRows`
+          // arithmetic below: an updated row counts as 2 affected and an ignored one as 0,
+          // so the synthesised id range desynchronises from the inserted rows and returned
+          // instances get primary keys belonging to other rows. Fall back to the raw
+          // insertId in that case rather than fabricating a wrong range. See #18281.
+          !this.options.updateOnDuplicate &&
+          !this.options.ignoreDuplicates
         ) {
           // ONLY TRUE IF @auto_increment_increment is set to 1 !!
           // Doesn't work with GALERA => each node will reserve increment (x for first server, x+1 for next node...)

--- a/packages/mysql/src/query.js
+++ b/packages/mysql/src/query.js
@@ -111,7 +111,14 @@ export class MySqlQuery extends AbstractQuery {
         if (
           data.constructor.name === 'ResultSetHeader' &&
           modelDefinition?.autoIncrementAttributeName &&
-          modelDefinition?.autoIncrementAttributeName === this.model.primaryKeyAttribute
+          modelDefinition?.autoIncrementAttributeName === this.model.primaryKeyAttribute &&
+          // `updateOnDuplicate`/`ignoreDuplicates` break the `insertId` + `affectedRows`
+          // arithmetic below: MySQL counts an updated row as 2 affected and an ignored one
+          // as 0, so the synthesised id range desynchronises from the inserted rows and
+          // returned instances get primary keys belonging to other rows. Fall back to the
+          // raw insertId in that case rather than fabricating a wrong range. See #18281.
+          !this.options.updateOnDuplicate &&
+          !this.options.ignoreDuplicates
         ) {
           const startId = data[this.getInsertIdField()];
           result = [];


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- n/a -->
- [x] Did you update the typescript typings accordingly (if applicable)? <!-- n/a, dialect .js files -->
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Addresses #18281.

On MySQL and MariaDB, `bulkCreate()` synthesises the primary keys of the returned instances from
`insertId` + `affectedRows` (`packages/mysql/src/query.js`, `packages/mariadb/src/query.js`). That
arithmetic assumes exactly one inserted row per submitted record.

`updateOnDuplicate` and `ignoreDuplicates` break the assumption: MySQL reports `affectedRows` as 2 per
updated row and 0 per ignored row, and `LAST_INSERT_ID()` is only the first generated id, so the
synthesised id range desynchronises from the instance array. Returned instances (which come back with
`isNewRecord === false`) then carry primary keys belonging to **other rows**, including rows outside
the batch. A later `instance.destroy()` / `instance.update()` silently hits the wrong row (the issue
documents a `destroy()` deleting a different record and an `update()` overwriting a pre-existing row
outside the batch).

**Fix:** when `updateOnDuplicate` or `ignoreDuplicates` is set, `formatResults` no longer fabricates
the contiguous id range; it returns the raw `insertId` instead, so the wrong-key path in `model.js`
(`if (Array.isArray(results))`) is skipped and no instance is given a fabricated key. Returning no
synthesised key is correct here: with the weighted `affectedRows` the real per-row keys cannot be
derived from the result header without a re-`SELECT`, and a missing key is safe where a wrong one
corrupts data. The plain `bulkCreate` path (no `updateOnDuplicate`/`ignoreDuplicates`) is unchanged:
every row goes through `AUTO_INCREMENT`, so the range stays contiguous and index-aligned.

Tests (`packages/core/test/unit/dialects/mysql/query.test.js`, no DB): using a mock `ResultSetHeader`,
both `MySqlQuery` and `MariaDbQuery` still synthesise the contiguous range for a plain bulkCreate, and
return the raw `insertId` (no fabricated range) under `updateOnDuplicate` / `ignoreDuplicates`. Failing
before the change, passing after; the full `core` unit suite stays green (2269 passing).

## Related items from the issue (not in this PR)

The issue also lists two companion items. I kept this PR focused on the data-integrity bug and am
happy to fold either in here or handle as a follow-up, whichever you prefer:

1. **Capability-based carve-out.** The block in `packages/core/src/model.js` that skips replacing a
   truthy primary key keys off the dialect allowlist `['mysql', 'mariadb']`. Since
   `supports.returnValues` defaults to `false`, db2/ibmi/snowflake inherit it and oracle sets it
   explicitly, yet they are not in the list. Deriving the predicate from
   `!this.sequelize.dialect.supports.returnValues` covers all of them and is a no-op for mysql/mariadb
   (already `returnValues: false`):

   ```diff
   -        ['mysql', 'mariadb'].includes(dialect))
   +        !this.sequelize.dialect.supports.returnValues)
   ```

2. **`updateOnDuplicate` + primary key footgun.** Listing the primary key in `updateOnDuplicate` but
   not in `fields` emits `` `id`=VALUES(`id`) `` and reassigns a matched row's primary key. Worth a
   validation or documentation note; separate from this fix.

## Caveat on scope

The contiguous-range assumption in the *plain* path is only verified at `auto_increment_increment = 1`;
the existing comment in `packages/mariadb/src/query.js` notes it does not hold under Galera or a non-1
increment. This PR does not change that path, so it neither fixes nor worsens that case.

## List of Breaking Changes

`bulkCreate(..., { updateOnDuplicate })` / `{ ignoreDuplicates }` on MySQL/MariaDB previously returned
instances with (often wrong) primary keys; they now come back without a synthesised primary key. This
removes silent wrong-row writes at the cost of not returning generated keys for these two options:
callers who need the keys should re-query by a unique column.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk-create result handling for MySQL and MariaDB when duplicate-update or duplicate-ignore options are enabled.
  * Avoided generating synthetic auto-increment ID ranges in these scenarios; the database-provided insert ID is now returned instead.
  * Ensures consistent behavior for both regular numeric and large integer insert IDs.
* **Tests**
  * Added unit coverage to validate primary-key/result formatting behavior across both MySQL/MariaDB dialects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->