### PR TITLE
fix(associations): use custom sourceKey/targetKey in internal belongsToMany associations

### DIFF
--- a/src/associations/belongs-to-many.js
+++ b/src/associations/belongs-to-many.js
@@ -354,10 +354,12 @@ class BelongsToMany extends Association {
     }
 
     this.toSource = new BelongsTo(this.through.model, this.source, {
-      foreignKey: this.foreignKey
+      foreignKey: this.foreignKey,
+      targetKey: this.sourceKey
     });
     this.manyFromSource = new HasMany(this.source, this.through.model, {
-      foreignKey: this.foreignKey
+      foreignKey: this.foreignKey,
+      sourceKey: this.sourceKey
     });
     this.oneFromSource = new HasOne(this.source, this.through.model, {
       foreignKey: this.foreignKey,
@@ -366,10 +368,12 @@ class BelongsToMany extends Association {
     });
 
     this.toTarget = new BelongsTo(this.through.model, this.target, {
-      foreignKey: this.otherKey
+      foreignKey: this.otherKey,
+      targetKey: this.targetKey
     });
     this.manyFromTarget = new HasMany(this.target, this.through.model, {
-      foreignKey: this.otherKey
+      foreignKey: this.otherKey,
+      sourceKey: this.targetKey
     });
     this.oneFromTarget = new HasOne(this.target, this.through.model, {
       foreignKey: this.otherKey,
@@ -379,7 +383,8 @@ class BelongsToMany extends Association {
 
     if (this.paired && this.paired.otherKeyDefault) {
       this.paired.toTarget = new BelongsTo(this.paired.through.model, this.paired.target, {
-        foreignKey: this.paired.otherKey
+        foreignKey: this.paired.otherKey,
+        targetKey: this.paired.targetKey
       });
 
       this.paired.oneFromTarget = new HasOne(this.paired.target, this.paired.through.model, {

--- a/test/unit/associations/belongs-to-many.test.js
+++ b/test/unit/associations/belongs-to-many.test.js
@@ -366,6 +366,56 @@ describe(Support.getTestDialectTeaser('belongsToMany'), () => {
       expect(Object.keys(ProductTag.rawAttributes)).to.deep.equal(['id', 'priority', 'productId', 'tagId']);
     });
 
+    it('should use custom sourceKey/targetKey in belongsTo/hasMany relations to source and target from join model', function() {
+      const Product = this.sequelize.define('Product', {
+          id: {
+            primaryKey: true,
+            type: DataTypes.INTEGER,
+            autoIncrement: true
+          },
+          code: {
+            type: DataTypes.STRING,
+            unique: true
+          }
+        }),
+        Tag = this.sequelize.define('Tag', {
+          id: {
+            primaryKey: true,
+            type: DataTypes.INTEGER,
+            autoIncrement: true
+          },
+          tagCode: {
+            type: DataTypes.STRING,
+            unique: true
+          }
+        }),
+        ProductTag = this.sequelize.define('ProductTag', {
+          id: {
+            primaryKey: true,
+            type: DataTypes.INTEGER,
+            autoIncrement: true
+          }
+        }, {
+          timestamps: false
+        });
+
+      Product.Tags = Product.belongsToMany(Tag, { through: ProductTag, foreignKey: 'productCode', otherKey: 'tagCode', sourceKey: 'code', targetKey: 'tagCode' });
+      Tag.Products = Tag.belongsToMany(Product, { through: ProductTag, foreignKey: 'tagCode', otherKey: 'productCode', sourceKey: 'tagCode', targetKey: 'code' });
+
+      expect(Product.Tags.sourceKey).to.equal('code');
+      expect(Product.Tags.targetKey).to.equal('tagCode');
+
+      expect(Product.Tags.toSource.targetKey).to.equal('code');
+      expect(Product.Tags.toTarget.targetKey).to.equal('tagCode');
+      expect(Product.Tags.manyFromSource.sourceKey).to.equal('code');
+      expect(Product.Tags.manyFromTarget.sourceKey).to.equal('tagCode');
+
+      expect(Tag.Products.toSource.targetKey).to.equal('tagCode');
+      expect(Tag.Products.toTarget.targetKey).to.equal('code');
+      expect(Tag.Products.manyFromSource.sourceKey).to.equal('tagCode');
+      expect(Tag.Products.manyFromTarget.sourceKey).to.equal('code');
+    });
+
     it('should setup hasOne relations to source and target from join model with defined foreign/other keys', function() {
       const Product = this.sequelize.define('Product', {
           title: DataTypes.STRING


### PR DESCRIPTION
## What does this PR do?

Fixes the internal `BelongsToMany` associations losing the custom `sourceKey` / `targetKey` options.

When defining `belongsToMany` with a custom `sourceKey` or `targetKey` (i.e. not the model primary key), the internally created associations fell back to the primary key:

- `toSource` / `toTarget` (`BelongsTo`) fell back to `primaryKeyAttribute` instead of `sourceKey` / `targetKey`
- `manyFromSource` / `manyFromTarget` (`HasMany`) fell back to the primary key instead of `sourceKey` / `targetKey`
- the `paired.toTarget` branch was also missing its `targetKey`

`oneFromSource` / `oneFromTarget` already passed `sourceKey`, so this aligns the remaining internal associations with the same behavior.

## Example of the bug

```js
User.belongsToMany(Department, {
  through: SysUserDepartment,
  foreignKey: "user_id",
  otherKey: "department_code",
  targetKey: "code",
  as: "departments",
});
```

Including through `belongsToMany.toTarget` generated a join on the primary key instead of the custom key:

```sql
-- before
LEFT OUTER JOIN `Departments` AS `Department` ON `SysUserDepartment`.`department_code` = `Department`.`id`;
-- after
LEFT OUTER JOIN `Departments` AS `Department` ON `SysUserDepartment`.`department_code` = `Department`.`code`;
```

## Related issue

Related to #18256 (custom `sourceKey`/`targetKey` being dropped in some code paths; this PR fixes the internal-association code path on the `v6` branch).

## Test plan

Added a unit test that asserts `toSource`/`toTarget`/`manyFromSource`/`manyFromTarget` carry the custom `sourceKey`/`targetKey`:

```
DIALECT=mysql npx mocha -r ./test/registerEsbuild test/unit/associations/belongs-to-many.test.js

36 passing
```