### PR TITLE
fix(postgres): backfill enum types that already exist with no values

### DIFF
--- a/packages/core/test/integration/dialects/postgres/regressions.test.js
+++ b/packages/core/test/integration/dialects/postgres/regressions.test.js
@@ -41,5 +41,29 @@ if (dialect.startsWith('postgres')) {
       const user = await User.findOne({ raw: true });
       expect(user.active).to.be.true;
     });
+
+    it('backfills an enum type that already exists but has no values yet', async function () {
+      const Media = this.sequelize.define(
+        'Media',
+        {
+          type: DataTypes.ENUM(['image', 'video', 'audio']),
+        },
+        { tableName: 'regression_empty_enum_media' },
+      );
+
+      const enumTypeName = this.sequelize.dialect.queryGenerator.pgEnumName(Media.table, 'type', {
+        noEscape: true,
+      });
+
+      await this.sequelize.queryInterface.dropTable(Media.table, { cascade: true });
+      await this.sequelize.query(`DROP TYPE IF EXISTS "${enumTypeName}"`);
+      await this.sequelize.query(`CREATE TYPE "${enumTypeName}" AS ENUM ()`);
+
+      await Media.sync();
+
+      const enums = await this.sequelize.queryInterface.pgListEnums(Media.table);
+      const enumRow = enums.find(enumType => enumType.enum_name === enumTypeName);
+      expect(enumRow.enum_value).to.deep.equal(['image', 'video', 'audio']);
+    });
   });
 }

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -93,9 +93,9 @@ describe('PostgresQueryGenerator', () => {
       const { FooUser } = vars;
 
       expectsql(queryGenerator.pgListEnums(FooUser.table, 'mood'), {
-        postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+        postgres: `SELECT t.typname enum_name, COALESCE(array_agg(e.enumlabel ORDER BY enumsortorder) FILTER (WHERE e.enumlabel IS NOT NULL), ARRAY[]::text[]) enum_value
                    FROM pg_type t
-                          JOIN pg_enum e ON t.oid = e.enumtypid
+                          LEFT JOIN pg_enum e ON t.oid = e.enumtypid
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
                    WHERE n.nspname = 'foo'
                      AND t.typname='enum_users_mood'
@@ -105,9 +105,9 @@ describe('PostgresQueryGenerator', () => {
 
     it('uses the default schema if no options given', () => {
       expectsql(queryGenerator.pgListEnums(), {
-        postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+        postgres: `SELECT t.typname enum_name, COALESCE(array_agg(e.enumlabel ORDER BY enumsortorder) FILTER (WHERE e.enumlabel IS NOT NULL), ARRAY[]::text[]) enum_value
                    FROM pg_type t
-                          JOIN pg_enum e ON t.oid = e.enumtypid
+                          LEFT JOIN pg_enum e ON t.oid = e.enumtypid
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
                    WHERE n.nspname = 'public'
                    GROUP BY 1`,
@@ -118,9 +118,9 @@ describe('PostgresQueryGenerator', () => {
       expectsql(
         queryGenerator.pgListEnums({ tableName: `ta'"ble`, schema: `sche'"ma` }, `attri'"bute`),
         {
-          postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+          postgres: `SELECT t.typname enum_name, COALESCE(array_agg(e.enumlabel ORDER BY enumsortorder) FILTER (WHERE e.enumlabel IS NOT NULL), ARRAY[]::text[]) enum_value
                    FROM pg_type t
-                          JOIN pg_enum e ON t.oid = e.enumtypid
+                          LEFT JOIN pg_enum e ON t.oid = e.enumtypid
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
                    WHERE n.nspname = 'sche''"ma'
                      AND t.typname='enum_ta''"ble_attri''"bute'

--- a/packages/core/test/unit/dialects/postgres/enum.test.js
+++ b/packages/core/test/unit/dialects/postgres/enum.test.js
@@ -97,7 +97,7 @@ describe('PostgresQueryGenerator', () => {
                    FROM pg_type t
                           LEFT JOIN pg_enum e ON t.oid = e.enumtypid
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-                   WHERE n.nspname = 'foo'
+                   WHERE n.nspname = 'foo' AND t.typtype = 'e'
                      AND t.typname='enum_users_mood'
                    GROUP BY 1`,
       });
@@ -109,7 +109,7 @@ describe('PostgresQueryGenerator', () => {
                    FROM pg_type t
                           LEFT JOIN pg_enum e ON t.oid = e.enumtypid
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-                   WHERE n.nspname = 'public'
+                   WHERE n.nspname = 'public' AND t.typtype = 'e'
                    GROUP BY 1`,
       });
     });
@@ -122,7 +122,7 @@ describe('PostgresQueryGenerator', () => {
                    FROM pg_type t
                           LEFT JOIN pg_enum e ON t.oid = e.enumtypid
                           JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-                   WHERE n.nspname = 'sche''"ma'
+                   WHERE n.nspname = 'sche''"ma' AND t.typtype = 'e'
                      AND t.typname='enum_ta''"ble_attri''"bute'
                    GROUP BY 1`,
         },

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -543,7 +543,11 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       // guard in pgEnum() -- instead of adding the missing values to the existing, empty type.
       'LEFT JOIN pg_enum e ON t.oid = e.enumtypid ' +
       'JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace ' +
-      `WHERE n.nspname = ${this.escape(tableDetails.schema)}${enumName} GROUP BY 1`
+      // The LEFT JOIN above means this query is no longer implicitly restricted to enum types
+      // (t.typtype = 'e') the way the old inner join was, so it must be restricted explicitly --
+      // otherwise every type in the schema (tables' row types, domains, extension types, etc.)
+      // comes back as a row with an empty enum_value array.
+      `WHERE n.nspname = ${this.escape(tableDetails.schema)} AND t.typtype = 'e'${enumName} GROUP BY 1`
     );
   }
 

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -532,8 +532,16 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     }
 
     return (
-      'SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t ' +
-      'JOIN pg_enum e ON t.oid = e.enumtypid ' +
+      'SELECT t.typname enum_name, ' +
+      'COALESCE(array_agg(e.enumlabel ORDER BY enumsortorder) FILTER (WHERE e.enumlabel IS NOT NULL), ARRAY[]::text[]) enum_value ' +
+      'FROM pg_type t ' +
+      // A LEFT JOIN (rather than an inner JOIN) is required so that a type that already exists
+      // but has no values yet (CREATE TYPE ... AS ENUM ()) still produces a result row, with an
+      // empty enum_value array, rather than no row at all. An inner join made that case
+      // indistinguishable from "the type does not exist yet", which caused ensureEnums() to
+      // attempt to (re-)create the type from scratch -- a no-op due to the duplicate_object
+      // guard in pgEnum() -- instead of adding the missing values to the existing, empty type.
+      'LEFT JOIN pg_enum e ON t.oid = e.enumtypid ' +
       'JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace ' +
       `WHERE n.nspname = ${this.escape(tableDetails.schema)}${enumName} GROUP BY 1`
     );

--- a/packages/postgres/src/query-generator.js
+++ b/packages/postgres/src/query-generator.js
@@ -535,18 +535,8 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       'SELECT t.typname enum_name, ' +
       'COALESCE(array_agg(e.enumlabel ORDER BY enumsortorder) FILTER (WHERE e.enumlabel IS NOT NULL), ARRAY[]::text[]) enum_value ' +
       'FROM pg_type t ' +
-      // A LEFT JOIN (rather than an inner JOIN) is required so that a type that already exists
-      // but has no values yet (CREATE TYPE ... AS ENUM ()) still produces a result row, with an
-      // empty enum_value array, rather than no row at all. An inner join made that case
-      // indistinguishable from "the type does not exist yet", which caused ensureEnums() to
-      // attempt to (re-)create the type from scratch -- a no-op due to the duplicate_object
-      // guard in pgEnum() -- instead of adding the missing values to the existing, empty type.
       'LEFT JOIN pg_enum e ON t.oid = e.enumtypid ' +
       'JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace ' +
-      // The LEFT JOIN above means this query is no longer implicitly restricted to enum types
-      // (t.typtype = 'e') the way the old inner join was, so it must be restricted explicitly --
-      // otherwise every type in the schema (tables' row types, domains, extension types, etc.)
-      // comes back as a row with an empty enum_value array.
       `WHERE n.nspname = ${this.escape(tableDetails.schema)} AND t.typtype = 'e'${enumName} GROUP BY 1`
     );
   }

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -101,6 +101,24 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
           const enumVals = this.queryGenerator.fromArray(results[enumIdx].enum_value);
           const vals = enumType.options.values;
 
+          // The enum type already exists, but has no values yet (e.g. it was created with
+          // CREATE TYPE ... AS ENUM ()). There's no existing value to anchor a BEFORE/AFTER
+          // clause to, so just append every value in order instead of going through the
+          // relative-positioning logic below, which requires at least one old value.
+          if (enumVals.length === 0) {
+            for (const val of vals) {
+              promises.push(() => {
+                return this.sequelize.queryRaw(
+                  this.queryGenerator.pgEnumAdd(tableName, field, val, options),
+                  options,
+                );
+              });
+            }
+
+            enumIdx++;
+            continue;
+          }
+
           // Going through already existing values allows us to make queries that depend on those values
           // We will prepend all new values between the old ones, but keep in mind - we can't change order of already existing values
           // Then we append the rest of new values AFTER the latest already existing value

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -109,7 +109,11 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
             for (const val of vals) {
               promises.push(() => {
                 return this.sequelize.queryRaw(
-                  this.queryGenerator.pgEnumAdd(tableName, field, val, { ...options, before: null, after: null }),
+                  this.queryGenerator.pgEnumAdd(tableName, field, val, {
+                    ...options,
+                    before: null,
+                    after: null,
+                  }),
                   options,
                 );
               });

--- a/packages/postgres/src/query-interface.js
+++ b/packages/postgres/src/query-interface.js
@@ -109,7 +109,7 @@ export class PostgresQueryInterface extends PostgresQueryInterfaceTypescript {
             for (const val of vals) {
               promises.push(() => {
                 return this.sequelize.queryRaw(
-                  this.queryGenerator.pgEnumAdd(tableName, field, val, options),
+                  this.queryGenerator.pgEnumAdd(tableName, field, val, { ...options, before: null, after: null }),
                   options,
                 );
               });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? _A doc update is not necessary, this is a bugfix_
- [x] Did you update the typescript typings accordingly (if applicable)? _Not applicable_
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? _No, it does not, I jumped directly to creating a PR when I noticed the bug_
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

`pgListEnums()` used an inner join to `pg_enum`, so a type that exists but has zero values (`CREATE TYPE ... AS ENUM ()`) produced no result row at all -- indistinguishable from the type not existing yet. That sent `ensureEnums()` down the "create the type" path instead of the "backfill missing values" path, and `pgEnum()`'s duplicate_object guard silently swallowed the resulting error, leaving the type permanently empty.

Switch to a left join with `COALESCE` so an existing-but-empty type still produces a row with an empty `enum_value` array, correctly distinguishing it from a type that doesn't exist yet.

That surfaced a second bug: the backfill logic anchors every added value with `BEFORE`/`AFTER` relative to the last pre-existing value, so it never adds anything when there are zero pre-existing values to anchor to. Special-case that by appending all values in order instead.

## List of Breaking Changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL enum handling for existing enum types with no values.
  * Enum synchronization now correctly adds all configured values to empty enum types.
  * Enum listings now return empty value lists instead of omitting empty enum types.

* **Tests**
  * Added regression coverage for syncing models with empty PostgreSQL enums.
  * Updated coverage for empty enums, default schemas, and safely handled schema names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->