### PR TITLE
fix(core): project belongsToMany sourceKey in the subquery select

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -2365,7 +2365,38 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         const joinColumn = association.sourceKeyField || attrSource || identSource;
 
         if (isRootParent) {
-          sourceJoinOn = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(joinColumn)} = `;
+          // Top-level include whose join is executed on the outer query, against the
+          // derived main table: if the source key column is not part of the subquery
+          // select (e.g. a custom sourceKey that is not selected), it must be projected
+          // under a minified alias, otherwise the outer join references a column that
+          // does not exist in the derived table.
+          const primaryKeyAttribute = association.source.primaryKeyAttribute;
+          const mainAttributes = topLevelInfo.options.attributes || [];
+          const isAlreadySelected =
+            attrSource === primaryKeyAttribute ||
+            mainAttributes.some(
+              attr =>
+                attr === attrSource ||
+                (Array.isArray(attr) && (attr[0] === attrSource || attr[1] === attrSource)),
+            );
+
+          if (isAlreadySelected) {
+            sourceJoinOn = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(joinColumn)} = `;
+          } else {
+            aliasedSource = this._getMinifiedAlias(
+              `${dottedTableSource}.${joinColumn}`,
+              tableSource,
+              topLevelInfo.options,
+            );
+
+            const projection = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(joinColumn)} AS ${this.quoteIdentifier(aliasedSource)}`;
+
+            if (!attributes.subQuery.includes(projection)) {
+              attributes.subQuery.push(projection);
+            }
+
+            sourceJoinOn = `${this.quoteIdentifier(aliasedSource)} = `;
+          }
         } else {
           const aliasBase = `${dottedTableSource}.${joinColumn}`;
 
@@ -2382,6 +2413,24 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       if (!sourceJoinOn) {
         sourceJoinOn = `${this.quoteIdentifier(aliasedSource)} = `;
       }
+    } else if (
+      topLevelInfo.subQuery &&
+      !include.subQuery &&
+      include.parent.subQuery &&
+      isRootParent
+    ) {
+      // Subquery + root parent: the join is executed on the outer query, against the
+      // derived main table, so the source key column must be projected in the subquery
+      // select, otherwise the outer join references a column that does not exist
+      // in the derived table (see https://github.com/sequelize/sequelize/issues/18256).
+      const joinColumn = association.sourceKeyField || attrSource || identSource;
+      const projection = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(joinColumn)}`;
+
+      if (!attributes.subQuery.includes(projection)) {
+        attributes.subQuery.push(projection);
+      }
+
+      sourceJoinOn = `${projection} = `;
     } else if (
       topLevelInfo.subQuery &&
       !include.subQuery &&

--- a/packages/core/test/unit/query-generator/select-query.test.ts
+++ b/packages/core/test/unit/query-generator/select-query.test.ts
@@ -1687,6 +1687,155 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
       });
     });
 
