### PR TITLE
fix(core): reject findCreateFind when recovery fails

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2119,6 +2119,10 @@ ${associationOwner._getAssociationDebugList()}`);
 
       const foundAgain = await this.findOne(options);
 
+      if (foundAgain === null) {
+        throw error;
+      }
+
       return [foundAgain, false];
     }
   }

--- a/packages/core/test/unit/model/find-create-find.test.js
+++ b/packages/core/test/unit/model/find-create-find.test.js
@@ -74,5 +74,26 @@ describe('Model#findCreateFind', () => {
       expect(findSpy).to.have.been.calledTwice;
       expect(findSpy.getCall(1).args[0].where).to.equal(where);
     });
+
+    it(`should rethrow the create error if the second find is empty after an error of type ${Error.name}`, async function () {
+      const { TestModel } = vars;
+      const where = { prop: Math.random().toString() };
+      const createError = new Error();
+      const findSpy = this.sinon.stub(TestModel, 'findOne');
+
+      this.sinon.stub(TestModel, 'create').rejects(createError);
+
+      findSpy.onFirstCall().resolves(null);
+      findSpy.onSecondCall().resolves(null);
+
+      try {
+        await TestModel.findCreateFind({ where });
+        expect.fail('findCreateFind should reject when the recovery find is empty');
+      } catch (error) {
+        expect(error).to.equal(createError);
+      }
+
+      expect(findSpy).to.have.been.calledTwice;
+    });
   }
 });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

findCreateFind promises an instance when it resolves. Rethrow the create error if the duplicate-recovery lookup finds no row, matching findOrCreate instead of resolving with null.

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when a create operation fails and the recovery lookup finds no matching record.
  - The original error is now preserved and reported instead of returning an empty result.

- **Tests**
  - Added coverage for recovery scenarios involving empty-result and uniqueness errors.
  - Verified that the original error is propagated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->