### PR TITLE
fix(core): don't default association key generics to any

### DIFF
--- a/packages/core/src/associations/base.ts
+++ b/packages/core/src/associations/base.ts
@@ -202,7 +202,7 @@ export abstract class MultiAssociation<
   S extends Model = Model,
   T extends Model = Model,
   ForeignKey extends string = string,
-  TargetKey extends AttributeNames<T> = any,
+  TargetKey extends AttributeNames<T> = AttributeNames<T>,
   Opts extends NormalizedAssociationOptions<ForeignKey> = NormalizedAssociationOptions<ForeignKey>,
 > extends Association<S, T, ForeignKey, Opts> {
   static get isMultiAssociation() {

--- a/packages/core/src/associations/belongs-to-many.ts
+++ b/packages/core/src/associations/belongs-to-many.ts
@@ -113,8 +113,8 @@ export class BelongsToManyAssociation<
   SourceModel extends Model = Model,
   TargetModel extends Model = Model,
   ThroughModel extends Model = Model,
-  SourceKey extends AttributeNames<SourceModel> = any,
-  TargetKey extends AttributeNames<TargetModel> = any,
+  SourceKey extends AttributeNames<SourceModel> = AttributeNames<SourceModel>,
+  TargetKey extends AttributeNames<TargetModel> = AttributeNames<TargetModel>,
 > extends MultiAssociation<
   SourceModel,
   TargetModel,

--- a/packages/core/src/associations/belongs-to.ts
+++ b/packages/core/src/associations/belongs-to.ts
@@ -45,8 +45,8 @@ import { defineAssociation, mixinMethods, normalizeBaseAssociationOptions } from
 export class BelongsToAssociation<
   S extends Model = Model,
   T extends Model = Model,
-  SourceKey extends AttributeNames<S> = any,
-  TargetKey extends AttributeNames<T> = any,
+  SourceKey extends AttributeNames<S> = AttributeNames<S>,
+  TargetKey extends AttributeNames<T> = AttributeNames<T>,
 > extends Association<S, T, SourceKey, NormalizedBelongsToOptions<SourceKey, TargetKey>> {
   readonly accessors: SingleAssociationAccessors;
 

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -58,9 +58,9 @@ import {
 export class HasManyAssociation<
   S extends Model = Model,
   T extends Model = Model,
-  SourceKey extends AttributeNames<S> = any,
-  TargetKey extends AttributeNames<T> = any,
-  TargetPrimaryKey extends AttributeNames<T> = any,
+  SourceKey extends AttributeNames<S> = AttributeNames<S>,
+  TargetKey extends AttributeNames<T> = AttributeNames<T>,
+  TargetPrimaryKey extends AttributeNames<T> = AttributeNames<T>,
 > extends MultiAssociation<
   S,
   T,

--- a/packages/core/src/associations/has-one.ts
+++ b/packages/core/src/associations/has-one.ts
@@ -44,9 +44,9 @@ import {
 export class HasOneAssociation<
   S extends Model = Model,
   T extends Model = Model,
-  SourceKey extends AttributeNames<S> = any,
-  TargetKey extends AttributeNames<T> = any,
-  TargetPrimaryKey extends AttributeNames<T> = any,
+  SourceKey extends AttributeNames<S> = AttributeNames<S>,
+  TargetKey extends AttributeNames<T> = AttributeNames<T>,
+  TargetPrimaryKey extends AttributeNames<T> = AttributeNames<T>,
 > extends Association<S, T, TargetKey, NormalizedHasOneOptions<SourceKey, TargetKey>> {
   get foreignKey(): TargetKey {
     return this.inverse.foreignKey;

--- a/packages/core/test/types/associations.ts
+++ b/packages/core/test/types/associations.ts
@@ -1,5 +1,12 @@
-import type { ForeignKey, InferAttributes } from '@sequelize/core';
+import type {
+  BelongsToAssociation,
+  ForeignKey,
+  HasManyAssociation,
+  HasOneAssociation,
+  InferAttributes,
+} from '@sequelize/core';
 import { Model } from '@sequelize/core';
+import { expectTypeOf } from 'expect-type';
 
 class Car extends Model<InferAttributes<Car>> {
   declare person: ForeignKey<number>;
@@ -130,3 +137,8 @@ Person.belongsToMany(Country, {
   // @ts-expect-error -- this key does not exist on Country
   targetKey: 'doesNotExist',
 });
+
+// Unparameterized associations must not leak `any` for their key properties
+expectTypeOf<HasOneAssociation['sourceKey']>().toEqualTypeOf<string>();
+expectTypeOf<HasManyAssociation['sourceKey']>().toEqualTypeOf<string>();
+expectTypeOf<BelongsToAssociation['targetKey']>().toEqualTypeOf<string>();


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to the documentation repository?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow our conventions?

## Description of Changes

`BelongsToAssociation`, `HasOneAssociation`, `HasManyAssociation`, and `BelongsToManyAssociation` constrain their `SourceKey`/`TargetKey` generics with `extends AttributeNames<Model>`, but default them to `any` instead of to that same constraint. Since `AttributeNames<Model>` (unparameterized `Model`) resolves to plain `string`, there's no reason for the default to be `any` — it looks like a leftover from the original JS→TS migration of the association classes.

In practice this means any code that uses these association classes without filling in the generics explicitly — the common case, e.g. the type of a value read out of `Model.associations` — silently loses type checking on `sourceKey`/`targetKey`/`foreignKey`, since they resolve to `any`. This can mask typos and trips `@typescript-eslint/no-unsafe-return`/`no-unsafe-member-access` for consumers with strict lint rules against `any` leakage, forcing them to add `eslint-disable` comments for something that should just be typed as `string`.

This changes the default to the same bound already used in the `extends` clause, so unparameterized usage now resolves to `string` instead of `any`. No behavior changes at runtime; this is a typings-only fix.

## List of Breaking Changes

None expected. Code that relied on the generics defaulting to `any` (e.g. assigning a non-string value to `sourceKey`) would now see a type error, but this would already have been incorrect at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type safety for model associations by automatically restricting association keys to valid model attribute names.
  * Prevented unconstrained key types from defaulting to `any`, providing more accurate type checking and editor support.

* **Tests**
  * Added compile-time checks to verify association keys resolve to the expected types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->