### PR TITLE
fix(core): make empty Op.in compose correctly under Op.not

### DIFF
--- a/packages/core/src/abstract-dialect/where-sql-builder.ts
+++ b/packages/core/src/abstract-dialect/where-sql-builder.ts
@@ -373,10 +373,10 @@ export class WhereSqlBuilder {
           return '1 = 1';
         }
 
-        rightSql = '(NULL)';
-      } else {
-        rightSql = this.#queryGenerator.escapeList(right, rightEscapeOptions);
+        return '0 = 1';
       }
+
+      rightSql = this.#queryGenerator.escapeList(right, rightEscapeOptions);
     } else {
       throw new TypeError(
         'Operators Op.in and Op.notIn must be called with an array of values, or a literal',

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -1631,7 +1631,28 @@ Caused by: "undefined" cannot be escaped`),
       testSql(
         { intAttr1: { [Op.in]: [] } },
         {
-          default: '[intAttr1] IN (NULL)',
+          default: '0 = 1',
+        },
+      );
+
+      testSql(
+        { [Op.or]: [{ intAttr1: { [Op.in]: [] } }, { intAttr2: 5 }] },
+        {
+          default: '0 = 1 OR [intAttr2] = 5',
+        },
+      );
+
+      testSql(
+        { [Op.not]: { intAttr1: { [Op.in]: [] } } },
+        {
+          default: 'NOT (0 = 1)',
+        },
+      );
+
+      testSql(
+        { [Op.and]: [{ intAttr1: { [Op.in]: [] } }, { intAttr2: 5 }] },
+        {
+          default: '0 = 1 AND [intAttr2] = 5',
         },
       );
     });


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Not needed: no documented behavior changes -->
- [ ] Did you update the typescript typings accordingly (if applicable)? <!-- Not applicable -->
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Closes #18306

An empty `Op.in` was emitted as `IN (NULL)`, which SQL evaluates to UNKNOWN rather than FALSE. At the top level of a `WHERE` that is indistinguishable from FALSE, so the bare case looked fine, but `NOT (UNKNOWN)` is still UNKNOWN, so `{ [Op.not]: { num: { [Op.in]: [] } } }` matched no rows when it should match every row. That shape is reachable without naming the operator, since an array value is inferred as `Op.in`.

The empty `Op.in` fragment is now `0 = 1`, mirroring the `1 = 1` that #18250 introduced for empty `Op.notIn`, so negation behaves as expected. The `Op.or` / `Op.not` / `Op.and` composition cases already covered for `Op.notIn` are now covered for `Op.in` as well.

Note: the emitted SQL for a bare `{ [Op.in]: [] }` changes from `IN (NULL)` to `0 = 1`. The two are equivalent inside a top-level `WHERE`, but code asserting on the exact generated SQL will see a difference.

One design note, since #18286 proposes throwing on an empty `Op.or` / `Op.not` rather than emitting a truth value: I went with the literal here because an empty `Op.in` has one unambiguous meaning, because #18250 settled the sibling `Op.notIn` case the same way, and because throwing would break the existing and widely relied on behaviour of `{ [Op.in]: [] }` matching no rows. Happy to switch to a throw if you prefer that direction.

## List of Breaking Changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queries using an empty `IN` condition to correctly return no matches instead of relying on SQL `NULL` behavior.
  * Ensured empty `IN` conditions work correctly when combined with `OR`, `AND`, and `NOT` filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->