### PR TITLE
fix(core): minify table aliases during query generation

### DIFF
--- a/packages/core/src/abstract-dialect/dialect.ts
+++ b/packages/core/src/abstract-dialect/dialect.ts
@@ -45,7 +45,8 @@ export interface SupportableExactDecimalOptions extends SupportableDecimalNumber
 }
 
 export type DialectSupports = {
-  maxIdentifierLength: number;
+  /** Maximum length of a table alias. */
+  maxTableAliasLength: number;
   DEFAULT: boolean;
   'DEFAULT VALUES': boolean;
   'VALUES ()': boolean;
@@ -335,7 +336,7 @@ export abstract class AbstractDialect<
    * When changing a default, ensure the implementations still properly declare which feature they support.
    */
   static readonly supports: DialectSupports = freezeDeep({
-    maxIdentifierLength: Number.POSITIVE_INFINITY,
+    maxTableAliasLength: Number.POSITIVE_INFINITY,
     DEFAULT: true,
     'DEFAULT VALUES': false,
     'VALUES ()': false,

--- a/packages/core/src/abstract-dialect/dialect.ts
+++ b/packages/core/src/abstract-dialect/dialect.ts
@@ -45,6 +45,7 @@ export interface SupportableExactDecimalOptions extends SupportableDecimalNumber
 }
 
 export type DialectSupports = {
+  maxIdentifierLength: number;
   DEFAULT: boolean;
   'DEFAULT VALUES': boolean;
   'VALUES ()': boolean;
@@ -334,6 +335,7 @@ export abstract class AbstractDialect<
    * When changing a default, ensure the implementations still properly declare which feature they support.
    */
   static readonly supports: DialectSupports = freezeDeep({
+    maxIdentifierLength: Number.POSITIVE_INFINITY,
     DEFAULT: true,
     'DEFAULT VALUES': false,
     'VALUES ()': false,

--- a/packages/core/src/abstract-dialect/dialect.ts
+++ b/packages/core/src/abstract-dialect/dialect.ts
@@ -45,7 +45,6 @@ export interface SupportableExactDecimalOptions extends SupportableDecimalNumber
 }
 
 export type DialectSupports = {
-  /** Maximum length of a table alias. */
   maxTableAliasLength: number;
   DEFAULT: boolean;
   'DEFAULT VALUES': boolean;

--- a/packages/core/src/abstract-dialect/dialect.ts
+++ b/packages/core/src/abstract-dialect/dialect.ts
@@ -335,7 +335,7 @@ export abstract class AbstractDialect<
    * When changing a default, ensure the implementations still properly declare which feature they support.
    */
   static readonly supports: DialectSupports = freezeDeep({
-    maxTableAliasLength: Number.POSITIVE_INFINITY,
+    maxTableAliasLength: Number.MAX_SAFE_INTEGER,
     DEFAULT: true,
     'DEFAULT VALUES': false,
     'VALUES ()': false,

--- a/packages/core/src/abstract-dialect/query-generator-internal.ts
+++ b/packages/core/src/abstract-dialect/query-generator-internal.ts
@@ -232,8 +232,8 @@ export class AbstractQueryGeneratorInternal<Dialect extends AbstractDialect = Ab
     }
   }
 
-  formatAssociationPath(associationPath: AssociationPath): string {
-    return `${this.queryGenerator.quoteIdentifier(associationPath.associationPath.join('->'))}.${this.queryGenerator.quoteIdentifier(associationPath.attributeName)}`;
+  formatAssociationPath(associationPath: AssociationPath, options?: EscapeOptions): string {
+    return `${this.queryGenerator._quoteTableAlias(associationPath.associationPath.join('->'), options)}.${this.queryGenerator.quoteIdentifier(associationPath.attributeName)}`;
   }
 
   formatJsonPath(jsonPathVal: JsonPath, options?: EscapeOptions): string {

--- a/packages/core/src/abstract-dialect/query-generator-internal.ts
+++ b/packages/core/src/abstract-dialect/query-generator-internal.ts
@@ -19,6 +19,12 @@ import type { AddLimitOffsetOptions } from './query-generator.internal-types.js'
 import type { GetConstraintSnippetQueryOptions, TableOrModel } from './query-generator.types.js';
 import { WhereSqlBuilder, wrapAmbiguousWhere } from './where-sql-builder.js';
 
+interface TableAliasOptions extends EscapeOptions {
+  minifyAliases?: boolean;
+  includeAliases?: Map<string, string>;
+  reservedTableAliases?: Set<string>;
+}
+
 export class AbstractQueryGeneratorInternal<Dialect extends AbstractDialect = AbstractDialect> {
   readonly dialect: Dialect;
   readonly whereSqlBuilder: WhereSqlBuilder;
@@ -233,7 +239,56 @@ export class AbstractQueryGeneratorInternal<Dialect extends AbstractDialect = Ab
   }
 
   formatAssociationPath(associationPath: AssociationPath, options?: EscapeOptions): string {
-    return `${this.queryGenerator._quoteTableAlias(associationPath.associationPath.join('->'), options)}.${this.queryGenerator.quoteIdentifier(associationPath.attributeName)}`;
+    return `${this.quoteTableAlias(associationPath.associationPath.join('->'), options)}.${this.queryGenerator.quoteIdentifier(associationPath.attributeName)}`;
+  }
+
+  getTableAlias(alias: string, options?: TableAliasOptions): string {
+    if (!options?.minifyAliases || !options.includeAliases) {
+      return alias;
+    }
+
+    return (
+      options.includeAliases.get(alias) ||
+      options.includeAliases.get(alias.replaceAll('.', '->')) ||
+      alias
+    );
+  }
+
+  getMinifiedTableAlias(alias: string, options?: TableAliasOptions): string {
+    if (!options?.minifyAliases) {
+      return alias;
+    }
+
+    options.includeAliases ||= new Map();
+    options.reservedTableAliases ||= new Set(options.includeAliases.values());
+
+    const minifiedAlias = this.getTableAlias(alias, options);
+
+    if (minifiedAlias !== alias) {
+      return minifiedAlias;
+    }
+
+    if (alias.length <= this.dialect.supports.maxTableAliasLength) {
+      return alias;
+    }
+
+    let newAlias;
+    let aliasIndex = options.includeAliases.size;
+
+    do {
+      newAlias = `%${aliasIndex++}`;
+    } while (options.reservedTableAliases.has(newAlias));
+
+    options.includeAliases.set(alias, newAlias);
+    options.reservedTableAliases.add(newAlias);
+
+    return newAlias;
+  }
+
+  quoteTableAlias(alias: string, options?: TableAliasOptions): string {
+    const minifiedAlias = this.getMinifiedTableAlias(alias, options);
+
+    return this.queryGenerator.quoteIdentifier(minifiedAlias, minifiedAlias.startsWith('%'));
   }
 
   formatJsonPath(jsonPathVal: JsonPath, options?: EscapeOptions): string {

--- a/packages/core/src/abstract-dialect/query-generator-internal.ts
+++ b/packages/core/src/abstract-dialect/query-generator-internal.ts
@@ -268,7 +268,7 @@ export class AbstractQueryGeneratorInternal<Dialect extends AbstractDialect = Ab
       return minifiedAlias;
     }
 
-    if (alias.length <= this.dialect.supports.maxTableAliasLength) {
+    if (Buffer.byteLength(alias, 'utf8') <= this.dialect.supports.maxTableAliasLength) {
       return alias;
     }
 

--- a/packages/core/src/abstract-dialect/query-generator-internal.ts
+++ b/packages/core/src/abstract-dialect/query-generator-internal.ts
@@ -278,7 +278,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
       modelDefinition?.getColumnNameLoose(piece.attributeName) ?? piece.attributeName;
 
     if (options?.mainAlias) {
-      return `${this.queryGenerator.quoteIdentifier(options.mainAlias)}.${this.queryGenerator.quoteIdentifier(columnName)}`;
+      return `${this.queryGenerator.quoteIdentifier(options.mainAlias, options.mainAlias.startsWith('%'))}.${this.queryGenerator.quoteIdentifier(columnName)}`;
     }
 
     return this.queryGenerator.quoteIdentifier(columnName);

--- a/packages/core/src/abstract-dialect/query-generator-typescript.ts
+++ b/packages/core/src/abstract-dialect/query-generator-typescript.ts
@@ -658,7 +658,8 @@ export class AbstractQueryGeneratorTypeScript<Dialect extends AbstractDialect = 
     }
 
     if (options?.alias) {
-      sql += ` ${this.#internals.getAliasToken()} ${this.quoteIdentifier(options.alias === true ? tableName.tableName : options.alias)}`;
+      const alias = options.alias === true ? tableName.tableName : options.alias;
+      sql += ` ${this.#internals.getAliasToken()} ${this.quoteIdentifier(alias, alias.startsWith('%'))}`;
     }
 
     if (options?.indexHints) {
@@ -785,7 +786,7 @@ export class AbstractQueryGeneratorTypeScript<Dialect extends AbstractDialect = 
     }
 
     if (piece instanceof AssociationPath) {
-      return this.#internals.formatAssociationPath(piece);
+      return this.#internals.formatAssociationPath(piece, options);
     }
 
     if (piece instanceof DialectAwareFn) {

--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -77,7 +77,6 @@ export interface AddColumnQueryOptions {
 export class AbstractQueryGenerator<
   Dialect extends AbstractDialect = AbstractDialect,
 > extends AbstractQueryGeneratorTypeScript<Dialect> {
-  _quoteTableAlias(alias: string, options?: object): string;
   quoteIdentifiers(identifiers: string): string;
 
   selectQuery<M extends Model>(

--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -77,6 +77,7 @@ export interface AddColumnQueryOptions {
 export class AbstractQueryGenerator<
   Dialect extends AbstractDialect = AbstractDialect,
 > extends AbstractQueryGeneratorTypeScript<Dialect> {
+  _quoteTableAlias(alias: string, options?: object): string;
   quoteIdentifiers(identifiers: string): string;
 
   selectQuery<M extends Model>(

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -2180,6 +2180,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         replacements: options?.replacements,
         minifyAliases: topLevelInfo.options.minifyAliases,
         includeAliases: topLevelInfo.options.includeAliases,
+        reservedTableAliases: topLevelInfo.options.reservedTableAliases,
       });
     }
 
@@ -2190,6 +2191,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         replacements: options?.replacements,
         minifyAliases: topLevelInfo.options.minifyAliases,
         includeAliases: topLevelInfo.options.includeAliases,
+        reservedTableAliases: topLevelInfo.options.reservedTableAliases,
       });
       if (joinWhere) {
         joinOn = joinWithLogicalOperator([joinOn, joinWhere], include.or ? Op.or : Op.and);

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -845,6 +845,10 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         const minifiedTableAlias = this._getTableAlias(tableAlias, options);
 
         if (minifiedTableAlias !== tableAlias) {
+          if (columnName === '*') {
+            return `${this.quoteIdentifier(minifiedTableAlias, true)}.*`;
+          }
+
           return `${this.quoteIdentifier(minifiedTableAlias, true)}.${this.quoteIdentifier(columnName)}`;
         }
       }
@@ -1085,15 +1089,32 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       options.aliasesByTable = {};
     }
 
-    if (options.minifyAliases && !options.includeAliases) {
-      options.includeAliases = new Map();
-    }
-
     // resolve table name options
     if (options.tableAs) {
       mainTable.as = options.tableAs;
     } else if (!Array.isArray(mainTable.name) && mainTable.model) {
       mainTable.as = mainTable.model.name;
+    }
+
+    if (options.minifyAliases) {
+      options.includeAliases ||= new Map();
+      options.reservedTableAliases ||= new Set(options.includeAliases.values());
+
+      if (mainTable.as) {
+        options.reservedTableAliases.add(mainTable.as);
+      }
+
+      const includes = [...(options.include ?? [])];
+
+      for (const include of includes) {
+        options.reservedTableAliases.add(include.as);
+
+        if (include.through?.as) {
+          options.reservedTableAliases.add(include.through.as);
+        }
+
+        includes.push(...(include.include ?? []));
+      }
     }
 
     mainTable.quotedAs =
@@ -1273,6 +1294,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
             aliasesMapping: options.aliasesMapping,
             aliasesByTable: options.aliasesByTable,
             includeAliases: options.includeAliases,
+            reservedTableAliases: options.reservedTableAliases,
             where,
             include,
             model,
@@ -1508,7 +1530,8 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   }
 
   escapeAttributes(attributes, options, mainTableAs) {
-    const quotedMainTableAs = mainTableAs && this.quoteIdentifier(mainTableAs);
+    const quotedMainTableAs =
+      mainTableAs && this.quoteIdentifier(mainTableAs, mainTableAs.startsWith('%'));
 
     return (
       attributes &&
@@ -1816,6 +1839,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     }
 
     options.includeAliases ||= new Map();
+    options.reservedTableAliases ||= new Set(options.includeAliases.values());
 
     const minifiedAlias = this._getTableAlias(alias, options);
 
@@ -1823,12 +1847,19 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       return minifiedAlias;
     }
 
-    if (alias.length <= this.dialect.supports.maxIdentifierLength) {
+    if (alias.length <= this.dialect.supports.maxTableAliasLength) {
       return alias;
     }
 
-    const newAlias = `%${options.includeAliases.size}`;
+    let newAlias;
+    let aliasIndex = options.includeAliases.size;
+
+    do {
+      newAlias = `%${aliasIndex++}`;
+    } while (options.reservedTableAliases.has(newAlias));
+
     options.includeAliases.set(alias, newAlias);
+    options.reservedTableAliases.add(newAlias);
 
     return newAlias;
   }
@@ -1836,7 +1867,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   _quoteTableAlias(alias, options) {
     const minifiedAlias = this._getMinifiedTableAlias(alias, options);
 
-    return this.quoteIdentifier(minifiedAlias, minifiedAlias !== alias);
+    return this.quoteIdentifier(minifiedAlias, minifiedAlias.startsWith('%'));
   }
 
   _getAliasForField(tableName, field, options) {
@@ -2148,7 +2179,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       ? topLevelInfo.names?.quotedAs || this.quoteIdentifier(asLeft)
       : this._quoteTableAlias(asLeft, topLevelInfo.options);
     const minifiedAsRight = this._getMinifiedTableAlias(asRight, topLevelInfo.options);
-    const quotedAsRight = this.quoteIdentifier(minifiedAsRight, minifiedAsRight !== asRight);
+    const quotedAsRight = this.quoteIdentifier(minifiedAsRight, minifiedAsRight.startsWith('%'));
 
     // TODO: use whereItemsQuery to generate the entire "ON" condition.
     let joinOn = `${quotedAsLeft}.${this.quoteIdentifier(columnNameLeft)}`;
@@ -2322,11 +2353,11 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     );
     const quotedThroughAs = this.quoteIdentifier(
       minifiedThroughAs,
-      minifiedThroughAs !== throughAs,
+      minifiedThroughAs.startsWith('%'),
     );
     const quotedIncludeAs = this.quoteIdentifier(
       minifiedIncludeAs,
-      minifiedIncludeAs !== includeAs.internalAs,
+      minifiedIncludeAs.startsWith('%'),
     );
     const quotedParentTableName = isRootParent
       ? this.quoteIdentifier(parentTableName, parentTableName.startsWith('%'))
@@ -2595,6 +2626,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
           aliasesMapping: topLevelInfo.options.aliasesMapping,
           aliasesByTable: topLevelInfo.options.aliasesByTable,
           includeAliases: topLevelInfo.options.includeAliases,
+          reservedTableAliases: topLevelInfo.options.reservedTableAliases,
         },
         topInclude.through.model,
       );
@@ -2609,7 +2641,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
       const minifiedTopIncludeAs = this._getMinifiedTableAlias(topInclude.as, topLevelInfo.options);
       const join = [
-        `${this.quoteIdentifier(minifiedTopIncludeAs, minifiedTopIncludeAs !== topInclude.as)}.${this.quoteIdentifier(targetField)}`,
+        `${this.quoteIdentifier(minifiedTopIncludeAs, minifiedTopIncludeAs.startsWith('%'))}.${this.quoteIdentifier(targetField)}`,
         `${this.quoteIdentifier(topParent.as || topParent.model.name)}.${this.quoteIdentifier(sourceField)}`,
       ].join(' = ');
 
@@ -2628,6 +2660,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
           aliasesMapping: topLevelInfo.options.aliasesMapping,
           aliasesByTable: topLevelInfo.options.aliasesByTable,
           includeAliases: topLevelInfo.options.includeAliases,
+          reservedTableAliases: topLevelInfo.options.reservedTableAliases,
         },
         topInclude.model,
       );

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -838,6 +838,17 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
     // just quote as identifiers if string
     if (typeof collection === 'string') {
+      if (collection.includes('.')) {
+        const parts = collection.split('.');
+        const columnName = parts.pop();
+        const tableAlias = parts.join('->');
+        const minifiedTableAlias = this._getTableAlias(tableAlias, options);
+
+        if (minifiedTableAlias !== tableAlias) {
+          return `${this.quoteIdentifier(minifiedTableAlias, true)}.${this.quoteIdentifier(columnName)}`;
+        }
+      }
+
       return this.quoteIdentifiers(collection);
     }
 
@@ -970,7 +981,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       let sql = '';
 
       if (i > 0) {
-        sql += `${this.quoteIdentifier(tableNames.join(connector))}.`;
+        sql += `${this._quoteTableAlias(tableNames.join(connector), options)}.`;
       } else if (typeof collection[0] === 'string' && parent) {
         sql += `${this.quoteIdentifier(parent.name)}.`;
       }
@@ -1072,6 +1083,9 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     if (options.minifyAliases && !options.aliasesMapping) {
       options.aliasesMapping = new Map();
       options.aliasesByTable = {};
+    }
+
+    if (options.minifyAliases && !options.includeAliases) {
       options.includeAliases = new Map();
     }
 
@@ -1082,7 +1096,8 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       mainTable.as = mainTable.model.name;
     }
 
-    mainTable.quotedAs = mainTable.as && this.quoteIdentifier(mainTable.as);
+    mainTable.quotedAs =
+      mainTable.as && this.quoteIdentifier(mainTable.as, mainTable.as.startsWith('%'));
 
     mainTable.quotedName = !Array.isArray(mainTable.name)
       ? this.quoteTable(mainTable.name, { ...options, alias: mainTable.as ?? false })
@@ -1257,6 +1272,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
             minifyAliases: options.minifyAliases,
             aliasesMapping: options.aliasesMapping,
             aliasesByTable: options.aliasesByTable,
+            includeAliases: options.includeAliases,
             where,
             include,
             model,
@@ -1571,6 +1587,8 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       includeAs.externalAs = `${parentTableName.externalAs}.${include.as}`;
     }
 
+    const quotedInternalAs = this._quoteTableAlias(includeAs.internalAs, topLevelInfo.options);
+
     // includeIgnoreAttributes is used by aggregate functions
     if (topLevelInfo.options.includeIgnoreAttributes !== false) {
       include.model._expandAttributes(include);
@@ -1610,19 +1628,13 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         if (verbatim === true) {
           prefix = attr;
         } else if (/#>>|->>/.test(attr)) {
-          prefix = `(${this.quoteIdentifier(includeAs.internalAs)}.${attr.replaceAll(/\(|\)/g, '')})`;
+          prefix = `(${quotedInternalAs}.${attr.replaceAll(/\(|\)/g, '')})`;
         } else if (/json_extract\(/.test(attr)) {
-          prefix = attr.replace(
-            /json_extract\(/i,
-            `json_extract(${this.quoteIdentifier(includeAs.internalAs)}.`,
-          );
+          prefix = attr.replace(/json_extract\(/i, `json_extract(${quotedInternalAs}.`);
         } else if (/json_value\(/.test(attr)) {
-          prefix = attr.replace(
-            /json_value\(/i,
-            `json_value(${this.quoteIdentifier(includeAs.internalAs)}.`,
-          );
+          prefix = attr.replace(/json_value\(/i, `json_value(${quotedInternalAs}.`);
         } else {
-          prefix = `${this.quoteIdentifier(includeAs.internalAs)}.${this.quoteIdentifier(attr)}`;
+          prefix = `${quotedInternalAs}.${this.quoteIdentifier(attr)}`;
         }
 
         let alias = `${includeAs.externalAs}.${attrAs}`;
@@ -1784,6 +1796,47 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     options.aliasesByTable[`${tableName}${alias}`] = minifiedAlias;
 
     return minifiedAlias;
+  }
+
+  _getTableAlias(alias, options) {
+    if (!options?.minifyAliases || !options.includeAliases) {
+      return alias;
+    }
+
+    return (
+      options.includeAliases.get(alias) ||
+      options.includeAliases.get(alias.replaceAll('.', '->')) ||
+      alias
+    );
+  }
+
+  _getMinifiedTableAlias(alias, options) {
+    if (!options?.minifyAliases) {
+      return alias;
+    }
+
+    options.includeAliases ||= new Map();
+
+    const minifiedAlias = this._getTableAlias(alias, options);
+
+    if (minifiedAlias !== alias) {
+      return minifiedAlias;
+    }
+
+    if (alias.length <= this.dialect.supports.maxIdentifierLength) {
+      return alias;
+    }
+
+    const newAlias = `%${options.includeAliases.size}`;
+    options.includeAliases.set(alias, newAlias);
+
+    return newAlias;
+  }
+
+  _quoteTableAlias(alias, options) {
+    const minifiedAlias = this._getMinifiedTableAlias(alias, options);
+
+    return this.quoteIdentifier(minifiedAlias, minifiedAlias !== alias);
   }
 
   _getAliasForField(tableName, field, options) {
@@ -2091,8 +2144,14 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       asRight = `${asLeft}->${asRight}`;
     }
 
+    const quotedAsLeft = parentIsTop
+      ? topLevelInfo.names?.quotedAs || this.quoteIdentifier(asLeft)
+      : this._quoteTableAlias(asLeft, topLevelInfo.options);
+    const minifiedAsRight = this._getMinifiedTableAlias(asRight, topLevelInfo.options);
+    const quotedAsRight = this.quoteIdentifier(minifiedAsRight, minifiedAsRight !== asRight);
+
     // TODO: use whereItemsQuery to generate the entire "ON" condition.
-    let joinOn = `${this.quoteIdentifier(asLeft)}.${this.quoteIdentifier(columnNameLeft)}`;
+    let joinOn = `${quotedAsLeft}.${this.quoteIdentifier(columnNameLeft)}`;
     const subqueryAttributes = [];
 
     if (
@@ -2101,8 +2160,8 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     ) {
       if (parentIsTop) {
         // The main model attributes is not aliased to a prefix
-        const tableName = parent.as || parent.model.name;
-        const quotedTableName = this.quoteIdentifier(tableName);
+        const tableName = topLevelInfo.names?.as || parent.as || parent.model.name;
+        const quotedTableName = topLevelInfo.names?.quotedAs || this.quoteIdentifier(tableName);
 
         // Check for potential aliased JOIN condition
         joinOn =
@@ -2127,31 +2186,29 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       }
     }
 
-    joinOn += ` = ${this.quoteIdentifier(asRight)}.${this.quoteIdentifier(fieldRight)}`;
+    joinOn += ` = ${quotedAsRight}.${this.quoteIdentifier(fieldRight)}`;
 
     if (include.on) {
       joinOn = this.whereItemsQuery(include.on, {
-        mainAlias: asRight,
+        mainAlias: minifiedAsRight,
         model: include.model,
         replacements: options?.replacements,
+        minifyAliases: topLevelInfo.options.minifyAliases,
+        includeAliases: topLevelInfo.options.includeAliases,
       });
     }
 
     if (include.where) {
       joinWhere = this.whereItemsQuery(include.where, {
-        mainAlias: asRight,
+        mainAlias: minifiedAsRight,
         model: include.model,
         replacements: options?.replacements,
+        minifyAliases: topLevelInfo.options.minifyAliases,
+        includeAliases: topLevelInfo.options.includeAliases,
       });
       if (joinWhere) {
         joinOn = joinWithLogicalOperator([joinOn, joinWhere], include.or ? Op.or : Op.and);
       }
-    }
-
-    if (options?.minifyAliases && asRight.length > 63) {
-      const alias = `%${topLevelInfo.options.includeAliases.size}`;
-
-      topLevelInfo.options.includeAliases.set(alias, asRight);
     }
 
     return {
@@ -2160,7 +2217,11 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         : include.right && this.dialect.supports['RIGHT JOIN']
           ? 'RIGHT OUTER JOIN'
           : 'LEFT OUTER JOIN',
-      body: this.quoteTable(tableRight, { ...topLevelInfo.options, ...include, alias: asRight }),
+      body: this.quoteTable(tableRight, {
+        ...topLevelInfo.options,
+        ...include,
+        alias: minifiedAsRight,
+      }),
       condition: joinOn,
       attributes: {
         main: [],
@@ -2254,6 +2315,22 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     const throughTable = through.model.table;
     const throughAs = `${includeAs.internalAs}->${through.as}`;
     const externalThroughAs = `${includeAs.externalAs}.${through.as}`;
+    const minifiedThroughAs = this._getMinifiedTableAlias(throughAs, topLevelInfo.options);
+    const minifiedIncludeAs = this._getMinifiedTableAlias(
+      includeAs.internalAs,
+      topLevelInfo.options,
+    );
+    const quotedThroughAs = this.quoteIdentifier(
+      minifiedThroughAs,
+      minifiedThroughAs !== throughAs,
+    );
+    const quotedIncludeAs = this.quoteIdentifier(
+      minifiedIncludeAs,
+      minifiedIncludeAs !== includeAs.internalAs,
+    );
+    const quotedParentTableName = isRootParent
+      ? this.quoteIdentifier(parentTableName, parentTableName.startsWith('%'))
+      : this._quoteTableAlias(parentTableName, topLevelInfo.options);
 
     const throughAttributes = through.attributes.map(attr => {
       let alias = `${externalThroughAs}.${Array.isArray(attr) ? attr[1] : attr}`;
@@ -2263,7 +2340,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       }
 
       return joinSQLFragments([
-        `${this.quoteIdentifier(throughAs)}.${this.quoteIdentifier(Array.isArray(attr) ? attr[0] : attr)}`,
+        `${quotedThroughAs}.${this.quoteIdentifier(Array.isArray(attr) ? attr[0] : attr)}`,
         'AS',
         this.quoteIdentifier(alias),
       ]);
@@ -2272,7 +2349,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     const association = include.association;
     const tableSource = parentTableName;
     const identSource = association.identifierField;
-    const tableTarget = includeAs.internalAs;
     const identTarget = association.foreignIdentifierField;
     const attrTarget = association.targetKeyField;
 
@@ -2292,19 +2368,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     let targetJoinOn;
     let throughWhere;
     let targetWhere;
-
-    if (options.minifyAliases && throughAs.length > 63) {
-      topLevelInfo.options.includeAliases.set(
-        `%${topLevelInfo.options.includeAliases.size}`,
-        throughAs,
-      );
-      if (includeAs.internalAs.length > 63) {
-        topLevelInfo.options.includeAliases.set(
-          `%${topLevelInfo.options.includeAliases.size}`,
-          includeAs.internalAs,
-        );
-      }
-    }
 
     if (topLevelInfo.options.includeIgnoreAttributes !== false) {
       // Through includes are always hasMany, so we need to add the attributes to the mainAttributes no matter what (Real join will never be executed in subquery)
@@ -2365,13 +2428,13 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         const joinColumn = association.sourceKeyField || attrSource || identSource;
 
         if (isRootParent) {
-          sourceJoinOn = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(joinColumn)} = `;
+          sourceJoinOn = `${quotedParentTableName}.${this.quoteIdentifier(joinColumn)} = `;
         } else {
           const aliasBase = `${dottedTableSource}.${joinColumn}`;
 
           aliasedSource = this._getMinifiedAlias(aliasBase, tableSource, topLevelInfo.options);
 
-          const projection = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(joinColumn)} AS ${this.quoteIdentifier(aliasedSource)}`;
+          const projection = `${quotedParentTableName}.${this.quoteIdentifier(joinColumn)} AS ${this.quoteIdentifier(aliasedSource)}`;
 
           if (!attributes.subQuery.includes(projection)) {
             attributes.subQuery.push(projection);
@@ -2411,26 +2474,26 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         }
       }
     } else {
-      sourceJoinOn = `${this.quoteIdentifier(tableSource)}.${this.quoteIdentifier(attrSource)} = `;
+      sourceJoinOn = `${quotedParentTableName}.${this.quoteIdentifier(attrSource)} = `;
     }
 
-    sourceJoinOn += `${this.quoteIdentifier(throughAs)}.${this.quoteIdentifier(identSource)}`;
+    sourceJoinOn += `${quotedThroughAs}.${this.quoteIdentifier(identSource)}`;
 
     // Filter statement for right side of through
     // Used by both join and subquery where
-    targetJoinOn = `${this.quoteIdentifier(tableTarget)}.${this.quoteIdentifier(attrTarget)} = `;
-    targetJoinOn += `${this.quoteIdentifier(throughAs)}.${this.quoteIdentifier(identTarget)}`;
+    targetJoinOn = `${quotedIncludeAs}.${this.quoteIdentifier(attrTarget)} = `;
+    targetJoinOn += `${quotedThroughAs}.${this.quoteIdentifier(identTarget)}`;
 
     if (through.where) {
       throughWhere = this.whereItemsQuery(through.where, {
         ...topLevelInfo.options,
         model: through.model,
-        mainAlias: throughAs,
+        mainAlias: minifiedThroughAs,
       });
     }
 
     // Generate a wrapped join so that the through table join can be dependent on the target join
-    joinBody = `( ${this.quoteTable(throughTable, { ...topLevelInfo.options, ...include, alias: throughAs })} INNER JOIN ${this.quoteTable(include.model.table, { ...topLevelInfo.options, ...include, alias: includeAs.internalAs })} ON ${targetJoinOn}`;
+    joinBody = `( ${this.quoteTable(throughTable, { ...topLevelInfo.options, ...include, alias: minifiedThroughAs })} INNER JOIN ${this.quoteTable(include.model.table, { ...topLevelInfo.options, ...include, alias: minifiedIncludeAs })} ON ${targetJoinOn}`;
     if (throughWhere) {
       joinBody += ` AND ${throughWhere}`;
     }
@@ -2442,7 +2505,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       targetWhere = this.whereItemsQuery(include.where, {
         ...topLevelInfo.options,
         model: include.model,
-        mainAlias: includeAs.internalAs,
+        mainAlias: minifiedIncludeAs,
       });
       if (targetWhere) {
         joinCondition += ` AND ${targetWhere}`;
@@ -2528,6 +2591,10 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
             ],
           },
           includeIgnoreAttributes: false,
+          minifyAliases: topLevelInfo.options.minifyAliases,
+          aliasesMapping: topLevelInfo.options.aliasesMapping,
+          aliasesByTable: topLevelInfo.options.aliasesByTable,
+          includeAliases: topLevelInfo.options.includeAliases,
         },
         topInclude.through.model,
       );
@@ -2540,8 +2607,9 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         ? topAssociation.sourceKeyField || topInclude.model.primaryKeyField
         : topAssociation.identifierField;
 
+      const minifiedTopIncludeAs = this._getMinifiedTableAlias(topInclude.as, topLevelInfo.options);
       const join = [
-        `${this.quoteIdentifier(topInclude.as)}.${this.quoteIdentifier(targetField)}`,
+        `${this.quoteIdentifier(minifiedTopIncludeAs, minifiedTopIncludeAs !== topInclude.as)}.${this.quoteIdentifier(targetField)}`,
         `${this.quoteIdentifier(topParent.as || topParent.model.name)}.${this.quoteIdentifier(sourceField)}`,
       ].join(' = ');
 
@@ -2554,8 +2622,12 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
           where: {
             [Op.and]: [topInclude.where, new Literal(join)],
           },
-          tableAs: topInclude.as,
+          tableAs: minifiedTopIncludeAs,
           includeIgnoreAttributes: false,
+          minifyAliases: topLevelInfo.options.minifyAliases,
+          aliasesMapping: topLevelInfo.options.aliasesMapping,
+          aliasesByTable: topLevelInfo.options.aliasesByTable,
+          includeAliases: topLevelInfo.options.includeAliases,
         },
         topInclude.model,
       );

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -842,7 +842,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         const parts = collection.split('.');
         const columnName = parts.pop();
         const tableAlias = parts.join('->');
-        const minifiedTableAlias = this._getTableAlias(tableAlias, options);
+        const minifiedTableAlias = this.#internals.getTableAlias(tableAlias, options);
 
         if (minifiedTableAlias !== tableAlias) {
           if (columnName === '*') {
@@ -985,7 +985,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       let sql = '';
 
       if (i > 0) {
-        sql += `${this._quoteTableAlias(tableNames.join(connector), options)}.`;
+        sql += `${this.#internals.quoteTableAlias(tableNames.join(connector), options)}.`;
       } else if (typeof collection[0] === 'string' && parent) {
         sql += `${this.quoteIdentifier(parent.name)}.`;
       }
@@ -1610,7 +1610,10 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       includeAs.externalAs = `${parentTableName.externalAs}.${include.as}`;
     }
 
-    const quotedInternalAs = this._quoteTableAlias(includeAs.internalAs, topLevelInfo.options);
+    const quotedInternalAs = this.#internals.quoteTableAlias(
+      includeAs.internalAs,
+      topLevelInfo.options,
+    );
 
     // includeIgnoreAttributes is used by aggregate functions
     if (topLevelInfo.options.includeIgnoreAttributes !== false) {
@@ -1819,55 +1822,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     options.aliasesByTable[`${tableName}${alias}`] = minifiedAlias;
 
     return minifiedAlias;
-  }
-
-  _getTableAlias(alias, options) {
-    if (!options?.minifyAliases || !options.includeAliases) {
-      return alias;
-    }
-
-    return (
-      options.includeAliases.get(alias) ||
-      options.includeAliases.get(alias.replaceAll('.', '->')) ||
-      alias
-    );
-  }
-
-  _getMinifiedTableAlias(alias, options) {
-    if (!options?.minifyAliases) {
-      return alias;
-    }
-
-    options.includeAliases ||= new Map();
-    options.reservedTableAliases ||= new Set(options.includeAliases.values());
-
-    const minifiedAlias = this._getTableAlias(alias, options);
-
-    if (minifiedAlias !== alias) {
-      return minifiedAlias;
-    }
-
-    if (alias.length <= this.dialect.supports.maxTableAliasLength) {
-      return alias;
-    }
-
-    let newAlias;
-    let aliasIndex = options.includeAliases.size;
-
-    do {
-      newAlias = `%${aliasIndex++}`;
-    } while (options.reservedTableAliases.has(newAlias));
-
-    options.includeAliases.set(alias, newAlias);
-    options.reservedTableAliases.add(newAlias);
-
-    return newAlias;
-  }
-
-  _quoteTableAlias(alias, options) {
-    const minifiedAlias = this._getMinifiedTableAlias(alias, options);
-
-    return this.quoteIdentifier(minifiedAlias, minifiedAlias.startsWith('%'));
   }
 
   _getAliasForField(tableName, field, options) {
@@ -2177,8 +2131,8 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
     const quotedAsLeft = parentIsTop
       ? topLevelInfo.names?.quotedAs || this.quoteIdentifier(asLeft)
-      : this._quoteTableAlias(asLeft, topLevelInfo.options);
-    const minifiedAsRight = this._getMinifiedTableAlias(asRight, topLevelInfo.options);
+      : this.#internals.quoteTableAlias(asLeft, topLevelInfo.options);
+    const minifiedAsRight = this.#internals.getMinifiedTableAlias(asRight, topLevelInfo.options);
     const quotedAsRight = this.quoteIdentifier(minifiedAsRight, minifiedAsRight.startsWith('%'));
 
     // TODO: use whereItemsQuery to generate the entire "ON" condition.
@@ -2346,8 +2300,11 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     const throughTable = through.model.table;
     const throughAs = `${includeAs.internalAs}->${through.as}`;
     const externalThroughAs = `${includeAs.externalAs}.${through.as}`;
-    const minifiedThroughAs = this._getMinifiedTableAlias(throughAs, topLevelInfo.options);
-    const minifiedIncludeAs = this._getMinifiedTableAlias(
+    const minifiedThroughAs = this.#internals.getMinifiedTableAlias(
+      throughAs,
+      topLevelInfo.options,
+    );
+    const minifiedIncludeAs = this.#internals.getMinifiedTableAlias(
       includeAs.internalAs,
       topLevelInfo.options,
     );
@@ -2361,7 +2318,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     );
     const quotedParentTableName = isRootParent
       ? this.quoteIdentifier(parentTableName, parentTableName.startsWith('%'))
-      : this._quoteTableAlias(parentTableName, topLevelInfo.options);
+      : this.#internals.quoteTableAlias(parentTableName, topLevelInfo.options);
 
     const throughAttributes = through.attributes.map(attr => {
       let alias = `${externalThroughAs}.${Array.isArray(attr) ? attr[1] : attr}`;
@@ -2639,7 +2596,10 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         ? topAssociation.sourceKeyField || topInclude.model.primaryKeyField
         : topAssociation.identifierField;
 
-      const minifiedTopIncludeAs = this._getMinifiedTableAlias(topInclude.as, topLevelInfo.options);
+      const minifiedTopIncludeAs = this.#internals.getMinifiedTableAlias(
+        topInclude.as,
+        topLevelInfo.options,
+      );
       const join = [
         `${this.quoteIdentifier(minifiedTopIncludeAs, minifiedTopIncludeAs.startsWith('%'))}.${this.quoteIdentifier(targetField)}`,
         `${this.quoteIdentifier(topParent.as || topParent.model.name)}.${this.quoteIdentifier(sourceField)}`,

--- a/packages/core/src/abstract-dialect/query.ts
+++ b/packages/core/src/abstract-dialect/query.ts
@@ -195,8 +195,13 @@ function remapRowFields(
     const field = fields[index];
     const name = fieldMap[field];
 
-    if (field in output && name !== field) {
-      output[name] = output[field];
+    if (Object.hasOwn(output, field) && name !== field) {
+      Object.defineProperty(output, name, {
+        configurable: true,
+        enumerable: true,
+        value: output[field],
+        writable: true,
+      });
       delete output[field];
     }
   }

--- a/packages/core/src/abstract-dialect/query.ts
+++ b/packages/core/src/abstract-dialect/query.ts
@@ -807,6 +807,8 @@ export interface AbstractQueryOptions {
   type?: QueryTypes;
   /** Map from raw column name to model attribute name, or `true` to disable. */
   fieldMap?: Record<string, string> | boolean;
+  /** Map from generated column aliases to their original names. */
+  aliasesMapping?: ReadonlyMap<string, string>;
   /** If `true`, returns only the first row (or `null`). */
   plain: boolean;
   /** If `true`, returns raw objects instead of model instances. */
@@ -1065,6 +1067,11 @@ export class AbstractQuery {
   protected handleSelectQuery(results: Array<Record<string, unknown>>): unknown {
     let processedResults: Array<Record<string, unknown>> = results;
     let result: unknown = null;
+
+    if (this.options.aliasesMapping?.size) {
+      const aliasesMapping = Object.fromEntries(this.options.aliasesMapping);
+      processedResults = processedResults.map(row => remapRowFields(row, aliasesMapping));
+    }
 
     if (this.options.fieldMap && typeof this.options.fieldMap === 'object') {
       processedResults = processedResults.map(row =>

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -389,7 +389,7 @@ Use Sequelize#query if you wish to use replacements.`);
         await this.hooks.runAsync('beforeQuery', options, query);
         checkTransaction();
 
-        return await query.run(sql, bindParameters, { minifyAliases: options.minifyAliases });
+        return await query.run(sql, bindParameters);
       } finally {
         await this.hooks.runAsync('afterQuery', options, query);
         if (!options.transaction && !options.connection) {

--- a/packages/core/test/integration/dialects/postgres/query.test.js
+++ b/packages/core/test/integration/dialects/postgres/query.test.js
@@ -7,10 +7,12 @@ const Support = require('../../support');
 const sinon = require('sinon');
 
 const dialect = Support.getTestDialect();
-const { DatabaseError, DataTypes, Op } = require('@sequelize/core');
+const { DatabaseError, DataTypes, Op, sql } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Query', () => {
+    Support.allowDeprecationsInSuite(['SEQUELIZE0023']);
+
     const taskAlias = 'AnActualVeryLongAliasThatShouldBreakthePostgresLimitOfSixtyFourCharacters';
     const teamAlias = 'Toto';
     const sponsorAlias = 'AnotherVeryLongAliasThatShouldBreakthePostgresLimitOfSixtyFourCharacters';
@@ -77,14 +79,144 @@ if (dialect.startsWith('postgres')) {
       });
     });
 
+    it('should quote minified include aliases when identifier quoting is disabled', async function () {
+      const options = {
+        ...this.sequelize.options,
+        minifyAliases: true,
+        quoteIdentifiers: false,
+      };
+
+      await executeTest(options, async (db, predicate) => {
+        expect((await db.User.findOne(predicate))[taskAlias].title).to.equal('SuperTask');
+      });
+    });
+
+    it('uses minified include aliases in structured query clauses', async function () {
+      const options = { ...this.sequelize.options, minifyAliases: true };
+
+      await executeTest(options, async (db, predicate) => {
+        const taskReference = { model: db.Task, as: taskAlias };
+        predicate.attributes = ['id'];
+        predicate.include = [{ ...predicate.include[0], attributes: [] }];
+        predicate.where = { [`$${taskAlias}.title$`]: 'SuperTask' };
+        predicate.group = ['User.id', `${taskAlias}.id`, `${taskAlias}.title`];
+        predicate.having = sql.where(sql.fn('COUNT', sql.col(`${taskAlias}.id`)), Op.gt, 0);
+        predicate.order = [[taskReference, 'title', 'ASC']];
+
+        expect(await db.User.findAll(predicate)).to.have.length(1);
+      });
+    });
+
+    it('minifies includes in grouped limits', async function () {
+      const options = { ...this.sequelize.options, minifyAliases: true };
+
+      await executeTest(options, async (db, predicate) => {
+        const team = await db.Team.findOne();
+        const users = await db.User.findAll({
+          groupedLimit: {
+            limit: 1,
+            on: db.User.associations[teamAlias],
+            values: [team.id],
+          },
+          include: [predicate.include[0]],
+        });
+
+        expect(users).to.have.length(1);
+        expect(users[0][taskAlias].title).to.equal('SuperTask');
+      });
+    });
+
+    it('does not replace root table names that match minified include aliases', async () => {
+      const sequelize = Support.createSingleTestSequelizeInstance({ minifyAliases: true });
+      const longAlias = 'associationWithAnAliasLongEnoughToExceedThePostgresIdentifierLimit';
+      const Root = sequelize.define(
+        'AliasRoot',
+        { name: DataTypes.STRING },
+        { tableName: longAlias, timestamps: false },
+      );
+      const Parent = sequelize.define('AliasParent', {}, { timestamps: false });
+      const FirstChild = sequelize.define('AliasFirstChild', {}, { timestamps: false });
+      const SecondChild = sequelize.define('AliasSecondChild', {}, { timestamps: false });
+
+      Root.hasOne(Parent, { as: longAlias, foreignKey: 'rootId' });
+      Parent.hasOne(FirstChild, { as: 'firstChild', foreignKey: 'parentId' });
+      Parent.hasOne(SecondChild, { as: 'secondChild', foreignKey: 'parentId' });
+
+      await sequelize.sync({ force: true });
+      const root = await Root.create({ name: longAlias });
+      const parent = await Parent.create({ rootId: root.id });
+      await Promise.all([
+        FirstChild.create({ parentId: parent.id }),
+        SecondChild.create({ parentId: parent.id }),
+      ]);
+
+      const result = await Root.findOne({
+        where: { name: longAlias },
+        include: [
+          {
+            association: Root.associations[longAlias],
+            include: [
+              { association: Parent.associations.firstChild },
+              { association: Parent.associations.secondChild },
+            ],
+          },
+        ],
+      });
+
+      expect(result[longAlias].firstChild).to.exist;
+      expect(result[longAlias].secondChild).to.exist;
+    });
+
+    it('minifies nested include aliases in subquery filters', async () => {
+      const sequelize = Support.createSingleTestSequelizeInstance({ minifyAliases: true });
+      const Root = sequelize.define('FilterRoot', {}, { timestamps: false });
+      const Parent = sequelize.define('FilterParent', {}, { timestamps: false });
+      const FirstChild = sequelize.define('FilterFirstChild', {}, { timestamps: false });
+      const SecondChild = sequelize.define('FilterSecondChild', {}, { timestamps: false });
+      const prefix = 'associationWithAnAliasLongEnoughToExceedThePostgresIdentifierLimit';
+      const parentAlias = `${prefix}Parents`;
+      const firstAlias = `${prefix}First`;
+      const secondAlias = `${prefix}Second`;
+
+      Root.hasMany(Parent, { as: parentAlias, foreignKey: 'rootId' });
+      Parent.hasOne(FirstChild, { as: firstAlias, foreignKey: 'parentId' });
+      Parent.hasOne(SecondChild, { as: secondAlias, foreignKey: 'parentId' });
+
+      await sequelize.sync({ force: true });
+      const root = await Root.create();
+      const parent = await Parent.create({ rootId: root.id });
+      await Promise.all([
+        FirstChild.create({ parentId: parent.id }),
+        SecondChild.create({ parentId: parent.id }),
+      ]);
+
+      const result = await Root.findOne({
+        include: [
+          {
+            association: Root.associations[parentAlias],
+            required: true,
+            include: [
+              { association: Parent.associations[firstAlias], required: true },
+              { association: Parent.associations[secondAlias], required: true },
+            ],
+          },
+        ],
+      });
+
+      expect(result[parentAlias][0][firstAlias]).to.exist;
+      expect(result[parentAlias][0][secondAlias]).to.exist;
+    });
+
     it('should throw due to long alias on through table', async function () {
       const options = { ...this.sequelize.options, minifyAliases: false };
 
       await executeTest(options, async (db, predicate) => {
+        predicate.include[1].required = true;
         predicate.include[1].include = [
           {
             model: db.Sponsor,
             as: sponsorAlias,
+            required: true,
           },
         ];
         await expect(db.User.findOne(predicate)).to.eventually.be.rejected;
@@ -95,10 +227,12 @@ if (dialect.startsWith('postgres')) {
       const options = { ...this.sequelize.options, minifyAliases: true };
 
       await executeTest(options, async (db, predicate) => {
+        predicate.include[1].required = true;
         predicate.include[1].include = [
           {
             model: db.Sponsor,
             as: sponsorAlias,
+            required: true,
           },
         ];
         expect((await db.User.findOne(predicate))[teamAlias][0][sponsorAlias][0].name).to.equal(

--- a/packages/core/test/integration/dialects/postgres/query.test.js
+++ b/packages/core/test/integration/dialects/postgres/query.test.js
@@ -16,6 +16,7 @@ if (dialect.startsWith('postgres')) {
     const taskAlias = 'AnActualVeryLongAliasThatShouldBreakthePostgresLimitOfSixtyFourCharacters';
     const teamAlias = 'Toto';
     const sponsorAlias = 'AnotherVeryLongAliasThatShouldBreakthePostgresLimitOfSixtyFourCharacters';
+    const reservedAlias = '%0';
 
     const executeTest = async (options, test) => {
       const sequelize = Support.createSingleTestSequelizeInstance(options);
@@ -26,6 +27,7 @@ if (dialect.startsWith('postgres')) {
       const Task = sequelize.define('Task', { title: DataTypes.STRING });
 
       User.belongsTo(Task, { as: taskAlias, foreignKey: 'task_id' });
+      User.belongsTo(Task, { as: reservedAlias, foreignKey: 'task_id' });
       User.belongsToMany(Team, {
         as: teamAlias,
         foreignKey: 'teamId',
@@ -79,6 +81,19 @@ if (dialect.startsWith('postgres')) {
       });
     });
 
+    it('skips user-defined generated-style aliases', async function () {
+      const options = { ...this.sequelize.options, minifyAliases: true };
+
+      await executeTest(options, async (db, predicate) => {
+        const user = await db.User.findOne({
+          include: [predicate.include[0], { model: db.Task, as: reservedAlias }],
+        });
+
+        expect(user[taskAlias].title).to.equal('SuperTask');
+        expect(user[reservedAlias].title).to.equal('SuperTask');
+      });
+    });
+
     it('should quote minified include aliases when identifier quoting is disabled', async function () {
       const options = {
         ...this.sequelize.options,
@@ -87,6 +102,10 @@ if (dialect.startsWith('postgres')) {
       };
 
       await executeTest(options, async (db, predicate) => {
+        predicate.include[0].required = true;
+        predicate.include[0].on = { title: 'SuperTask' };
+        predicate.include[0].where = { title: 'SuperTask' };
+
         expect((await db.User.findOne(predicate))[taskAlias].title).to.equal('SuperTask');
       });
     });
@@ -123,6 +142,18 @@ if (dialect.startsWith('postgres')) {
 
         expect(users).to.have.length(1);
         expect(users[0][taskAlias].title).to.equal('SuperTask');
+      });
+    });
+
+    it('preserves wildcard columns for minified include aliases', async function () {
+      const options = { ...this.sequelize.options, minifyAliases: true };
+
+      await executeTest(options, async (db, predicate) => {
+        predicate.attributes = ['id'];
+        predicate.include = [{ ...predicate.include[0], attributes: [] }];
+        predicate.group = ['User.id', `${taskAlias}.*`];
+
+        expect(await db.User.findAll(predicate)).to.have.length(1);
       });
     });
 
@@ -167,8 +198,11 @@ if (dialect.startsWith('postgres')) {
       expect(result[longAlias].secondChild).to.exist;
     });
 
-    it('minifies nested include aliases in subquery filters', async () => {
-      const sequelize = Support.createSingleTestSequelizeInstance({ minifyAliases: true });
+    it('quotes minified aliases in nested subquery filters', async () => {
+      const sequelize = Support.createSingleTestSequelizeInstance({
+        minifyAliases: true,
+        quoteIdentifiers: false,
+      });
       const Root = sequelize.define('FilterRoot', {}, { timestamps: false });
       const Parent = sequelize.define('FilterParent', {}, { timestamps: false });
       const FirstChild = sequelize.define('FilterFirstChild', {}, { timestamps: false });
@@ -223,8 +257,12 @@ if (dialect.startsWith('postgres')) {
       });
     });
 
-    it('should be able to retrieve includes with nested through joins due to alias minifying', async function () {
-      const options = { ...this.sequelize.options, minifyAliases: true };
+    it('should quote minified aliases in nested through joins', async function () {
+      const options = {
+        ...this.sequelize.options,
+        minifyAliases: true,
+        quoteIdentifiers: false,
+      };
 
       await executeTest(options, async (db, predicate) => {
         predicate.include[1].required = true;
@@ -233,6 +271,8 @@ if (dialect.startsWith('postgres')) {
             model: db.Sponsor,
             as: sponsorAlias,
             required: true,
+            where: { name: 'Company' },
+            through: { where: { createdAt: { [Op.ne]: null } } },
           },
         ];
         expect((await db.User.findOne(predicate))[teamAlias][0][sponsorAlias][0].name).to.equal(

--- a/packages/core/test/integration/dialects/postgres/query.test.js
+++ b/packages/core/test/integration/dialects/postgres/query.test.js
@@ -10,7 +10,7 @@ const dialect = Support.getTestDialect();
 const { DatabaseError, DataTypes, Op, sql } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
-  describe('[POSTGRES] Query', () => {
+  describe(Support.getTestDialectTeaser('Query'), () => {
     Support.allowDeprecationsInSuite(['SEQUELIZE0023']);
 
     const taskAlias = 'AnActualVeryLongAliasThatShouldBreakthePostgresLimitOfSixtyFourCharacters';

--- a/packages/core/test/integration/model/findAll.test.js
+++ b/packages/core/test/integration/model/findAll.test.js
@@ -35,6 +35,29 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   });
 
   describe('findAll', () => {
+    it('restores minified aliases in included models', async function () {
+      const Task = this.sequelize.define(
+        'MinifiedAliasTask',
+        { title: DataTypes.STRING },
+        { timestamps: false },
+      );
+      const User = this.sequelize.define('MinifiedAliasUser', {}, { timestamps: false });
+
+      User.belongsTo(Task, { as: 'task', foreignKey: 'taskId' });
+
+      await Task.sync({ force: true });
+      await User.sync({ force: true });
+      const task = await Task.create({ title: 'task' });
+      await User.create({ taskId: task.id });
+
+      const [user] = await User.findAll({
+        include: [{ association: User.associations.task }],
+        minifyAliases: true,
+      });
+
+      expect(user.task.title).to.equal('task');
+    });
+
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.createSingleTransactionalTestSequelizeInstance(

--- a/packages/core/test/unit/dialects/abstract/query.test.js
+++ b/packages/core/test/unit/dialects/abstract/query.test.js
@@ -501,6 +501,20 @@ describe('[ABSTRACT]', () => {
       ]);
     });
 
+    it('restores magic property names without changing the row prototype', () => {
+      const value = { injected: true };
+      const query = new Query({}, current, {
+        aliasesMapping: new Map([['_0', '__proto__']]),
+        raw: true,
+      });
+
+      const [row] = query.handleSelectQuery([{ _0: value }]);
+
+      expect(Object.getPrototypeOf(row)).to.equal(Object.prototype);
+      expect(Object.hasOwn(row, '__proto__')).to.be.true;
+      expect(Object.getOwnPropertyDescriptor(row, '__proto__').value).to.equal(value);
+    });
+
     it('restores minified aliases before grouping joined results', () => {
       const User = current.define('AliasMappingUser', {}, { timestamps: false });
       const Task = current.define(

--- a/packages/core/test/unit/dialects/abstract/query.test.js
+++ b/packages/core/test/unit/dialects/abstract/query.test.js
@@ -486,6 +486,50 @@ describe('[ABSTRACT]', () => {
     });
   });
 
+  describe('handleSelectQuery', () => {
+    it('restores minified aliases in raw results', () => {
+      const query = new Query({}, current, {
+        aliasesMapping: new Map([
+          ['_0', 'tasks.id'],
+          ['_1', 'tasks.title'],
+        ]),
+        raw: true,
+      });
+
+      expect(query.handleSelectQuery([{ _0: 1, _1: 'task', untouched: true }])).to.deep.equal([
+        { 'tasks.id': 1, 'tasks.title': 'task', untouched: true },
+      ]);
+    });
+
+    it('restores minified aliases before grouping joined results', () => {
+      const User = current.define('AliasMappingUser', {}, { timestamps: false });
+      const Task = current.define(
+        'AliasMappingTask',
+        { title: DataTypes.STRING },
+        { timestamps: false },
+      );
+      const tasks = User.hasMany(Task, { as: 'tasks', foreignKey: 'userId' });
+      const include = { association: tasks, as: 'tasks', model: Task };
+      const query = new Query({}, current, {
+        aliasesMapping: new Map([
+          ['_0', 'tasks.id'],
+          ['_1', 'tasks.title'],
+        ]),
+        hasJoin: true,
+        hasMultiAssociation: true,
+        include: [include],
+        includeMap: { tasks: include },
+        includeNames: ['tasks'],
+        model: User,
+      });
+
+      const [user] = query.handleSelectQuery([{ id: 1, _0: 2, _1: 'task' }]);
+
+      expect(user.tasks).to.have.length(1);
+      expect(user.tasks[0].get({ plain: true })).to.include({ id: 2, title: 'task' });
+    });
+  });
+
   describe('_logQuery', () => {
     beforeEach(function () {
       this.cls = class MyQuery extends Query {};

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -16,6 +16,20 @@ if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] QueryGenerator', () => {
     Support.allowDeprecationsInSuite(['SEQUELIZE0023']);
 
+    describe('getMinifiedTableAlias()', () => {
+      it('measures aliases in UTF-8 bytes', function () {
+        const internals = new QueryGenerator(this.sequelize.dialect).__TEST__getInternals();
+        const options = { minifyAliases: true };
+        const aliasWithinLimit = 'é'.repeat(31);
+        const aliasOverLimit = 'é'.repeat(32);
+
+        expect(internals.getMinifiedTableAlias(aliasWithinLimit, options)).to.equal(
+          aliasWithinLimit,
+        );
+        expect(internals.getMinifiedTableAlias(aliasOverLimit, options)).to.equal('%0');
+      });
+    });
+
     const suites = {
       attributesToSQL: [
         {

--- a/packages/core/test/unit/query-generator/select-query.test.ts
+++ b/packages/core/test/unit/query-generator/select-query.test.ts
@@ -2268,7 +2268,6 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         Project.table,
         {
           model: Project,
-          attributes: ['id'],
           include: _validateIncludedElements({
             model: Project,
             include: [{ association: Project.associations[as], attributes: [] }],

--- a/packages/core/test/unit/query-generator/select-query.test.ts
+++ b/packages/core/test/unit/query-generator/select-query.test.ts
@@ -2254,6 +2254,32 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
   });
 
   describe('minifyAliases', () => {
+    const { maxTableAliasLength } = sequelize.dialect.supports;
+
+    function selectWithAliasOfLength(length: number): string {
+      const localSequelize = createSequelizeInstance({ minifyAliases: true });
+      const Project = localSequelize.define('Project', {}, { timestamps: false });
+      const User = localSequelize.define('User', { age: DataTypes.INTEGER }, { timestamps: false });
+      const as = 'a'.repeat(length);
+
+      Project.hasMany(User, { as, foreignKey: 'projectId' });
+
+      return localSequelize.queryGenerator.selectQuery(
+        Project.table,
+        {
+          model: Project,
+          attributes: ['id'],
+          include: _validateIncludedElements({
+            model: Project,
+            include: [{ association: Project.associations[as], attributes: [] }],
+          }).include,
+          order: [[Project.associations[as], 'age', 'ASC']],
+          minifyAliases: true,
+        },
+        Project,
+      );
+    }
+
     it('minifies custom attributes', () => {
       const { User } = vars;
 
@@ -2274,6 +2300,29 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         oracle: `SELECT 1 AS "_0" FROM "Users" "User" GROUP BY "_0" ORDER BY "_0";`,
       });
     });
+
+    if (maxTableAliasLength < Number.MAX_SAFE_INTEGER) {
+      it('does not minify a table alias at the dialect limit', () => {
+        const sql = selectWithAliasOfLength(maxTableAliasLength);
+
+        expect(sql).to.include('a'.repeat(maxTableAliasLength));
+        expect(sql).to.not.include('%0');
+      });
+
+      it('minifies a table alias one character over the dialect limit', () => {
+        const sql = selectWithAliasOfLength(maxTableAliasLength + 1);
+
+        expect(sql).to.not.include('a'.repeat(maxTableAliasLength + 1));
+        expect(sql).to.include('%0');
+      });
+    } else {
+      it('never minifies table aliases when the dialect has no limit', () => {
+        const sql = selectWithAliasOfLength(1000);
+
+        expect(sql).to.include('a'.repeat(1000));
+        expect(sql).to.not.include('%0');
+      });
+    }
   });
 
   describe('optimizer hints', () => {

--- a/packages/db2/src/dialect.ts
+++ b/packages/db2/src/dialect.ts
@@ -38,7 +38,7 @@ const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<Db2ConnectionOptions>({
 
 export class Db2Dialect extends AbstractDialect<Db2DialectOptions, Db2ConnectionOptions> {
   static readonly supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 128,
+    maxTableAliasLength: 128,
     migrations: false,
     schemas: true,
     finalTable: true,

--- a/packages/db2/src/dialect.ts
+++ b/packages/db2/src/dialect.ts
@@ -38,6 +38,7 @@ const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<Db2ConnectionOptions>({
 
 export class Db2Dialect extends AbstractDialect<Db2DialectOptions, Db2ConnectionOptions> {
   static readonly supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 128,
     migrations: false,
     schemas: true,
     finalTable: true,

--- a/packages/ibmi/src/dialect.ts
+++ b/packages/ibmi/src/dialect.ts
@@ -37,7 +37,7 @@ const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<IBMiConnectionOptions>({
 
 export class IBMiDialect extends AbstractDialect<IbmiDialectOptions, IBMiConnectionOptions> {
   static readonly supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 128,
+    maxTableAliasLength: 128,
     'VALUES ()': true,
     'ON DUPLICATE KEY': false,
     connectionTransactionMethods: true,

--- a/packages/ibmi/src/dialect.ts
+++ b/packages/ibmi/src/dialect.ts
@@ -37,6 +37,7 @@ const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<IBMiConnectionOptions>({
 
 export class IBMiDialect extends AbstractDialect<IbmiDialectOptions, IBMiConnectionOptions> {
   static readonly supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 128,
     'VALUES ()': true,
     'ON DUPLICATE KEY': false,
     connectionTransactionMethods: true,

--- a/packages/mariadb/src/dialect.ts
+++ b/packages/mariadb/src/dialect.ts
@@ -53,6 +53,7 @@ export class MariaDbDialect extends AbstractDialect<
   MariaDbConnectionOptions
 > {
   static supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 64,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: true,

--- a/packages/mariadb/src/dialect.ts
+++ b/packages/mariadb/src/dialect.ts
@@ -53,7 +53,7 @@ export class MariaDbDialect extends AbstractDialect<
   MariaDbConnectionOptions
 > {
   static supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 64,
+    maxTableAliasLength: 256,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: true,

--- a/packages/mssql/src/dialect.ts
+++ b/packages/mssql/src/dialect.ts
@@ -37,7 +37,7 @@ const DIALECT_OPTION_NAMES = getSynchronizedTypeKeys<MsSqlDialectOptions>({
 
 export class MsSqlDialect extends AbstractDialect<MsSqlDialectOptions, MsSqlConnectionOptions> {
   static supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 128,
+    maxTableAliasLength: 128,
     'DEFAULT VALUES': true,
     'LIMIT ON UPDATE': true,
     migrations: false,

--- a/packages/mssql/src/dialect.ts
+++ b/packages/mssql/src/dialect.ts
@@ -37,6 +37,7 @@ const DIALECT_OPTION_NAMES = getSynchronizedTypeKeys<MsSqlDialectOptions>({
 
 export class MsSqlDialect extends AbstractDialect<MsSqlDialectOptions, MsSqlConnectionOptions> {
   static supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 128,
     'DEFAULT VALUES': true,
     'LIMIT ON UPDATE': true,
     migrations: false,

--- a/packages/mysql/src/dialect.ts
+++ b/packages/mysql/src/dialect.ts
@@ -50,7 +50,7 @@ const numericOptions: SupportableNumericOptions = {
 
 export class MySqlDialect extends AbstractDialect<MySqlDialectOptions, MySqlConnectionOptions> {
   static supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 64,
+    maxTableAliasLength: 256,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: true,

--- a/packages/mysql/src/dialect.ts
+++ b/packages/mysql/src/dialect.ts
@@ -50,6 +50,7 @@ const numericOptions: SupportableNumericOptions = {
 
 export class MySqlDialect extends AbstractDialect<MySqlDialectOptions, MySqlConnectionOptions> {
   static supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 64,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: true,

--- a/packages/oracle/src/dialect.ts
+++ b/packages/oracle/src/dialect.ts
@@ -22,7 +22,7 @@ const numericOptions: SupportableNumericOptions = {
 
 export class OracleDialect extends AbstractDialect<OracleDialectOptions, OracleConnectionOptions> {
   static readonly supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 128,
+    maxTableAliasLength: 128,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: false,

--- a/packages/oracle/src/dialect.ts
+++ b/packages/oracle/src/dialect.ts
@@ -22,6 +22,7 @@ const numericOptions: SupportableNumericOptions = {
 
 export class OracleDialect extends AbstractDialect<OracleDialectOptions, OracleConnectionOptions> {
   static readonly supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 128,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: false,

--- a/packages/oracle/src/query.js
+++ b/packages/oracle/src/query.js
@@ -16,7 +16,6 @@ import isPlainObject from 'lodash/isPlainObject';
 import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
 import reduce from 'lodash/reduce';
-import toPairs from 'lodash/toPairs';
 import oracledb from 'oracledb';
 
 const debug = logger.debugContext('sql:oracle');
@@ -368,26 +367,6 @@ export class OracleQuery extends AbstractQuery {
       if (this.model) {
         const modelDefinition = this.model.modelDefinition;
         this._getAttributeMap(attrsMap, modelDefinition.rawAttributes);
-      }
-
-      // If aliasesmapping exists we update the attribute map
-      if (this.options.aliasesMapping) {
-        const obj = Object.fromEntries(this.options.aliasesMapping);
-        rows = rows.map(row =>
-          toPairs(row).reduce((acc, [key, value]) => {
-            const mapping = Object.values(obj).find(element => {
-              const catalogElement =
-                this.sequelize.queryInterface.queryGenerator.getCatalogName(element);
-
-              return catalogElement === key;
-            });
-            if (mapping) {
-              acc[mapping || key] = value;
-            }
-
-            return acc;
-          }, {}),
-        );
       }
 
       // Modify the keys into the format that sequelize expects

--- a/packages/postgres/src/dialect.ts
+++ b/packages/postgres/src/dialect.ts
@@ -72,6 +72,7 @@ export class PostgresDialect extends AbstractDialect<
   PostgresConnectionOptions
 > {
   static readonly supports: DialectSupports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 63,
     'DEFAULT VALUES': true,
     EXCEPTION: true,
     'ON DUPLICATE KEY': false,

--- a/packages/postgres/src/dialect.ts
+++ b/packages/postgres/src/dialect.ts
@@ -72,7 +72,7 @@ export class PostgresDialect extends AbstractDialect<
   PostgresConnectionOptions
 > {
   static readonly supports: DialectSupports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 63,
+    maxTableAliasLength: 63,
     'DEFAULT VALUES': true,
     EXCEPTION: true,
     'ON DUPLICATE KEY': false,

--- a/packages/postgres/src/query.js
+++ b/packages/postgres/src/query.js
@@ -13,32 +13,20 @@ import {
 } from '@sequelize/core';
 import { logger } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/logger.js';
 import { pojo } from '@sequelize/utils';
-import escapeRegExp from 'lodash/escapeRegExp';
 import forOwn from 'lodash/forOwn';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import mapKeys from 'lodash/mapKeys';
-import toPairs from 'lodash/toPairs';
 import zipObject from 'lodash/zipObject';
 
 const debug = logger.debugContext('sql:pg');
 
 export class PostgresQuery extends AbstractQuery {
-  async run(sql, parameters, options) {
+  async run(sql, parameters) {
     const { connection } = this;
 
     if (!isEmpty(this.options.searchPath)) {
       sql = this.sequelize.queryGenerator.setSearchPath(this.options.searchPath) + sql;
-    }
-
-    if (options?.minifyAliases && this.options.includeAliases) {
-      for (const [alias, original] of toPairs(this.options.includeAliases)
-        // Sorting to replace the longest aliases first to prevent alias collision
-        .sort((a, b) => b[1].length - a[1].length)) {
-        const reg = new RegExp(escapeRegExp(original), 'g');
-
-        sql = sql.replace(reg, alias);
-      }
     }
 
     this.sql = sql;
@@ -81,7 +69,7 @@ export class PostgresQuery extends AbstractQuery {
 
     complete();
 
-    let rows = Array.isArray(queryResult)
+    const rows = Array.isArray(queryResult)
       ? queryResult.reduce((allRows, r) => allRows.concat(r.rows || []), [])
       : queryResult.rows;
     const rowCount = Array.isArray(queryResult)
@@ -90,17 +78,6 @@ export class PostgresQuery extends AbstractQuery {
           0,
         )
       : queryResult.rowCount || 0;
-
-    if (options?.minifyAliases && this.options.aliasesMapping) {
-      rows = rows.map(row =>
-        toPairs(row).reduce((acc, [key, value]) => {
-          const mapping = this.options.aliasesMapping.get(key);
-          acc[mapping || key] = value;
-
-          return acc;
-        }, {}),
-      );
-    }
 
     const isTableNameQuery = sql.startsWith('SELECT table_name FROM information_schema.tables');
     const isRelNameQuery = sql.startsWith('SELECT relname FROM pg_class WHERE oid IN');

--- a/packages/snowflake/src/dialect.ts
+++ b/packages/snowflake/src/dialect.ts
@@ -101,6 +101,7 @@ export class SnowflakeDialect extends AbstractDialect<
   SnowflakeConnectionOptions
 > {
   static supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: 255,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: true,

--- a/packages/snowflake/src/dialect.ts
+++ b/packages/snowflake/src/dialect.ts
@@ -101,7 +101,7 @@ export class SnowflakeDialect extends AbstractDialect<
   SnowflakeConnectionOptions
 > {
   static supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: 255,
+    maxTableAliasLength: 255,
     'VALUES ()': true,
     'LIMIT ON UPDATE': true,
     lock: true,

--- a/packages/sqlite3/src/dialect.ts
+++ b/packages/sqlite3/src/dialect.ts
@@ -41,7 +41,6 @@ const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<SqliteConnectionOptions>
 
 export class SqliteDialect extends AbstractDialect<SqliteDialectOptions, SqliteConnectionOptions> {
   static supports = AbstractDialect.extendSupport({
-    maxTableAliasLength: Number.POSITIVE_INFINITY,
     DEFAULT: false,
     'DEFAULT VALUES': true,
     'UNION ALL': false,

--- a/packages/sqlite3/src/dialect.ts
+++ b/packages/sqlite3/src/dialect.ts
@@ -41,7 +41,7 @@ const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<SqliteConnectionOptions>
 
 export class SqliteDialect extends AbstractDialect<SqliteDialectOptions, SqliteConnectionOptions> {
   static supports = AbstractDialect.extendSupport({
-    maxIdentifierLength: Number.POSITIVE_INFINITY,
+    maxTableAliasLength: Number.POSITIVE_INFINITY,
     DEFAULT: false,
     'DEFAULT VALUES': true,
     'UNION ALL': false,

--- a/packages/sqlite3/src/dialect.ts
+++ b/packages/sqlite3/src/dialect.ts
@@ -41,6 +41,7 @@ const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<SqliteConnectionOptions>
 
 export class SqliteDialect extends AbstractDialect<SqliteDialectOptions, SqliteConnectionOptions> {
   static supports = AbstractDialect.extendSupport({
+    maxIdentifierLength: Number.POSITIVE_INFINITY,
     DEFAULT: false,
     'DEFAULT VALUES': true,
     'UNION ALL': false,


### PR DESCRIPTION
## Pull Request Checklist


- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ x Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

With sufficently long aliases, you can still come up with places wehre tables names are also too long in included tables as well. This just fixes that

## List of Breaking Changes

No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL alias handling across joins, nested queries, grouped limits, filters, and quoted identifiers.
  - Restored original column and association names in query results when alias minimization is enabled.
  - Improved support for aliases that overlap with table names or use special characters.

- **Improvements**
  - Added dialect-specific maximum identifier length support for more accurate alias generation.
  - Enhanced quoting of table and association aliases across supported databases.

- **Tests**
  - Added coverage for aliasing, nested associations, grouped queries, quoted identifiers, and result restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->