+    it('projects the sourceKey of a belongsToMany include in the subquery select (#18256)', () => {
+      const { schemaQueryGenerator, User } = schemaVars;
+
+      const sql = schemaQueryGenerator.selectQuery(
+        User.table,
+        {
+          model: User,
+          attributes: ['id'],
+          include: _validateIncludedElements({
+            model: User,
+            limit: 5,
+            include: [{ association: User.associations.uuidTags, attributes: ['id'], required: true }],
+          }).include,
+          limit: 5,
+          offset: 0,
+          subQuery: true,
+        },
+        User,
+      );
+
+      expectsql(sql, {
+        default: `
+          SELECT
+            [User].*,
+            [uuidTags].[id] AS [uuidTags.id],
+            [uuidTags->UserUuidTags].[createdAt] AS [uuidTags.UserUuidTags.createdAt],
+            [uuidTags->UserUuidTags].[updatedAt] AS [uuidTags.UserUuidTags.updatedAt],
+            [uuidTags->UserUuidTags].[tagId] AS [uuidTags.UserUuidTags.tagId],
+            [uuidTags->UserUuidTags].[userUuid] AS [uuidTags.UserUuidTags.userUuid]
+          FROM (
+            SELECT [User].[id], [User].[uuid]
+            FROM [mySchema].[Users] AS [User]
+            WHERE EXISTS (
+              SELECT [UserUuidTags].[tagId]
+              FROM [mySchema].[UserUuidTags] AS [UserUuidTags]
+              INNER JOIN [mySchema].[Tags] AS [uuidTag] ON [UserUuidTags].[tagId] = [uuidTag].[id]
+              WHERE [User].[uuid] = [UserUuidTags].[userUuid]
+            )
+            ORDER BY [User].[id] LIMIT 5
+          ) AS [User]
+          INNER JOIN (
+            [mySchema].[UserUuidTags] AS [uuidTags->UserUuidTags]
+            INNER JOIN [mySchema].[Tags] AS [uuidTags] ON [uuidTags].[id] = [uuidTags->UserUuidTags].[tagId]
+          )
+            ON [User].[uuid] = [uuidTags->UserUuidTags].[userUuid];
+        `,
+        sqlite3: `
+          SELECT
+            \`User\`.*,
+            \`uuidTags\`.\`id\` AS \`uuidTags.id\`,
+            \`uuidTags->UserUuidTags\`.\`createdAt\` AS \`uuidTags.UserUuidTags.createdAt\`,
+            \`uuidTags->UserUuidTags\`.\`updatedAt\` AS \`uuidTags.UserUuidTags.updatedAt\`,
+            \`uuidTags->UserUuidTags\`.\`tagId\` AS \`uuidTags.UserUuidTags.tagId\`,
+            \`uuidTags->UserUuidTags\`.\`userUuid\` AS \`uuidTags.UserUuidTags.userUuid\`
+          FROM (
+            SELECT \`User\`.\`id\`, \`User\`.\`uuid\`
+            FROM \`mySchema.Users\` AS \`User\`
+            WHERE EXISTS (
+              SELECT \`UserUuidTags\`.\`tagId\`
+              FROM \`mySchema.UserUuidTags\` AS \`UserUuidTags\`
+              INNER JOIN \`mySchema.Tags\` AS \`uuidTag\` ON \`UserUuidTags\`.\`tagId\` = \`uuidTag\`.\`id\`
+              WHERE \`User\`.\`uuid\` = \`UserUuidTags\`.\`userUuid\`
+            )
+            ORDER BY \`User\`.\`id\` LIMIT 5
+          ) AS \`User\`
+          INNER JOIN (
+            \`mySchema.UserUuidTags\` AS \`uuidTags->UserUuidTags\`
+            INNER JOIN \`mySchema.Tags\` AS \`uuidTags\` ON \`uuidTags\`.\`id\` = \`uuidTags->UserUuidTags\`.\`tagId\`
+          )
+            ON \`User\`.\`uuid\` = \`uuidTags->UserUuidTags\`.\`userUuid\`;
+        `,
+      });
+    });
+
+    it('projects the sourceKey of a belongsToMany include in the subquery select with minified aliases (#18256)', () => {
+      const { schemaQueryGenerator, User } = schemaVars;
+
+      const sql = schemaQueryGenerator.selectQuery(
+        User.table,
+        {
+          model: User,
+          attributes: ['id'],
+          include: _validateIncludedElements({
+            model: User,
+            limit: 5,
+            include: [{ association: User.associations.uuidTags, attributes: ['id'], required: true }],
+          }).include,
+          limit: 5,
+          offset: 0,
+          subQuery: true,
+          minifyAliases: true,
+        },
+        User,
+      );
+
+      expectsql(sql, {
+        default: `
+          SELECT
+            [User].*,
+            [uuidTags].[id] AS [_0],
+            [uuidTags->UserUuidTags].[createdAt] AS [_1],
+            [uuidTags->UserUuidTags].[updatedAt] AS [_2],
+            [uuidTags->UserUuidTags].[tagId] AS [_3],
+            [uuidTags->UserUuidTags].[userUuid] AS [_4]
+          FROM (
+            SELECT [User].[id], [User].[uuid] AS [_5]
+            FROM [mySchema].[Users] AS [User]
+            WHERE EXISTS (
+              SELECT [UserUuidTags].[tagId]
+              FROM [mySchema].[UserUuidTags] AS [UserUuidTags]
+              INNER JOIN [mySchema].[Tags] AS [uuidTag] ON [UserUuidTags].[tagId] = [uuidTag].[id]
+              WHERE [User].[uuid] = [UserUuidTags].[userUuid]
+            )
+            ORDER BY [User].[id] LIMIT 5
+          ) AS [User]
+          INNER JOIN (
+            [mySchema].[UserUuidTags] AS [uuidTags->UserUuidTags]
+            INNER JOIN [mySchema].[Tags] AS [uuidTags] ON [uuidTags].[id] = [uuidTags->UserUuidTags].[tagId]
+          )
+            ON [_5] = [uuidTags->UserUuidTags].[userUuid];
+        `,
+        sqlite3: `
+          SELECT
+            \`User\`.*,
+            \`uuidTags\`.\`id\` AS \`_0\`,
+            \`uuidTags->UserUuidTags\`.\`createdAt\` AS \`_1\`,
+            \`uuidTags->UserUuidTags\`.\`updatedAt\` AS \`_2\`,
+            \`uuidTags->UserUuidTags\`.\`tagId\` AS \`_3\`,
+            \`uuidTags->UserUuidTags\`.\`userUuid\` AS \`_4\`
+          FROM (
+            SELECT \`User\`.\`id\`, \`User\`.\`uuid\` AS \`_5\`
+            FROM \`mySchema.Users\` AS \`User\`
+            WHERE EXISTS (
+              SELECT \`UserUuidTags\`.\`tagId\`
+              FROM \`mySchema.UserUuidTags\` AS \`UserUuidTags\`
+              INNER JOIN \`mySchema.Tags\` AS \`uuidTag\` ON \`UserUuidTags\`.\`tagId\` = \`uuidTag\`.\`id\`
+              WHERE \`User\`.\`uuid\` = \`UserUuidTags\`.\`userUuid\`
+            )
+            ORDER BY \`User\`.\`id\` LIMIT 5
+          ) AS \`User\`
+          INNER JOIN (
+            \`mySchema.UserUuidTags\` AS \`uuidTags->UserUuidTags\`
+            INNER JOIN \`mySchema.Tags\` AS \`uuidTags\` ON \`uuidTags\`.\`id\` = \`uuidTags->UserUuidTags\`.\`tagId\`
+          )
+            ON \`_5\` = \`uuidTags->UserUuidTags\`.\`userUuid\`;
+        `,
+      });
+    });
+
     it('does not schema-qualify table aliases in a belongsToMany JOIN condition with minified aliases', () => {
       const { schemaQueryGenerator, User } = schemaVars;
 


### PR DESCRIPTION
## What does this PR do?

Fixes #18256: a `belongsToMany` include with a custom `sourceKey` generated an invalid query in subQuery mode when the source key attribute was not part of the selected attributes.

## Why it happens

With `limit` (or an explicit `subQuery: true`), duplicating includes (hasMany/belongsToMany) are executed as an outer join against the derived main table, while an EXISTS subquery filter keeps the pagination semantics correct. The outer join references the association source key column on the main table:

```sql
SELECT User.*
FROM (
  SELECT User.id           -- sourceKey `uuid` missing here
  FROM Users AS User
  LIMIT 10
) AS User
INNER JOIN (...) ON User.uuid = UserTags.userUuid;  -- references a missing column
```

The primary key is always projected in the subquery select, but a custom `sourceKey` was not.

## The fix

In `generateThroughJoin`, when the join is executed on the outer query (root parent + subQuery), project the source key column in the subquery select:

- non-minified: project the raw column (`User.uuid`)
- minified aliases: project under a minified alias and reference it (`User.uuid AS _5` / `ON _5 = ...`)
- skip the projection when the column is already selected (primary key or user-selected attribute)

This mirrors what `generateJoin` already does for non-through associations.

## Test plan

Added two query-generator unit tests (plain + minified aliases) asserting the projected column and the resulting join condition:

```
DIALECT=sqlite3 yarn _test-unit
2262 passing
```

Also verified with the reproduction from #18256 against a real SQLite database (all 3 scenarios in the issue + non-required include) returning the expected rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed required many-to-many queries using non-primary source keys in subqueries.
  * Ensured necessary source key values are selected and correctly referenced in outer joins.
  * Improved compatibility for both standard and minified SQL aliases across supported databases.

* **Tests**
  * Added regression coverage for affected subquery and join scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->