### PR TITLE
fix: compose empty and null-bearing operand sets correctly

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator-typescript.ts
+++ b/packages/core/src/abstract-dialect/query-generator-typescript.ts
@@ -51,6 +51,7 @@ import type {
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   QuoteTableOptions,
+  RejectAlwaysTrueWhereOption,
   RemoveColumnQueryOptions,
   RemoveConstraintQueryOptions,
   RemoveIndexQueryOptions,
@@ -63,7 +64,12 @@ import type {
 import type { TableNameWithSchema } from './query-interface.js';
 import type { WhereOptions } from './where-sql-builder-types.js';
 import type { WhereSqlBuilder } from './where-sql-builder.js';
-import { PojoWhere } from './where-sql-builder.js';
+import {
+  ALWAYS_TRUE,
+  PojoWhere,
+  buildAlwaysTrueWhereError,
+  renderWhereFragment,
+} from './where-sql-builder.js';
 
 export const CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>([
   'charset',
@@ -130,7 +136,10 @@ export interface EscapeOptions extends FormatWhereOptions {
   readonly type?: DataType | undefined;
 }
 
-export interface FormatWhereOptions extends Partial<BindParamOptions>, ParameterOptions {
+export interface FormatWhereOptions
+  extends Partial<BindParamOptions>,
+    ParameterOptions,
+    RejectAlwaysTrueWhereOption {
   /**
    * The model of the main alias. Used to determine the type & column name of attributes referenced in the where clause.
    */
@@ -717,12 +726,38 @@ export class AbstractQueryGeneratorTypeScript<Dialect extends AbstractDialect = 
   }
 
   whereQuery<M extends Model>(where: WhereOptions<Attributes<M>>, options?: FormatWhereOptions) {
-    const query = this.whereItemsQuery(where, options);
-    if (query && query.length > 0) {
+    const fragment = this.#whereGenerator.formatWhereOptionsFragment(where, options);
+
+    if (options?.rejectAlwaysTrueWhere && fragment === ALWAYS_TRUE) {
+      throw buildAlwaysTrueWhereError(options.rejectAlwaysTrueWhere);
+    }
+
+    const query = renderWhereFragment(fragment);
+    if (query.length > 0) {
       return `WHERE ${query}`;
     }
 
     return '';
+  }
+
+  /**
+   * Throws if `where` on its own imposes no restriction, i.e. Sequelize derived it to be true for
+   * every row. Called by the model methods that modify rows, before a scope or a paranoid clause
+   * is merged in, so that the judgement is about what the caller asked for rather than about the
+   * statement Sequelize ends up building.
+   *
+   * @param where
+   * @param statement the SQL statement being built, used in the error message
+   * @param options
+   */
+  assertNotAlwaysTrueWhere<M extends Model>(
+    where: WhereOptions<Attributes<M>>,
+    statement: 'DELETE' | 'UPDATE',
+    options?: FormatWhereOptions,
+  ): void {
+    if (this.#whereGenerator.formatWhereOptionsFragment(where, options) === ALWAYS_TRUE) {
+      throw buildAlwaysTrueWhereError(statement);
+    }
   }
 
   whereItemsQuery<M extends Model>(

--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -17,7 +17,11 @@ import type {
   ParameterOptions,
 } from './query-generator-typescript.js';
 import type { AttributeToSqlOptions } from './query-generator.internal-types.js';
-import type { BoundQuery, TableOrModel } from './query-generator.types.js';
+import type {
+  BoundQuery,
+  RejectAlwaysTrueWhereOption,
+  TableOrModel,
+} from './query-generator.types.js';
 import type { TableName } from './query-interface.js';
 import type { ColumnsDescription } from './query-interface.types.js';
 import type { WhereOptions } from './where-sql-builder-types.js';
@@ -43,11 +47,12 @@ type BulkInsertOptions = ParameterOptions & {
   returning?: boolean | Array<string | Literal | Col>;
 };
 
-type UpdateOptions = ParameterOptions;
+type UpdateOptions = ParameterOptions & RejectAlwaysTrueWhereOption;
 
-type ArithmeticQueryOptions = ParameterOptions & {
-  returning?: boolean | Array<string | Literal | Col>;
-};
+type ArithmeticQueryOptions = ParameterOptions &
+  RejectAlwaysTrueWhereOption & {
+    returning?: boolean | Array<string | Literal | Col>;
+  };
 
 // keep CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
 export interface CreateTableQueryOptions {

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -35,7 +35,7 @@ import { nameIndex, spliceStr } from '../utils/string';
 import { attributeTypeToSql } from './data-types-utils';
 import { AbstractQueryGeneratorInternal } from './query-generator-internal.js';
 import { AbstractQueryGeneratorTypeScript } from './query-generator-typescript';
-import { joinWithLogicalOperator } from './where-sql-builder';
+import { joinWithLogicalOperator, renderWhereFragment } from './where-sql-builder';
 
 export const CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set([
   'collate',
@@ -603,7 +603,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
     // TODO: add attribute DataType
     // TODO: add model
-    const escapeOptions = pick(options, ['replacements', 'model']);
+    const escapeOptions = pick(options, ['replacements', 'model', 'rejectAlwaysTrueWhere']);
 
     extraAttributesToBeUpdated = removeNullishValuesFromHash(
       extraAttributesToBeUpdated,
@@ -2194,7 +2194,9 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         reservedTableAliases: topLevelInfo.options.reservedTableAliases,
       });
       if (joinWhere) {
-        joinOn = joinWithLogicalOperator([joinOn, joinWhere], include.or ? Op.or : Op.and);
+        joinOn = renderWhereFragment(
+          joinWithLogicalOperator([joinOn, joinWhere], include.or ? Op.or : Op.and),
+        );
       }
     }
 
@@ -2485,7 +2487,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     // Generate a wrapped join so that the through table join can be dependent on the target join
     joinBody = `( ${this.quoteTable(throughTable, { ...topLevelInfo.options, ...include, alias: minifiedThroughAs })} INNER JOIN ${this.quoteTable(include.model.table, { ...topLevelInfo.options, ...include, alias: minifiedIncludeAs })} ON ${targetJoinOn}`;
     if (throughWhere) {
-      joinBody += ` AND ${throughWhere}`;
+      joinBody += ` AND (${throughWhere})`;
     }
 
     joinBody += ')';
@@ -2498,7 +2500,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         mainAlias: minifiedIncludeAs,
       });
       if (targetWhere) {
-        joinCondition += ` AND ${targetWhere}`;
+        joinCondition += ` AND (${targetWhere})`;
       }
     }
 

--- a/packages/core/src/abstract-dialect/query-generator.types.ts
+++ b/packages/core/src/abstract-dialect/query-generator.types.ts
@@ -186,9 +186,23 @@ export interface QuoteTableOptions extends IndexHintable {
   tableHints?: TableHints[] | undefined;
 }
 
+export interface RejectAlwaysTrueWhereOption {
+  /**
+   * Set by the query interface methods that modify rows. When set, a `where` that Sequelize
+   * derived to be true for every row is rejected rather than compiled, because that is almost
+   * always a list that turned out to be empty rather than an intent to rewrite the whole table.
+   * The value is the SQL keyword used in the error message.
+   *
+   * A condition the caller wrote to be true for every row (sql`1 = 1`) is a plain SQL fragment
+   * rather than a derived truth value, so it is still accepted, as is an empty `where`.
+   */
+  readonly rejectAlwaysTrueWhere?: 'DELETE' | 'UPDATE' | undefined;
+}
+
 export interface BulkDeleteQueryOptions<TAttributes = any>
   extends AddLimitOffsetOptions,
-    Filterable<TAttributes> {}
+    Filterable<TAttributes>,
+    RejectAlwaysTrueWhereOption {}
 
 // keep REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
 export interface RemoveIndexQueryOptions {

--- a/packages/core/src/abstract-dialect/query-interface-typescript.ts
+++ b/packages/core/src/abstract-dialect/query-interface-typescript.ts
@@ -950,7 +950,10 @@ export class AbstractQueryInterfaceTypeScript<Dialect extends AbstractDialect = 
    */
   async bulkDelete(tableOrModel: TableOrModel, options?: QiBulkDeleteOptions): Promise<number> {
     const bulkDeleteOptions = { ...options };
-    const sql = this.queryGenerator.bulkDeleteQuery(tableOrModel, bulkDeleteOptions);
+    const sql = this.queryGenerator.bulkDeleteQuery(tableOrModel, {
+      ...bulkDeleteOptions,
+      rejectAlwaysTrueWhere: 'DELETE',
+    });
     // unlike bind, replacements are handled by QueryGenerator, not QueryRaw
     delete bulkDeleteOptions.replacements;
 

--- a/packages/core/src/abstract-dialect/query-interface.js
+++ b/packages/core/src/abstract-dialect/query-interface.js
@@ -545,6 +545,7 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
     }
 
     options = cloneDeep(options) ?? {};
+    options.rejectAlwaysTrueWhere = 'UPDATE';
     if (typeof where === 'object') {
       where = cloneDeep(where) ?? {};
     }
@@ -564,6 +565,9 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
     options.type = QueryTypes.BULKUPDATE;
     options.model = model;
     options.bind = combineBinds(options.bind, bind);
+
+    // like replacements, this is a query generation concern and has no meaning to QueryRaw
+    delete options.rejectAlwaysTrueWhere;
 
     return await this.sequelize.queryRaw(query, options);
   }
@@ -629,6 +633,7 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   ) {
     options = cloneDeep(options) ?? {};
     options.model = model;
+    options.rejectAlwaysTrueWhere = 'UPDATE';
 
     const sql = this.queryGenerator.arithmeticQuery(
       operator,
@@ -643,6 +648,7 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
 
     // unlike bind, replacements are handled by QueryGenerator, not QueryRaw
     delete options.replacements;
+    delete options.rejectAlwaysTrueWhere;
 
     return await this.sequelize.queryRaw(sql, options);
   }

--- a/packages/core/src/abstract-dialect/where-sql-builder-types.ts
+++ b/packages/core/src/abstract-dialect/where-sql-builder-types.ts
@@ -57,7 +57,7 @@ export type WhereAttributeHashValue<AttributeType> =
       // if the right-hand side is an array, it will be equal to Op.in
       // otherwise it will be equal to Op.eq
       // Exception: array attribtues always use Op.eq, never Op.in.
-      AttributeType extends any[]
+      [AttributeType] extends [any[]]
         ? WhereOperators<AttributeType>[typeof Op.eq] | WhereOperators<AttributeType>
         :
             | WhereOperators<AttributeType>[typeof Op.in]

--- a/packages/core/src/abstract-dialect/where-sql-builder.ts
+++ b/packages/core/src/abstract-dialect/where-sql-builder.ts
@@ -141,6 +141,21 @@ export class WhereSqlBuilder {
    * @param options
    */
   formatWhereOptions(where: WhereOptions, options: FormatWhereOptions = EMPTY_OBJECT): string {
+    return renderWhereFragment(this.formatWhereOptionsFragment(where, options));
+  }
+
+  /**
+   * Same as {@link formatWhereOptions}, but keeps a known truth value as a {@link WhereFragment}
+   * rather than rendering it to SQL. Use this when composing the result with AND / OR / NOT, or
+   * when it matters whether a condition was derived by Sequelize or written by the caller.
+   *
+   * @param where
+   * @param options
+   */
+  formatWhereOptionsFragment(
+    where: WhereOptions,
+    options: FormatWhereOptions = EMPTY_OBJECT,
+  ): WhereFragment {
     if (typeof where === 'string') {
       throw new TypeError(
         "Support for `{ where: 'raw query' }` has been removed. Use `{ where: literal('raw query') }` instead",
@@ -148,7 +163,7 @@ export class WhereSqlBuilder {
     }
 
     if (where === undefined) {
-      return '';
+      return NO_CONDITION;
     }
 
     try {
@@ -159,10 +174,14 @@ export class WhereSqlBuilder {
             return this.#queryGenerator.formatSqlExpression(piece, options);
           }
 
-          return this.formatPojoWhere(piece, options);
+          return this.formatPojoWhereFragment(piece, options);
         },
       );
     } catch (error) {
+      if (error instanceof AlwaysTrueWhereError) {
+        throw error;
+      }
+
       throw new BaseError(
         `Invalid value received for the "where" option. Refer to the sequelize documentation to learn which values the "where" option accepts.\nValue: ${NodeUtil.inspect(where)}`,
         {
@@ -183,15 +202,15 @@ export class WhereSqlBuilder {
    */
   #handleRecursiveNotOrAndWithImplicitAndArray<TAttributes>(
     input: WhereOptions<TAttributes>,
-    handlePart: (part: BaseSqlExpression | PojoWhere) => string,
+    handlePart: (part: BaseSqlExpression | PojoWhere) => WhereFragment,
     logicalOperator: typeof Op.and | typeof Op.or = Op.and,
-  ): string {
+  ): WhereFragment {
     // Arrays in this method are treated as an implicit "AND" operator
     if (Array.isArray(input)) {
       return joinWithLogicalOperator(
         input.map(part => {
           if (part === undefined) {
-            return '';
+            return NO_CONDITION;
           }
 
           return this.#handleRecursiveNotOrAndWithImplicitAndArray(part, handlePart);
@@ -268,6 +287,19 @@ export class WhereSqlBuilder {
    * @param options Option bag.
    */
   formatPojoWhere(pojoWhere: PojoWhere, options: FormatWhereOptions = EMPTY_OBJECT): string {
+    return renderWhereFragment(this.formatPojoWhereFragment(pojoWhere, options));
+  }
+
+  /**
+   * Same as {@link formatPojoWhere}, but keeps a known truth value instead of rendering it.
+   *
+   * @param pojoWhere The representation of the group.
+   * @param options Option bag.
+   */
+  formatPojoWhereFragment(
+    pojoWhere: PojoWhere,
+    options: FormatWhereOptions = EMPTY_OBJECT,
+  ): WhereFragment {
     const modelDefinition = options?.model ? extractModelDefinition(options.model) : null;
 
     // we need to parse the left operand early to determine the data type of the right operand
@@ -346,7 +378,7 @@ export class WhereSqlBuilder {
     );
   }
 
-  protected [Op.notIn](...args: Parameters<WhereSqlBuilder[typeof Op.in]>): string {
+  protected [Op.notIn](...args: Parameters<WhereSqlBuilder[typeof Op.in]>): WhereFragment {
     return this[Op.in](...args);
   }
 
@@ -357,7 +389,7 @@ export class WhereSqlBuilder {
     right: Expression,
     rightDataType: NormalizedDataType | undefined,
     options: FormatWhereOptions,
-  ): string {
+  ): WhereFragment {
     const rightEscapeOptions = { ...options, type: rightDataType ?? leftDataType };
     const leftEscapeOptions = { ...options, type: leftDataType ?? rightDataType };
 
@@ -366,17 +398,32 @@ export class WhereSqlBuilder {
       rightSql = this.#queryGenerator.escape(right, rightEscapeOptions);
     } else if (Array.isArray(right)) {
       if (right.length === 0) {
-        // NOT IN () does not exist in SQL, so we need to return a condition that is:
-        // - always false if the operator is IN
-        // - always true if the operator is NOT IN
-        if (operator === Op.notIn) {
-          return '1 = 1';
+        const leftValidationOptions = { ...leftEscapeOptions };
+        delete leftValidationOptions.bindParam;
+        this.#queryGenerator.escape(left, leftValidationOptions);
+
+        return operator === Op.notIn ? ALWAYS_TRUE : ALWAYS_FALSE;
+      }
+
+      if (right.includes(null)) {
+        const nonNullValues = right.filter(value => value !== null);
+        const isOperator = operator === Op.notIn ? Op.isNot : Op.is;
+
+        if (nonNullValues.length === 0) {
+          const onlyLeftSql = this.#queryGenerator.escape(left, leftEscapeOptions);
+
+          return `${onlyLeftSql} ${this.#operatorMap[isOperator]} NULL`;
         }
 
-        rightSql = '(NULL)';
-      } else {
-        rightSql = this.#queryGenerator.escapeList(right, rightEscapeOptions);
+        const listLeftSql = this.#queryGenerator.escape(left, leftEscapeOptions);
+        const listSql = `${listLeftSql} ${this.#operatorMap[operator]} ${this.#queryGenerator.escapeList(nonNullValues, rightEscapeOptions)}`;
+        const nullLeftSql = this.#queryGenerator.escape(left, leftEscapeOptions);
+        const nullSql = `${nullLeftSql} ${this.#operatorMap[isOperator]} NULL`;
+
+        return operator === Op.notIn ? `${listSql} AND ${nullSql}` : `${listSql} OR ${nullSql}`;
       }
+
+      rightSql = this.#queryGenerator.escapeList(right, rightEscapeOptions);
     } else {
       throw new TypeError(
         'Operators Op.in and Op.notIn must be called with an array of values, or a literal',
@@ -796,10 +843,14 @@ export class WhereSqlBuilder {
     leftOperand: Expression,
     whereValue: WhereAttributeHashValue<any>,
     allowJsonPath: boolean,
-    handlePart: (left: Expression, operator: symbol | undefined, right: Expression) => string,
+    handlePart: (
+      left: Expression,
+      operator: symbol | undefined,
+      right: Expression,
+    ) => WhereFragment,
     operator: typeof Op.and | typeof Op.or = Op.and,
     parentJsonPath: ReadonlyArray<string | number> = EMPTY_ARRAY,
-  ): string {
+  ): WhereFragment {
     if (!isPlainObject(whereValue)) {
       return handlePart(
         this.#wrapSimpleJsonPath(leftOperand, parentJsonPath),
@@ -819,7 +870,7 @@ export class WhereSqlBuilder {
 
     const keys = [...stringKeys, ...getOperators(whereValue)];
 
-    const parts: string[] = keys.map(key => {
+    const parts: WhereFragment[] = keys.map(key => {
       const value = whereValue[key];
 
       // nested JSON path
@@ -976,23 +1027,113 @@ export class WhereSqlBuilder {
   }
 }
 
-export function joinWithLogicalOperator(
-  sqlArray: string[],
-  operator: typeof Op.and | typeof Op.or,
-): string {
-  const operatorSql = operator === Op.and ? ' AND ' : ' OR ';
+/**
+ * True for every row, with no SQL to show for it: an empty conjunction, an empty `where`, or an
+ * omitted condition. Distinct from {@link ALWAYS_TRUE} because it renders to nothing at all, and
+ * because the caller asked for it rather than Sequelize deriving it.
+ */
+export const NO_CONDITION = Symbol('noCondition');
 
-  sqlArray = sqlArray.filter(val => Boolean(val));
+/** A WHERE fragment known to be true for every row, e.g. `x NOT IN ()`. */
+export const ALWAYS_TRUE = Symbol('alwaysTrue');
 
-  if (sqlArray.length === 0) {
+/** A WHERE fragment known to be false for every row, e.g. `x IN ()` or an empty disjunction. */
+export const ALWAYS_FALSE = Symbol('alwaysFalse');
+
+/**
+ * Either a piece of SQL, or a truth value query generation worked out without needing any.
+ */
+export type WhereFragment = string | typeof NO_CONDITION | typeof ALWAYS_TRUE | typeof ALWAYS_FALSE;
+
+/**
+ * Renders a fragment as the SQL that goes into the query.
+ *
+ * @param fragment
+ */
+export function renderWhereFragment(fragment: WhereFragment | undefined): string {
+  if (fragment === undefined || fragment === NO_CONDITION) {
     return '';
   }
 
-  if (sqlArray.length === 1) {
-    return sqlArray[0];
+  if (fragment === ALWAYS_TRUE) {
+    return '1 = 1';
   }
 
-  return sqlArray
+  if (fragment === ALWAYS_FALSE) {
+    return '0 = 1';
+  }
+
+  return fragment;
+}
+
+export class AlwaysTrueWhereError extends BaseError {}
+
+export function buildAlwaysTrueWhereError(statement: 'DELETE' | 'UPDATE'): AlwaysTrueWhereError {
+  return new AlwaysTrueWhereError(
+    `Invalid Query: the "where" option of this ${statement} is true for every row, so it would affect the entire table.
+This usually means a condition was built from a list that turned out to be empty, such as { id: { [Op.notIn]: [] } }.
+Check that list before building the where clause. If you do mean every row, pass a condition that says so, such as sql\`1 = 1\`.`,
+  );
+}
+
+/**
+ * Combines fragments with AND or OR, folding any truth values among them:
+ * FALSE decides an AND, TRUE decides an OR, and each is the identity of the other operator.
+ * An empty AND is {@link NO_CONDITION}; an empty OR is {@link ALWAYS_FALSE}.
+ *
+ * @param sqlArray
+ * @param operator
+ */
+export function joinWithLogicalOperator(
+  sqlArray: ReadonlyArray<WhereFragment | undefined>,
+  operator: typeof Op.and | typeof Op.or,
+): WhereFragment {
+  const operatorSql = operator === Op.and ? ' AND ' : ' OR ';
+  const isAnd = operator === Op.and;
+
+  let sawNoCondition = false;
+  let sawAlwaysTrue = false;
+  const parts: string[] = [];
+
+  for (const fragment of sqlArray) {
+    if (fragment === undefined || fragment === '' || fragment === NO_CONDITION) {
+      sawNoCondition = true;
+      continue;
+    }
+
+    if (fragment === ALWAYS_TRUE) {
+      if (!isAnd) {
+        return ALWAYS_TRUE;
+      }
+
+      sawAlwaysTrue = true;
+      continue;
+    }
+
+    if (fragment === ALWAYS_FALSE) {
+      if (isAnd) {
+        return ALWAYS_FALSE;
+      }
+
+      continue;
+    }
+
+    parts.push(fragment);
+  }
+
+  if (parts.length === 0) {
+    if (isAnd) {
+      return sawAlwaysTrue ? ALWAYS_TRUE : NO_CONDITION;
+    }
+
+    return sawNoCondition ? NO_CONDITION : ALWAYS_FALSE;
+  }
+
+  if (parts.length === 1) {
+    return parts[0];
+  }
+
+  return parts
     .map(sql => {
       if (/ AND | OR /i.test(sql)) {
         return `(${sql})`;
@@ -1003,12 +1144,16 @@ export function joinWithLogicalOperator(
     .join(operatorSql);
 }
 
-function wrapWithNot(sql: string): string {
-  if (!sql) {
-    return '';
+function wrapWithNot(fragment: WhereFragment): WhereFragment {
+  if (fragment === NO_CONDITION || fragment === '' || fragment === ALWAYS_TRUE) {
+    return ALWAYS_FALSE;
   }
 
-  return `NOT (${sql})`;
+  if (fragment === ALWAYS_FALSE) {
+    return ALWAYS_TRUE;
+  }
+
+  return `NOT (${fragment})`;
 }
 
 export function wrapAmbiguousWhere(operand: Expression, sql: string): string {

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -346,10 +346,21 @@ export interface WhereOperators<AttributeType = any> {
   /** @example `[Op.notBetween]: [11, 15],` becomes `NOT BETWEEN 11 AND 15` */
   [Op.notBetween]?: WhereOperators<AttributeType>[typeof Op.between];
 
-  /** @example `[Op.in]: [1, 2],` becomes `IN (1, 2)` */
-  [Op.in]?: ReadonlyArray<OperatorValues<NonNullable<AttributeType>>> | Literal;
+  /**
+   * A `null` in the list means "or is null" for a nullable attribute: it is compared separately
+   * rather than emitted as `IN (..., NULL)`, which never matches a NULL value.
+   *
+   * @example `[Op.in]: [1, 2],` becomes `IN (1, 2)`
+   * @example `{ age: { [Op.in]: [1, null] } }` becomes `age IN (1) OR age IS NULL`
+   */
+  [Op.in]?:
+    | ReadonlyArray<OperatorValues<NonNullable<AttributeType>> | Extract<AttributeType, null>>
+    | Literal;
 
-  /** @example `[Op.notIn]: [1, 2],` becomes `NOT IN (1, 2)` */
+  /**
+   * @example `[Op.notIn]: [1, 2],` becomes `NOT IN (1, 2)`
+   * @example `{ age: { [Op.notIn]: [1, null] } }` becomes `age NOT IN (1) AND age IS NOT NULL`
+   */
   [Op.notIn]?: WhereOperators<AttributeType>[typeof Op.in];
 
   /**

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2720,6 +2720,10 @@ ${associationOwner._getAssociationDebugList()}`);
 
     setTransactionFromCls(options, this.sequelize);
 
+    if (options.where !== undefined) {
+      this.queryGenerator.assertNotAlwaysTrueWhere(options.where, 'DELETE', { model: this });
+    }
+
     this._injectScope(options);
 
     if (options && 'truncate' in options) {
@@ -2915,6 +2919,10 @@ ${associationOwner._getAssociationDebugList()}`);
     options = cloneDeep(options) ?? {};
 
     setTransactionFromCls(options, this.sequelize);
+
+    if (options.where !== undefined) {
+      this.queryGenerator.assertNotAlwaysTrueWhere(options.where, 'UPDATE', { model: this });
+    }
 
     this._injectScope(options);
     this._optionsMustContainWhere(options);
@@ -3287,6 +3295,10 @@ Instead of specifying a Model, either:
 
         return rawFields;
       }, {});
+    }
+
+    if (options.where !== undefined) {
+      this.queryGenerator.assertNotAlwaysTrueWhere(options.where, 'UPDATE', { model: this });
     }
 
     this._injectScope(options);

--- a/packages/core/test/integration/model/destroy.test.ts
+++ b/packages/core/test/integration/model/destroy.test.ts
@@ -57,6 +57,55 @@ describe('destroy', () => {
       expect(await User.findAll()).to.have.lengthOf(0);
     });
 
+    it('refuses a where that was derived to be true for every row', async () => {
+      const { User } = vars;
+
+      await User.bulkCreate([{ username: 'user1' }, { username: 'user2' }]);
+
+      await expect(User.destroy({ where: { username: { [Op.notIn]: [] } } })).to.be.rejectedWith(
+        /is true for every row/,
+      );
+
+      await expect(
+        User.destroy({ where: { [Op.not]: { username: { [Op.in]: [] } } } }),
+      ).to.be.rejectedWith(/is true for every row/);
+
+      expect(await User.findAll()).to.have.lengthOf(2);
+    });
+
+    it('refuses a derived always-true where even when a paranoid clause is added', async () => {
+      const { ParanoidUser } = vars;
+
+      await ParanoidUser.bulkCreate([{ username: 'user1' }, { username: 'user2' }]);
+
+      await expect(
+        ParanoidUser.destroy({ where: { username: { [Op.notIn]: [] } } }),
+      ).to.be.rejectedWith(/is true for every row/);
+
+      expect(await ParanoidUser.findAll()).to.have.lengthOf(2);
+    });
+
+    it('allows a derived always-true condition alongside a real one', async () => {
+      const { User } = vars;
+
+      await User.bulkCreate([{ username: 'user1' }, { username: 'user2' }]);
+
+      expect(
+        await User.destroy({
+          where: { [Op.and]: [{ username: 'user1' }, { username: { [Op.notIn]: [] } }] },
+        }),
+      ).to.equal(1);
+      expect(await User.findAll()).to.have.lengthOf(1);
+    });
+
+    it('deletes no rows for a where that can never be satisfied', async () => {
+      const { User } = vars;
+
+      await User.bulkCreate([{ username: 'user1' }, { username: 'user2' }]);
+      expect(await User.destroy({ where: { username: { [Op.in]: [] } } })).to.equal(0);
+      expect(await User.findAll()).to.have.lengthOf(2);
+    });
+
     it('deletes values that match filter', async () => {
       const { User } = vars;
 

--- a/packages/core/test/integration/model/findAll.test.js
+++ b/packages/core/test/integration/model/findAll.test.js
@@ -124,6 +124,44 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]);
       });
 
+      it('returns no rows for an empty Op.in, and every row including NULL for its negation', async function () {
+        await this.User.create({ username: 'nullval', intVal: null });
+        const emptyList = [];
+
+        const none = await this.User.findAll({ where: { intVal: { [Op.in]: emptyList } } });
+        expect(none).to.have.length(0);
+
+        const all = await this.User.findAll({
+          where: { [Op.not]: { intVal: { [Op.in]: emptyList } } },
+        });
+        expect(all.map(u => u.username).sort()).to.deep.equal(['boo', 'boo2', 'nullval']);
+
+        const inferred = await this.User.findAll({ where: { [Op.not]: { intVal: emptyList } } });
+        expect(inferred).to.have.length(3);
+      });
+
+      it('returns every row including NULL for an empty Op.notIn, and none for its negation', async function () {
+        await this.User.create({ username: 'nullval', intVal: null });
+
+        const all = await this.User.findAll({ where: { intVal: { [Op.notIn]: [] } } });
+        expect(all.map(u => u.username).sort()).to.deep.equal(['boo', 'boo2', 'nullval']);
+
+        const none = await this.User.findAll({
+          where: { [Op.not]: { intVal: { [Op.notIn]: [] } } },
+        });
+        expect(none).to.have.length(0);
+      });
+
+      it('matches NULL rows for a list containing null', async function () {
+        await this.User.create({ username: 'nullval', intVal: null });
+
+        const notIn = await this.User.findAll({ where: { intVal: { [Op.notIn]: [5, null] } } });
+        expect(notIn.map(u => u.username)).to.deep.equal(['boo2']);
+
+        const isIn = await this.User.findAll({ where: { intVal: { [Op.in]: [5, null] } } });
+        expect(isIn.map(u => u.username).sort()).to.deep.equal(['boo', 'nullval']);
+      });
+
       it('should be able to find rows where attribute is in a list of values', async function () {
         const users = await this.User.findAll({
           where: {

--- a/packages/core/test/integration/model/increment.test.js
+++ b/packages/core/test/integration/model/increment.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes } = require('@sequelize/core');
+const { DataTypes, Op } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
@@ -64,6 +64,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         await this.User[method](['aNumber'], { by: 2, where: { id: 1 } });
         const user3 = await this.User.findByPk(2);
         expect(user3.aNumber).to.equal(this.assert(0, 0));
+      });
+
+      it('refuses a where that was derived to be true for every row', async function () {
+        await expect(
+          this.User[method](['aNumber'], { by: 2, where: { id: { [Op.notIn]: [] } } }),
+        ).to.be.rejectedWith(/is true for every row/);
+
+        const user = await this.User.findByPk(1);
+        expect(user.aNumber).to.equal(0);
       });
 
       it('uses correct column names for where conditions', async function () {

--- a/packages/core/test/integration/model/update.test.ts
+++ b/packages/core/test/integration/model/update.test.ts
@@ -1,5 +1,5 @@
 import type { CreationOptional, InferAttributes, InferCreationAttributes } from '@sequelize/core';
-import { DataTypes, Model, sql } from '@sequelize/core';
+import { DataTypes, Model, Op, sql } from '@sequelize/core';
 import { Attribute, ColumnName, PrimaryKey, Table } from '@sequelize/core/decorators-legacy';
 import chai from 'chai';
 import sinon from 'sinon';
@@ -68,6 +68,34 @@ describe('Model.update', () => {
         Error,
         'Missing where attribute in the options parameter',
       );
+    });
+
+    it('refuses a where that was derived to be true for every row', async () => {
+      const { User } = vars;
+
+      await User.bulkCreate([{ username: 'Peter' }, { username: 'Paul' }]);
+
+      await expect(
+        User.update({ username: 'Bob' }, { where: { id: { [Op.notIn]: [] } } }),
+      ).to.be.rejectedWith(/is true for every row/);
+
+      await expect(
+        User.update({ username: 'Bob' }, { where: { [Op.not]: { id: { [Op.in]: [] } } } }),
+      ).to.be.rejectedWith(/is true for every row/);
+
+      const users = await User.findAll({ order: [['username', 'ASC']] });
+      expect(users.map(user => user.username)).to.deep.equal(['Paul', 'Peter']);
+    });
+
+    it('updates no rows for a where that can never be satisfied', async () => {
+      const { User } = vars;
+
+      await User.bulkCreate([{ username: 'Peter' }, { username: 'Paul' }]);
+      const [affectedRows] = await User.update(
+        { username: 'Bob' },
+        { where: { id: { [Op.in]: [] } } },
+      );
+      expect(affectedRows).to.equal(0);
     });
 
     it('only updates rows that match where', async () => {

--- a/packages/core/test/unit/query-generator/bulk-delete-query.test.ts
+++ b/packages/core/test/unit/query-generator/bulk-delete-query.test.ts
@@ -1,4 +1,5 @@
-import { DataTypes, literal } from '@sequelize/core';
+import { DataTypes, Op, literal, sql } from '@sequelize/core';
+import { expect } from 'chai';
 import { createSequelizeInstance, expectsql, sequelize } from '../../support';
 
 const dialect = sequelize.dialect;
@@ -39,7 +40,7 @@ describe('QueryGenerator#bulkDeleteQuery', () => {
         "DELETE FROM `MyModels` WHERE rowid IN (SELECT rowid FROM `MyModels` WHERE `name` = 'barry' LIMIT 10)",
       'db2 ibmi': `DELETE FROM "MyModels" WHERE "name" = 'barry' FETCH NEXT 10 ROWS ONLY`,
       'postgres snowflake': `DELETE FROM "MyModels" WHERE "id" IN (SELECT "id" FROM "MyModels" WHERE "name" = 'barry' ORDER BY "id" LIMIT 10)`,
-      oracle: `DELETE FROM "MyModels" WHERE rowid IN (SELECT rowid FROM "MyModels" WHERE rownum <= 10 AND "name" = 'barry')`,
+      oracle: `DELETE FROM "MyModels" WHERE rowid IN (SELECT rowid FROM "MyModels" WHERE rownum <= 10 AND ("name" = 'barry'))`,
     });
   });
 
@@ -56,7 +57,7 @@ describe('QueryGenerator#bulkDeleteQuery', () => {
           "DELETE FROM `MyModels` WHERE rowid IN (SELECT rowid FROM `MyModels` WHERE `name` = 'barry' LIMIT 10)",
         'db2 ibmi': `DELETE FROM "MyModels" WHERE "name" = 'barry' FETCH NEXT 10 ROWS ONLY`,
         'postgres snowflake': `DELETE FROM "MyModels" WHERE "id" IN (SELECT "id" FROM "MyModels" WHERE "name" = 'barry' ORDER BY "id" LIMIT 10)`,
-        oracle: `DELETE FROM "MyModels" WHERE rowid IN (SELECT rowid FROM "MyModels" WHERE rownum <= 10 AND "name" = 'barry')`,
+        oracle: `DELETE FROM "MyModels" WHERE rowid IN (SELECT rowid FROM "MyModels" WHERE rownum <= 10 AND ("name" = 'barry'))`,
       },
     );
   });
@@ -80,7 +81,7 @@ describe('QueryGenerator#bulkDeleteQuery', () => {
       sqlite3: `DELETE FROM \`MyModels\` WHERE rowid IN (SELECT rowid FROM \`MyModels\` WHERE name = 'Zoe' LIMIT 1)`,
       'db2 ibmi': `DELETE FROM "MyModels" WHERE name = 'Zoe' FETCH NEXT 1 ROWS ONLY`,
       'postgres snowflake': `DELETE FROM "MyModels" WHERE "id" IN (SELECT "id" FROM "MyModels" WHERE name = 'Zoe' ORDER BY "id" LIMIT 1)`,
-      oracle: `DELETE FROM "MyModels" WHERE rowid IN (SELECT rowid FROM "MyModels" WHERE rownum <= :limit AND name = 'Zoe')`,
+      oracle: `DELETE FROM "MyModels" WHERE rowid IN (SELECT rowid FROM "MyModels" WHERE rownum <= :limit AND (name = 'Zoe'))`,
     });
   });
 
@@ -146,6 +147,63 @@ Caused by: "undefined" cannot be escaped`),
       mssql: `DELETE FROM [mySchema].[myTable] WHERE [name] = N'barry'; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
       sqlite3: "DELETE FROM `mySchema.myTable` WHERE `name` = 'barry'",
     });
+  });
+
+  it('refuses a where derived to be true for every row when rejectAlwaysTrueWhere is set', () => {
+    expect(() =>
+      queryGenerator.bulkDeleteQuery('myTable', {
+        where: { id: { [Op.notIn]: [] } },
+        rejectAlwaysTrueWhere: 'DELETE',
+      }),
+    ).to.throw(/is true for every row/);
+
+    expect(() =>
+      queryGenerator.bulkDeleteQuery('myTable', {
+        where: { [Op.not]: { id: { [Op.in]: [] } } },
+        rejectAlwaysTrueWhere: 'DELETE',
+      }),
+    ).to.throw(/is true for every row/);
+
+    expectsql(queryGenerator.bulkDeleteQuery('myTable', { where: { id: { [Op.notIn]: [] } } }), {
+      default: `DELETE FROM [myTable] WHERE 1 = 1`,
+      mssql: `DELETE FROM [myTable] WHERE 1 = 1; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
+    });
+  });
+
+  it('accepts a where the caller wrote to be true for every row', () => {
+    expectsql(
+      queryGenerator.bulkDeleteQuery('myTable', {
+        where: sql`1 = 1`,
+        rejectAlwaysTrueWhere: 'DELETE',
+      }),
+      {
+        default: `DELETE FROM [myTable] WHERE 1 = 1`,
+        mssql: `DELETE FROM [myTable] WHERE 1 = 1; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
+      },
+    );
+  });
+
+  it('accepts an empty where', () => {
+    expectsql(
+      queryGenerator.bulkDeleteQuery('myTable', { where: {}, rejectAlwaysTrueWhere: 'DELETE' }),
+      {
+        default: `DELETE FROM [myTable]`,
+        mssql: `DELETE FROM [myTable]; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
+      },
+    );
+  });
+
+  it('still emits an unsatisfiable where instead of rejecting it', () => {
+    expectsql(
+      queryGenerator.bulkDeleteQuery('myTable', {
+        where: { id: { [Op.in]: [] } },
+        rejectAlwaysTrueWhere: 'DELETE',
+      }),
+      {
+        default: `DELETE FROM [myTable] WHERE 0 = 1`,
+        mssql: `DELETE FROM [myTable] WHERE 0 = 1; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
+      },
+    );
   });
 
   it('produces a delete query with schema and custom delimiter argument', () => {

--- a/packages/core/test/unit/query-generator/select-query.test.ts
+++ b/packages/core/test/unit/query-generator/select-query.test.ts
@@ -75,6 +75,56 @@ describe('QueryGenerator#selectQuery', () => {
     return { User, Project, ProjectContributor };
   });
 
+  it('renders a constant include.where into the JOIN condition', () => {
+    const { Project } = vars;
+
+    const sql = queryGenerator.selectQuery(
+      Project.table,
+      {
+        model: Project,
+        attributes: ['id'],
+        include: _validateIncludedElements({
+          model: Project,
+          include: [
+            {
+              association: Project.associations.owner,
+              where: { id: { [Op.notIn]: [] } },
+              required: true,
+            },
+          ],
+        }).include,
+      },
+      Project,
+    );
+
+    expect(sql).to.include('AND 1 = 1');
+  });
+
+  it('brackets an include.where that compiles to a disjunction', () => {
+    const { Project } = vars;
+
+    const sql = queryGenerator.selectQuery(
+      Project.table,
+      {
+        model: Project,
+        attributes: ['id'],
+        include: _validateIncludedElements({
+          model: Project,
+          include: [
+            {
+              association: Project.associations.contributors,
+              where: { id: { [Op.in]: [1, null] } },
+              required: true,
+            },
+          ],
+        }).include,
+      },
+      Project,
+    );
+
+    expect(sql).to.match(/AND \(\[?[`"]?contributors[`"\]]?\.\[?[`"]?id[`"\]]? IN \(1\) OR /);
+  });
+
   describe('limit/offset', () => {
     it('supports offset without limit', () => {
       const { User } = vars;
@@ -601,7 +651,7 @@ describe('QueryGenerator#selectQuery', () => {
             [ProjectContributors] AS [contributors->ProjectContributor]
             INNER JOIN [Users] AS [contributors]
             ON [contributors].[id] = [contributors->ProjectContributor].[userId]
-            AND 'where'
+            AND ('where')
           )
           ON [Project].[id] = [contributors->ProjectContributor].[projectId];
         `,
@@ -616,7 +666,7 @@ describe('QueryGenerator#selectQuery', () => {
             [ProjectContributors] AS [contributors->ProjectContributor]
             INNER JOIN [Users] AS [contributors]
             ON [contributors].[id] = [contributors->ProjectContributor].[userId]
-            AND N'where'
+            AND (N'where')
           )
           ON [Project].[id] = [contributors->ProjectContributor].[projectId];
         `,
@@ -631,7 +681,7 @@ describe('QueryGenerator#selectQuery', () => {
               "ProjectContributors" "contributors->ProjectContributor"
               INNER JOIN "Users" "contributors"
               ON "contributors"."id" = "contributors->ProjectContributor"."userId"
-              AND 'where'
+              AND ('where')
             )
           ON "Project"."id" = "contributors->ProjectContributor"."projectId";
         `,

--- a/packages/core/test/unit/query-generator/update-query.test.ts
+++ b/packages/core/test/unit/query-generator/update-query.test.ts
@@ -1,4 +1,4 @@
-import { DataTypes, ParameterStyle, literal } from '@sequelize/core';
+import { DataTypes, Op, ParameterStyle, literal, sql } from '@sequelize/core';
 import { expect } from 'chai';
 import { beforeAll2, expectsql, sequelize } from '../../support';
 
@@ -108,6 +108,79 @@ describe('QueryGenerator#updateQuery', () => {
     });
 
     expect(bind).to.be.undefined;
+  });
+
+  it('refuses a where derived to be true for every row when rejectAlwaysTrueWhere is set', () => {
+    const { User } = vars;
+
+    expect(() =>
+      queryGenerator.updateQuery(
+        User.table,
+        { firstName: 'John' },
+        { id: { [Op.notIn]: [] } },
+        { rejectAlwaysTrueWhere: 'UPDATE' },
+      ),
+    ).to.throw(/is true for every row/);
+
+    expect(() =>
+      queryGenerator.updateQuery(
+        User.table,
+        { firstName: 'John' },
+        { [Op.not]: { id: { [Op.in]: [] } } },
+        { rejectAlwaysTrueWhere: 'UPDATE' },
+      ),
+    ).to.throw(/is true for every row/);
+  });
+
+  it('accepts a where the caller wrote to be true for every row', () => {
+    const { User } = vars;
+
+    const { query } = queryGenerator.updateQuery(User.table, { firstName: 'John' }, sql`1 = 1`, {
+      parameterStyle: ParameterStyle.REPLACEMENT,
+      rejectAlwaysTrueWhere: 'UPDATE',
+    });
+
+    expectsql(query, {
+      default: `UPDATE [Users] SET [firstName]='John' WHERE 1 = 1`,
+      mssql: `UPDATE [Users] SET [firstName]=N'John' WHERE 1 = 1`,
+      db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"='John' WHERE 1 = 1);`,
+    });
+  });
+
+  it('keeps the bind parameters of conditions that were folded away', () => {
+    const { query, bind } = queryGenerator.updateQuery(
+      'myTable',
+      { name: 'bar' },
+      { id: 2, other: { [Op.in]: [] }, value: 3 },
+    );
+
+    expectsql(query, {
+      default: 'UPDATE [myTable] SET [name]=$sequelize_1 WHERE 0 = 1',
+      db2: 'SELECT * FROM FINAL TABLE (UPDATE "myTable" SET "name"=$sequelize_1 WHERE 0 = 1);',
+    });
+
+    expect(bind).to.deep.eq({
+      sequelize_1: 'bar',
+      sequelize_2: 2,
+      sequelize_3: 3,
+    });
+  });
+
+  it('binds nothing for the left operand of an empty Op.in', () => {
+    const { User } = vars;
+
+    const { query, bind } = queryGenerator.updateQuery(
+      User.table,
+      { firstName: 'bar' },
+      sql.where(sql.fn('lower', 'ABC'), Op.in, []),
+    );
+
+    expectsql(query, {
+      default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE 0 = 1',
+      db2: 'SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE 0 = 1);',
+    });
+
+    expect(bind).to.deep.eq({ sequelize_1: 'bar' });
   });
 
   it('binds date values', () => {

--- a/packages/core/test/unit/query-interface/bulk-delete.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-delete.test.ts
@@ -1,4 +1,4 @@
-import { DataTypes } from '@sequelize/core';
+import { DataTypes, Op, sql } from '@sequelize/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { beforeAll2, expectsql, sequelize } from '../../support';
@@ -41,5 +41,36 @@ describe('QueryInterface#bulkDelete', () => {
     });
 
     expect(firstCall.args[1]?.bind).to.be.undefined;
+  });
+
+  it('refuses a where that was derived to be true for every row', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw');
+
+    await expect(
+      sequelize.queryInterface.bulkDelete(User, { where: { firstName: { [Op.notIn]: [] } } }),
+    ).to.be.rejectedWith(/is true for every row/);
+
+    expect(stub.callCount).to.eq(0);
+  });
+
+  it('accepts a where the caller wrote to be true for every row', async () => {
+    const stub = sinon.stub(sequelize, 'queryRaw');
+
+    await sequelize.queryInterface.bulkDelete(vars.User, { where: sql`1 = 1` });
+
+    expect(stub.callCount).to.eq(1);
+    expectsql(stub.getCall(0).args[0], {
+      default: `DELETE FROM [Users] WHERE 1 = 1`,
+      mssql: `DELETE FROM [Users] WHERE 1 = 1; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
+    });
+  });
+
+  it('does not pass rejectAlwaysTrueWhere on to queryRaw', async () => {
+    const stub = sinon.stub(sequelize, 'queryRaw');
+
+    await sequelize.queryInterface.bulkDelete(vars.User, { where: { firstName: 'foo' } });
+
+    expect(stub.getCall(0).args[1]).to.not.have.property('rejectAlwaysTrueWhere');
   });
 });

--- a/packages/core/test/unit/query-interface/bulk-update.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-update.test.ts
@@ -1,4 +1,4 @@
-import { DataTypes, Op, literal } from '@sequelize/core';
+import { DataTypes, Op, literal, sql } from '@sequelize/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { beforeAll2, expectsql, sequelize } from '../../support';
@@ -141,5 +141,46 @@ describe('QueryInterface#bulkUpdate', () => {
       sequelize_1: 'newName',
       1: 'bind1',
     });
+  });
+
+  it('refuses a where that was derived to be true for every row', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
+
+    await expect(
+      sequelize.queryInterface.bulkUpdate(
+        User.table,
+        { firstName: 'John' },
+        { firstName: { [Op.notIn]: [] } },
+      ),
+    ).to.be.rejectedWith(/is true for every row/);
+
+    expect(stub.callCount).to.eq(0);
+  });
+
+  it('accepts a where the caller wrote to be true for every row', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
+
+    await sequelize.queryInterface.bulkUpdate(User.table, { firstName: 'John' }, sql`1 = 1`);
+
+    expect(stub.callCount).to.eq(1);
+    expectsql(stub.getCall(0).args[0], {
+      default: `UPDATE [Users] SET [firstName]=$sequelize_1 WHERE 1 = 1`,
+      db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE 1 = 1);`,
+    });
+  });
+
+  it('does not pass rejectAlwaysTrueWhere on to queryRaw', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
+
+    await sequelize.queryInterface.bulkUpdate(
+      User.table,
+      { firstName: 'John' },
+      { firstName: 'foo' },
+    );
+
+    expect(stub.getCall(0).args[1]).to.not.have.property('rejectAlwaysTrueWhere');
   });
 });

--- a/packages/core/test/unit/query-interface/decrement.test.ts
+++ b/packages/core/test/unit/query-interface/decrement.test.ts
@@ -1,4 +1,4 @@
-import { DataTypes } from '@sequelize/core';
+import { DataTypes, Op } from '@sequelize/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { beforeAll2, expectsql, sequelize } from '../../support';
@@ -55,5 +55,39 @@ describe('QueryInterface#decrement', () => {
       postgres: `UPDATE "Users" SET "age"="age"- ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
     });
     expect(firstCall.args[1]?.bind).to.be.undefined;
+  });
+
+  it('refuses a where that was derived to be true for every row', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw');
+
+    await expect(
+      sequelize.queryInterface.decrement(
+        User,
+        User.table,
+        { firstName: { [Op.notIn]: [] } },
+        { age: 1 },
+        {},
+        {},
+      ),
+    ).to.be.rejectedWith(/is true for every row/);
+
+    expect(stub.callCount).to.eq(0);
+  });
+
+  it('does not pass rejectAlwaysTrueWhere on to queryRaw', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw');
+
+    await sequelize.queryInterface.decrement(
+      User,
+      User.table,
+      { firstName: 'foo' },
+      { age: 1 },
+      {},
+      {},
+    );
+
+    expect(stub.getCall(0).args[1]).to.not.have.property('rejectAlwaysTrueWhere');
   });
 });

--- a/packages/core/test/unit/query-interface/increment.test.ts
+++ b/packages/core/test/unit/query-interface/increment.test.ts
@@ -1,4 +1,4 @@
-import { DataTypes } from '@sequelize/core';
+import { DataTypes, Op } from '@sequelize/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { beforeAll2, expectsql, sequelize } from '../../support';
@@ -55,5 +55,39 @@ describe('QueryInterface#increment', () => {
       postgres: `UPDATE "Users" SET "age"="age"+ ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
     });
     expect(firstCall.args[1]?.bind).to.be.undefined;
+  });
+
+  it('refuses a where that was derived to be true for every row', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw');
+
+    await expect(
+      sequelize.queryInterface.increment(
+        User,
+        User.table,
+        { firstName: { [Op.notIn]: [] } },
+        { age: 1 },
+        {},
+        {},
+      ),
+    ).to.be.rejectedWith(/is true for every row/);
+
+    expect(stub.callCount).to.eq(0);
+  });
+
+  it('does not pass rejectAlwaysTrueWhere on to queryRaw', async () => {
+    const { User } = vars;
+    const stub = sinon.stub(sequelize, 'queryRaw');
+
+    await sequelize.queryInterface.increment(
+      User,
+      User.table,
+      { firstName: 'foo' },
+      { age: 1 },
+      {},
+      {},
+    );
+
+    expect(stub.getCall(0).args[1]).to.not.have.property('rejectAlwaysTrueWhere');
   });
 });

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -1092,7 +1092,7 @@ Caused by: "undefined" cannot be escaped`),
       testSql(
         { [Op.not]: {} },
         {
-          default: '',
+          default: '0 = 1',
         },
       );
 
@@ -1103,21 +1103,22 @@ Caused by: "undefined" cannot be escaped`),
           },
         },
         {
-          default: '',
+          default: '1 = 1',
         },
       );
 
       testSql(
         { [Op.not]: [] },
         {
-          default: '',
+          default: '0 = 1',
         },
       );
 
+      // same case, reached through the attribute-level path instead
       testSql(
         { nullableIntAttr: { [Op.not]: {} } },
         {
-          default: '',
+          default: '0 = 1',
         },
       );
 
@@ -1631,9 +1632,89 @@ Caused by: "undefined" cannot be escaped`),
       testSql(
         { intAttr1: { [Op.in]: [] } },
         {
-          default: '[intAttr1] IN (NULL)',
+          default: '0 = 1',
         },
       );
+
+      testSql(
+        { [Op.or]: [{ intAttr1: { [Op.in]: [] } }, { intAttr2: 5 }] },
+        {
+          default: '[intAttr2] = 5',
+        },
+      );
+
+      testSql(
+        { [Op.not]: { intAttr1: { [Op.in]: [] } } },
+        {
+          default: '1 = 1',
+        },
+      );
+
+      testSql(
+        { [Op.and]: [{ intAttr1: { [Op.in]: [] } }, { intAttr2: 5 }] },
+        {
+          default: '0 = 1',
+        },
+      );
+
+      testSql(
+        { [Op.not]: { intAttr1: [] } },
+        {
+          default: '1 = 1',
+        },
+      );
+
+      // same case, reached through the attribute-level path instead
+      testSql(
+        { intAttr1: { [Op.not]: { [Op.in]: [] } } },
+        {
+          default: '1 = 1',
+        },
+      );
+
+      {
+        // fails if WhereAttributeHashValue's conditional is left distributive: Op.in is then
+        // instantiated once for `number` and once for `null`, and neither accepts both
+        const ignoreMixed: TestModelWhere = { nullableIntAttr: { [Op.in]: [1, null] } };
+        const ignoreOnlyNull: TestModelWhere = { nullableIntAttr: { [Op.notIn]: [null] } };
+
+        // @ts-expect-error -- null is only accepted for a nullable attribute
+        const ignoreWrong: TestModelWhere = { intAttr1: { [Op.in]: [1, null] } };
+      }
+
+      testSql(
+        { nullableIntAttr: { [Op.in]: [1, null] } },
+        {
+          default: '[nullableIntAttr] IN (1) OR [nullableIntAttr] IS NULL',
+        },
+      );
+
+      testSql(
+        { nullableIntAttr: { [Op.in]: [null] } },
+        {
+          default: '[nullableIntAttr] IS NULL',
+        },
+      );
+
+      testSql(
+        { [Op.and]: [{ nullableIntAttr: { [Op.in]: [1, null] } }, { intAttr2: 5 }] },
+        {
+          default: '([nullableIntAttr] IN (1) OR [nullableIntAttr] IS NULL) AND [intAttr2] = 5',
+        },
+      );
+
+      testSql(
+        { [Op.not]: { nullableIntAttr: { [Op.in]: [1, null] } } },
+        {
+          default: 'NOT ([nullableIntAttr] IN (1) OR [nullableIntAttr] IS NULL)',
+        },
+      );
+
+      // only the cause is asserted: the rest of the message inspects the where object, and
+      // util.inspect renders it differently across Node versions
+      testSql(where(fn('lower', undefined), Op.in, []), {
+        default: new Error(`Caused by: "undefined" cannot be escaped`),
+      });
     });
 
     describeInSuite(Op.notIn, 'NOT IN', () => {
@@ -1647,23 +1728,50 @@ Caused by: "undefined" cannot be escaped`),
       testSql(
         { [Op.or]: [{ intAttr1: { [Op.notIn]: [] } }, { intAttr2: 5 }] },
         {
-          default: '1 = 1 OR [intAttr2] = 5',
+          default: '1 = 1',
         },
       );
 
       testSql(
         { [Op.not]: { intAttr1: { [Op.notIn]: [] } } },
         {
-          default: 'NOT (1 = 1)',
+          default: '0 = 1',
         },
       );
 
       testSql(
         { [Op.and]: [{ intAttr1: { [Op.notIn]: [] } }, { intAttr2: 5 }] },
         {
-          default: '1 = 1 AND [intAttr2] = 5',
+          default: '[intAttr2] = 5',
         },
       );
+
+      testSql(
+        { nullableIntAttr: { [Op.notIn]: [1, null] } },
+        {
+          default: '[nullableIntAttr] NOT IN (1) AND [nullableIntAttr] IS NOT NULL',
+        },
+      );
+
+      testSql(
+        { nullableIntAttr: { [Op.notIn]: [null] } },
+        {
+          default: '[nullableIntAttr] IS NOT NULL',
+        },
+      );
+
+      testSql(
+        { [Op.not]: { nullableIntAttr: { [Op.notIn]: [1, null] } } },
+        {
+          default: 'NOT ([nullableIntAttr] NOT IN (1) AND [nullableIntAttr] IS NOT NULL)',
+        },
+      );
+
+      // only the cause is asserted: the rest of the message inspects the where object, and
+      // util.inspect renders it differently across Node versions
+      testSql(where(fn('lower', undefined), Op.notIn, []), {
+        default: new Error(`Caused by: "undefined" cannot be escaped`),
+      });
     });
 
     function describeLikeSuite(
@@ -3767,6 +3875,8 @@ Caused by: "undefined" cannot be escaped`),
         expect(util.inspect(and('a', 'b'))).to.deep.equal(util.inspect({ [Op.and]: ['a', 'b'] }));
       });
 
+      // Deliberately asymmetric with Op.or: an empty conjunction is true, so "no condition" is
+      // the right SQL for it. Do not "fix" this for consistency with or([]).
       testSql(and([]), {
         default: '',
       });
@@ -3774,6 +3884,35 @@ Caused by: "undefined" cannot be escaped`),
       testSql(and({}), {
         default: '',
       });
+
+      testSql(
+        { [Op.not]: { [Op.and]: [] } },
+        {
+          default: '0 = 1',
+        },
+      );
+
+      testSql(
+        { [Op.or]: [{ [Op.and]: [] }, { intAttr1: 1 }] },
+        {
+          default: '[intAttr1] = 1',
+        },
+      );
+
+      testSql(
+        // @ts-expect-error -- an absent arm is handled at runtime but not accepted by the typings
+        { [Op.or]: [undefined, { intAttr1: 1 }] },
+        {
+          default: '[intAttr1] = 1',
+        },
+      );
+
+      testSql(
+        { [Op.and]: [{ intAttr1: 1 }, { [Op.or]: [] }] },
+        {
+          default: '0 = 1',
+        },
+      );
 
       // by default: it already is Op.and
       testSql(
@@ -3836,11 +3975,11 @@ Caused by: "undefined" cannot be escaped`),
       });
 
       testSql(or([]), {
-        default: '',
+        default: '0 = 1',
       });
 
       testSql(or({}), {
-        default: '',
+        default: '0 = 1',
       });
 
       // can pass a simple object

--- a/packages/oracle/src/query-generator-typescript.internal.ts
+++ b/packages/oracle/src/query-generator-typescript.internal.ts
@@ -366,7 +366,7 @@ export class OracleQueryGeneratorTypeScript extends AbstractQueryGenerator {
         );
       }
 
-      const whereTmpl = whereClause ? ` AND ${whereClause}` : '';
+      const whereTmpl = whereClause ? ` AND (${whereClause})` : '';
       queryTmpl = `DELETE FROM ${table} WHERE rowid IN (SELECT rowid FROM ${table} WHERE rownum <= ${this.escape(options.limit)}${whereTmpl})`;
     } else {
       const whereTmpl = whereClause ? ` WHERE${whereClause}` : '';

--- a/packages/oracle/src/query-generator.js
+++ b/packages/oracle/src/query-generator.js
@@ -836,7 +836,7 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
     // delete with limit <l> and optional condition <e> on Oracle: DELETE FROM <t> WHERE rowid in (SELECT rowid FROM <t> WHERE <e> AND rownum <= <l>)
     // Note that the condition <e> has to be in the subquery; otherwise, the subquery would select <l> arbitrary rows.
     if (options.limit) {
-      const whereTmpl = whereClause ? ` AND ${whereClause}` : '';
+      const whereTmpl = whereClause ? ` AND (${whereClause})` : '';
       queryTmpl = `DELETE FROM ${this.quoteTable(table)} WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(table)} WHERE rownum <= ${this.escape(options.limit)}${whereTmpl})`;
     } else {
       const whereTmpl = whereClause ? ` WHERE${whereClause}` : '';


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Closes #18306
Closes #18307
Closes #18286

A condition whose operand set turns out to be empty, or to contain `NULL`, compiled to SQL
that did not mean what the condition meant. The mismatch was invisible on its own and only
surfaced once the condition was composed — which is why it kept being fixed one operator at a
time (#4859, #18248 / #18250, #18286, #18306) without the class ever closing.

### 1. An empty `Op.in` / `Op.notIn` compiles to a truth value

`{ [Op.in]: [] }` emitted `IN (NULL)`, which is UNKNOWN rather than FALSE. UNKNOWN is
indistinguishable from FALSE at the top of a `WHERE`, so the bare case looked right — but
`NOT (UNKNOWN)` is still UNKNOWN, so negating it matched **no** rows where it should match
**every** row.

This is not a judgement call: SQL defines `x IN (…)` as `x = ANY (…)`, and an existential
quantifier over an empty set is FALSE for every `x`, `NULL` included. You can observe it
directly, because SQL does have a syntax for an empty right-hand side:

```sql
SELECT NULL::int IN     (SELECT 1 WHERE false);  -- f    <- FALSE, not NULL
SELECT NULL::int NOT IN (SELECT 1 WHERE false);  -- t
SELECT NULL::int IN     (NULL);                  -- NULL <- what Sequelize emitted
```

Identical on MySQL. Every ORM I checked emits a constant here and none throws: ActiveRecord
`1=0`/`1=1` (`arel/visitors/to_sql.rb`), Knex `1 = 0`/`1 = 1`, TypeORM `0=1`, SQLAlchemy
`(col IN (NULL)) AND (1 != 1)`, Django raises `EmptyResultSet` internally and converts it to
a full result set under `exclude()`.

### 2. A `NULL` inside a list is compared separately

`x NOT IN (1, NULL)` is UNKNOWN for every row, so it silently matched nothing on every
dialect, and `x IN (1, NULL)` never matched a `NULL` x. Sequelize already rewrites
`{ x: null }` to `x IS NULL` rather than emitting `x = NULL`; the same now happens inside a
list:

```
[Op.in]:    [1, null] -> x IN (1) OR x IS NULL
[Op.notIn]: [1, null] -> x NOT IN (1) AND x IS NOT NULL
[Op.in]:    [null]    -> x IS NULL
```

Django strips `None` for the same reason (*"NULL is never equal to anything"*); ActiveRecord
ORs in `attribute.eq(nil)`, which is the behaviour chosen here.

The typings accept `null` for nullable attributes. That needed `WhereAttributeHashValue`'s
conditional to become non-distributive — for `number | null` it otherwise instantiates the
operator table once for `number` and once for `null`, and neither arm accepts a list
containing both.

### 3. Truth values are tracked instead of overloading the empty string

`joinWithLogicalOperator` and `wrapWithNot` dropped `''` unconditionally — including from an
`OR`, whose identity is FALSE rather than TRUE, and from a `NOT`, where dropping it is never
right. That single behaviour is the shared cause of #18248, #18306 and #18286.

Fragments now carry `NO_CONDITION` / `ALWAYS_TRUE` / `ALWAYS_FALSE`, and AND, OR and NOT do
boolean algebra over them.

| where | before | after |
| --- | --- | --- |
| `or([])`, `or({})` | *(no condition — matched every row)* | `0 = 1` |
| `{[Op.not]: {}}`, `{[Op.not]: []}` | *(no condition)* | `0 = 1` |
| `{attr: {[Op.not]: {}}}` | *(no condition)* | `0 = 1` |
| `{[Op.and]: [{status:'active'}, {[Op.or]: []}]}` | `status = 'active'` — the OR vanished | `0 = 1` |
| `{[Op.and]: []}`, `and({})` | *(no condition)* | unchanged, deliberately |

An `Op.or` **arm** that carries no condition contributes nothing rather than satisfying the
whole disjunction, so `{ [Op.or]: [maybeFilter, cond] }` still means `cond` when the first arm
is absent. That distinction — an OR with an empty *arm* versus an OR with no arms — is what
keeps the common optional-filter idiom working.

**This supersedes #18286**, which fixes the same cases by throwing. The literal is chosen here
because the empty set has a defined meaning in SQL (§1) and because `Op.notIn: []` was already
settled that way in #18250. The `Op.and` asymmetry that PR calls out is preserved and pinned
by tests.

### 4. Statements that modify rows refuse a `where` that imposes no restriction

`Model.destroy`, `Model.update` and `Model.increment` / `Model.decrement` only checked that a
`where` was *passed*, not what it meant — so `{ id: { [Op.notIn]: [] } }` compiled to
`WHERE 1 = 1` and rewrote the whole table. This is what @SippieCup asked for in #18307.

They now check the caller's `where` on its own, immediately before a scope or a paranoid
clause is merged into it — the last point at which `options.where` is purely what the caller
asked for.

```js
Model.destroy({ where: { id: { [Op.notIn]: [] } } })          // throws
Model.destroy({ where: { [Op.not]: { id: { [Op.in]: [] } } } }) // throws
Model.destroy({ where: { tenantId: 5, id: { [Op.notIn]: [] } } }) // runs — the tenant filter is real
Model.destroy({ where: sql`1 = 1` })                          // runs — the documented escape hatch
Model.destroy({ where: {} })                                  // runs — unchanged
Model.findAll({ where: { id: { [Op.notIn]: [] } } })          // reads are untouched
```

Judging the caller's conditions rather than the compiled statement is what keeps the third
line working while still catching the first on a **paranoid or scoped** model — where the
injected `deletedAt IS NULL` would otherwise absorb the always-true condition and hide it.
`QueryInterface#bulkDelete`, `#bulkUpdate` and the increment path additionally reject an
always-true `where` for callers that use them directly.

That this check has to sit in a *window* rather than being a property of the compiled
statement is a symptom of scope and paranoid conditions being merged into the caller's
`where` at all. Filed as #18323 for a later re-architecture.

### 5. Where fragments are bracketed where they are concatenated by hand

Four sites build SQL by appending `` ` AND ${fragment}` `` instead of going through
`joinWithLogicalOperator`, so a fragment containing `OR` rebound:

```sql
ON "User"."id" = "…"."userId" AND "p"."tag" IN ('x') OR "p"."tag" IS NULL
```

which pulled unrelated rows into a `belongsToMany` include, and made Oracle's limited `DELETE`
ignore its own `rownum` limit. The bug predates this PR — an `Op.or` in an `include.where` hit
it too — but a null-bearing `Op.in` now produces an `OR`, which widens it a long way.

## Verification

- Unit suite on all nine dialects: 2241–2867 passing, 0 failing
- PostgreSQL integration suite against a live server: 2103 passing, 0 failing
- Behaviour confirmed against live PostgreSQL 17, MySQL 8.4 and SQL Server 2025
- `tsc --noEmit` and `tsc -b test/tsconfig.json` clean

## List of Breaking Changes

- `or([])`, `or({})`, `{ [Op.not]: {} }` and `{ [Op.not]: [] }` produce `0 = 1` instead of no
  condition at all. `{ [Op.and]: [] }` and `and({})` still produce no condition.
- `Model.update`, `Model.destroy` and `Model.increment` / `Model.decrement` throw when the
  caller's `where` compiles to a condition that is true for every row, such as
  `{ [Op.notIn]: [] }`. Pass ``sql`1 = 1` `` to affect every row deliberately.
- A `null` inside an `Op.in` / `Op.notIn` list now means "or is null" instead of being passed
  through to SQL as a list element.
- A bare `{ [Op.in]: [] }` emits `0 = 1` instead of `IN (NULL)`. Equivalent inside a top-level
  `WHERE`, but code asserting on the exact generated SQL will see a difference.

## Credit

§1 is @lazerg's fix from #18307, and the analysis it rests on is theirs — the diagnosis in
#18306 identified `IN (NULL)` as UNKNOWN rather than FALSE, corrected the assumption #18248
had been written on, and spotted that the `Op.in` describe block was missing the composition
cases that would have caught it. The write-path discussion in §4 follows their reasoning in
the #18307 thread, including the point that a guard belongs at the layer that already checks
for a missing `where`.

---
*Created by Opus 5 with Claude Code, supervised by @WikiRik.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented accidental unrestricted `UPDATE`, `DELETE`, and increment/decrement operations when conditions match every row.
  - Corrected empty `IN`/`NOT IN` behavior, including handling of `NULL` values.
  - Improved grouping of conditions in generated JOIN and Oracle queries.
- **Developer Experience**
  - Added clearer errors when destructive operations would affect every row.
  - Improved TypeScript support for nullable `IN` values and query-safety options.
  - Preserved explicitly supplied always-true SQL conditions when intentionally requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->