### PR TITLE
ci: pin pg-native so the Node 10 postgres-native legs parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn global add node-gyp --ignore-engines
       - run: yarn install --frozen-lockfile --ignore-engines
-      - run: yarn add pg-native --ignore-engines
+      # pg-native 3.8.0 and later use nullish coalescing, which Node 10 cannot
+      # parse, so the module throws at load time. Pin it while the matrix still
+      # covers Node 10. See #18312.
+      - run: yarn add pg-native@3.7.0 --ignore-engines
         if: matrix.native
       - name: Unit Tests
         run: yarn test-unit


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions? Not applicable. This changes a workflow step only.
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? CI on this pull request is the test.
- [x] Is a documentation update included? Not applicable.
- [x] Did you update the typescript typings accordingly? Not applicable.
- [x] Does the description below contain a link to an existing issue? Closes #18312.
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md? Yes.

### Description Of Change

Closes #18312.

The workflow installs `pg-native` unpinned, after the lockfile install, so CI always takes
the newest release:

```yaml
- run: yarn install --frozen-lockfile --ignore-engines
- run: yarn add pg-native --ignore-engines
  if: matrix.native
```

`pg-native` 3.8.0 added nullish coalescing, which Node 10 cannot parse, so the module throws
at load time before mocha runs a single test. That takes out four legs of the `test-postgres`
matrix on every pull request against `v6`:

```
node_modules/pg-native/index.js:153
  return statusMap[this.pq.transactionStatus()] ?? null
                                               ^
SyntaxError: Unexpected token ?
```

This pins the version. The Node 10 legs are the reason a pin is needed, and I pinned all
`native` legs rather than only the Node 10 ones, so the matrix stays uniform and no leg
depends on whatever npm publishes next.

### Verification

Under `node:10-alpine`, Node v10.24.1, `node --check` on every `.js` file in each package:

| Version | Result |
| -- | -- |
| `pg-native@3.7.0` | 3 files, all parse |
| `pg-native@3.8.0` | `SyntaxError: Unexpected token ?` |
| `pg-native@3.9.0` | `SyntaxError: Unexpected token ?` |
| `libpq@1.11.0`, the version 3.7.0 resolves | parses |

`pg-native` pins `pg-types` to an exact version, and `libpq` above is the resolved
transitive, so 3.7.0 is enough on its own. The native build itself was never the problem:
the Node 10 legs today get through install and fail at test time.

I could not run the native suite locally, because `libpq` needs headers this machine does not
have. CI on this pull request covers that.

### Alternative I did not take

Adding `pg-native` to `devDependencies` would let `--frozen-lockfile` govern it and end this
class of failure for good. I left it alone, because every leg and every contributor would
then build `libpq` from source, and only the four `native` legs need it.
