### PR TITLE
fix: Core UUID Validation to Support Any Version

### DIFF
--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -6,6 +6,7 @@ import type {
   StrictRequiredBy,
 } from '@sequelize/utils';
 import type { SetRequired } from 'type-fest';
+import type { UUIDVersion } from 'validator';
 import type { AbstractConnection } from './abstract-dialect/connection-manager.js';
 import type { DataType, NormalizedDataType } from './abstract-dialect/data-types.js';
 import type { IndexField, IndexOptions, TableName } from './abstract-dialect/query-interface';
@@ -1625,9 +1626,9 @@ export interface ColumnValidateOptions {
   len?: readonly [number, number] | { msg: string; args: readonly [number, number] };
 
   /**
-   * only allow uuids
+   * only allow UUIDs of a specific version
    */
-  isUUID?: number | { msg: string; args: number };
+  isUUID?: UUIDVersion | { msg: string; args: UUIDVersion };
 
   /**
    * only allow date strings

--- a/packages/core/test/types/validators.ts
+++ b/packages/core/test/types/validators.ts
@@ -4,7 +4,7 @@ import { MySqlDialect } from '@sequelize/mysql';
 const sequelize = new Sequelize({ dialect: MySqlDialect });
 
 /**
- * Test for isIn/notIn validation - should accept any[]
+ * Tests for isIn/notIn and isUUID validation types.
  */
 class ValidatedUser extends Model {}
 
@@ -20,6 +20,18 @@ ValidatedUser.init(
       type: DataTypes.STRING,
       validate: {
         notIn: [['second', 2, null]],
+      },
+    },
+    uuid: {
+      type: DataTypes.UUID,
+      validate: {
+        isUUID: 'all',
+      },
+    },
+    uuidWithMessage: {
+      type: DataTypes.UUID,
+      validate: {
+        isUUID: { msg: 'must be a UUID', args: 'all' },
       },
     },
   },


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] A documentation update is not necessary.
- [x] Did you update the TypeScript typings accordingly?
- [x] Fixes #18171
- [x] Does the name of your PR follow our conventions?

## Description of Changes

Fixes the public `isUUID` validator configuration type by reusing `validator`'s `UUIDVersion` contract. `"all"` now type-checks both directly and in custom validation-message arguments.

## List of Breaking Changes

None.

## Related Links

Fixes https://github.com/sequelize/sequelize/issues/18171

## Context

`ColumnValidateOptions.isUUID` passes its version value directly to `validator`. The validator dependency owns the supported version vocabulary, so its exported type is the single source of truth.

## Implementation

Uses `UUIDVersion` for both accepted configuration forms and adds a compiler fixture for direct and custom-message `"all"` values. No new abstraction or runtime behavior.

## Screenshots

N/A — Type-only change.

## Testing Instructions

1. Run `node .yarn/releases/yarn-4.13.0.cjs build`.
2. From `packages/core`, run `node ../../node_modules/typescript/bin/tsc -b test/tsconfig.json`.

## Review and QA Status

PASS — Self-review found the change confined to the public validator configuration boundary and its compiler fixture. Workspace build, focused core type fixtures, Prettier, and ESLint passed.

## Learner Coverage

Learner coverage: no action — this manually reported type mismatch has no repeatable OMP Learner signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * UUID validation options now support named UUID versions, including the default “all” mode.
  * Custom UUID validation messages accept the same version-specific options.
* **Tests**
  * Expanded validation coverage for UUID checks, including default behavior and custom error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->