### PR TITLE
ci: pin pg-native to 3.7.0 for Node 10 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn global add node-gyp --ignore-engines
       - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn add pg-native --ignore-engines
+      - run: yarn add pg-native@3.7.0 --ignore-engines
         if: matrix.native
       - name: Unit Tests
         run: yarn test-unit


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions? <!-- Not applicable: workflow-only change, the CI run on this PR is the proof -->
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Not needed: no documented behavior changes -->
- [x] Did you update the typescript typings accordingly (if applicable)? <!-- Not applicable -->
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

The `native` legs of `test-postgres` install `pg-native` unpinned, so they now pull 3.8.0+, which uses `??` in `Client.prototype.getTransactionStatus`. Node 10 cannot parse that, `require('pg-native')` throws at module load, and the four Node 10 native jobs end up running no tests at all.

3.7.0 is the last release Node 10 can read, and `pg` 8.11.0 (the version the lockfile pins) never calls `getTransactionStatus`, so pinning it costs nothing here.

Closes #18312

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->

None.
