### PR TITLE
docs: generate TypeDoc for every package

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,9 +101,9 @@
     "prettier-plugin-organize-imports": "4.3.0",
     "source-map-support": "0.5.21",
     "ts-node": "10.9.2",
-    "typedoc": "0.27.9",
+    "typedoc": "0.28.19",
     "typedoc-plugin-mdn-links": "5.1.1",
-    "typedoc-plugin-missing-exports": "3.1.0",
+    "typedoc-plugin-missing-exports": "4.1.3",
     "typescript": "5.8.3"
   },
   "packageManager": "yarn@4.13.0",

--- a/packages/core/src/abstract-dialect/query-generator-typescript.ts
+++ b/packages/core/src/abstract-dialect/query-generator-typescript.ts
@@ -159,7 +159,7 @@ export interface ParameterOptions {
    */
   readonly parameterStyle?: ParameterStyle | `${ParameterStyle}` | undefined;
   /**
-   * These are used to inline replacements into the query, when one is found inside of a {@link sql.literal}.
+   * These are used to inline replacements into the query, when one is found inside of a {@link @sequelize/core!sql.literal}.
    */
   readonly replacements?: BindOrReplacements | undefined;
 }

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -1021,7 +1021,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
    *
    * ⚠️ You almost certainly want to use `quoteIdentifier` instead!
    * This method splits the identifier by "." into multiple identifiers, and has special meaning for "*".
-   * This behavior should never be the default and should be explicitly opted into by using {@link sql.col}.
+   * This behavior should never be the default and should be explicitly opted into by using {@link @sequelize/core!sql.col}.
    *
    * @param {string} identifiers
    *

--- a/packages/core/src/associations/base.ts
+++ b/packages/core/src/associations/base.ts
@@ -101,7 +101,10 @@ export abstract class Association<
     /* method name in model */ string
   >;
 
-  abstract foreignKey: ForeignKey;
+  /**
+   * The name of the foreign key attribute used by this association.
+   */
+  abstract get foreignKey(): ForeignKey;
 
   /**
    * A reference to the association that created this one.

--- a/packages/core/src/associations/belongs-to.ts
+++ b/packages/core/src/associations/belongs-to.ts
@@ -48,6 +48,8 @@ export class BelongsToAssociation<
   SourceKey extends AttributeNames<S> = AttributeNames<S>,
   TargetKey extends AttributeNames<T> = AttributeNames<T>,
 > extends Association<S, T, SourceKey, NormalizedBelongsToOptions<SourceKey, TargetKey>> {
+  readonly #foreignKey: SourceKey;
+
   readonly accessors: SingleAssociationAccessors;
 
   /**
@@ -59,7 +61,9 @@ export class BelongsToAssociation<
     return this.foreignKey;
   }
 
-  foreignKey: SourceKey;
+  get foreignKey(): SourceKey {
+    return this.#foreignKey;
+  }
 
   /**
    * The column name of the foreign key
@@ -146,7 +150,7 @@ export class BelongsToAssociation<
       foreignKey = this.inferForeignKey();
     }
 
-    this.foreignKey = foreignKey as SourceKey;
+    this.#foreignKey = foreignKey as SourceKey;
 
     this.targetKeyField = getColumnName(targetAttributes.getOrThrow(this.targetKey));
     this.targetKeyIsPrimary = this.targetKey === this.target.primaryKeyAttribute;

--- a/packages/core/src/expression-builders/attribute.ts
+++ b/packages/core/src/expression-builders/attribute.ts
@@ -6,7 +6,7 @@ import type { DialectAwareFn } from './dialect-aware-fn.js';
 import type { JsonPath } from './json-path.js';
 
 /**
- * Use {@link sql.attribute} instead.
+ * Use {@link @sequelize/core!sql.attribute} instead.
  */
 export class Attribute extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'attribute';

--- a/packages/core/src/expression-builders/cast.ts
+++ b/packages/core/src/expression-builders/cast.ts
@@ -6,7 +6,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 import { where } from './where.js';
 
 /**
- * Do not use me directly. Use {@link sql.cast}
+ * Do not use me directly. Use {@link @sequelize/core!sql.cast}
  */
 export class Cast extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'cast';

--- a/packages/core/src/expression-builders/col.ts
+++ b/packages/core/src/expression-builders/col.ts
@@ -1,7 +1,7 @@
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
- * Do not use me directly. Use {@link sql.col}
+ * Do not use me directly. Use {@link @sequelize/core!sql.col}
  */
 export class Col extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'col';
@@ -18,11 +18,11 @@ export class Col extends BaseSqlExpression {
 
 /**
  * Creates an object which represents a column in the DB, this allows referencing another column in your query.
- * This is often useful in conjunction with {@link sql.fn}, {@link sql.where} and {@link sql} which interpret strings as values and not column names.
+ * This is often useful in conjunction with {@link @sequelize/core!sql.fn}, {@link @sequelize/core!sql.where} and {@link @sequelize/core!sql} which interpret strings as values and not column names.
  *
- * Col works similarly to {@link sql.identifier}, but "*" has special meaning, for backwards compatibility.
+ * Col works similarly to {@link @sequelize/core!sql.identifier}, but "*" has special meaning, for backwards compatibility.
  *
- * ⚠️ We recommend using {@link sql.identifier}, or {@link sql.attribute} instead.
+ * ⚠️ We recommend using {@link @sequelize/core!sql.identifier}, or {@link @sequelize/core!sql.attribute} instead.
  *
  * @param identifiers The name of the column
  */

--- a/packages/core/src/expression-builders/dialect-aware-fn.ts
+++ b/packages/core/src/expression-builders/dialect-aware-fn.ts
@@ -6,7 +6,7 @@ import { BaseSqlExpression } from './base-sql-expression.js';
 import { JsonPath } from './json-path.js';
 
 /**
- * Unlike {@link sql.fn}, this class does not accept a function name.
+ * Unlike {@link @sequelize/core!sql.fn}, this class does not accept a function name.
  * It must instead be extended by a class that implements the {@link applyForDialect} method, in which
  * the function name is provided.
  *

--- a/packages/core/src/expression-builders/fn.ts
+++ b/packages/core/src/expression-builders/fn.ts
@@ -5,7 +5,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 import { where } from './where.js';
 
 /**
- * Do not use me directly. Use {@link sql.fn}
+ * Do not use me directly. Use {@link @sequelize/core!sql.fn}
  */
 export class Fn extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'fn';
@@ -22,10 +22,10 @@ export class Fn extends BaseSqlExpression {
 
 /**
  * Creates an object representing a database function. This can be used in search queries, both in where and order parts, and as default values in column definitions.
- * If you want to refer to columns in your function, you should use {@link sql.attribute} (recommended), {@link sql.identifier}, or {@link sql.col} (discouraged)
+ * If you want to refer to columns in your function, you should use {@link @sequelize/core!sql.attribute} (recommended), {@link @sequelize/core!sql.identifier}, or {@link @sequelize/core!sql.col} (discouraged)
  * otherwise the value will be interpreted as a string.
  *
- * ℹ️ This method is usually verbose and we recommend using the {@link sql} template string tag instead.
+ * ℹ️ This method is usually verbose and we recommend using the {@link @sequelize/core!sql} template string tag instead.
  *
  * @param fnName The SQL function you want to call
  * @param args All further arguments will be passed as arguments to the function

--- a/packages/core/src/expression-builders/identifier.ts
+++ b/packages/core/src/expression-builders/identifier.ts
@@ -2,7 +2,7 @@ import type { TableOrModel } from '../abstract-dialect/query-generator.types';
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
- * Use {@link sql.identifier} instead.
+ * Use {@link @sequelize/core!sql.identifier} instead.
  */
 export class Identifier extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'identifier';
@@ -14,7 +14,7 @@ export class Identifier extends BaseSqlExpression {
 
 /**
  * Used to represent a value that will either be escaped to a literal, or a bind parameter.
- * Unlike {@link sql.attribute} and {@link sql.col}, this identifier will be escaped as-is,
+ * Unlike {@link @sequelize/core!sql.attribute} and {@link @sequelize/core!sql.col}, this identifier will be escaped as-is,
  * without mapping to a column name or any other transformation.
  *
  * This method supports strings, table structures, model classes (in which case the identifiers will be the model schema & table name), and model definitions (same behavior as model classes)

--- a/packages/core/src/expression-builders/json-path.ts
+++ b/packages/core/src/expression-builders/json-path.ts
@@ -2,7 +2,7 @@ import type { Expression } from '../sequelize.js';
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
- * Do not use me directly. Use {@link sql.jsonPath}.
+ * Do not use me directly. Use {@link @sequelize/core!sql.jsonPath}.
  */
 export class JsonPath extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'jsonPath';
@@ -17,7 +17,7 @@ export class JsonPath extends BaseSqlExpression {
 
 /**
  * Use this to access nested properties in a JSON column.
- * You can also use the dot notation with {@link sql.attribute}, but this works with any values, not just attributes.
+ * You can also use the dot notation with {@link @sequelize/core!sql.attribute}, but this works with any values, not just attributes.
  *
  * @param expression The expression to access the property on.
  * @param path The path to the property. If a number is used, it will be treated as an array index, otherwise as a key.

--- a/packages/core/src/expression-builders/json.ts
+++ b/packages/core/src/expression-builders/json.ts
@@ -14,7 +14,7 @@ import { where } from './where.js';
  * @param conditionsOrPath A hash containing strings/numbers or other nested hash, a string using dot notation or a string using postgres/sqlite/mysql json syntax.
  * @param value An optional value to compare against. Produces a string of the form "<json path> = '<value>'".
  *
- * @deprecated use {@link sql.where}, {@link sql.attribute}, and/or {@link sql.jsonPath} instead.
+ * @deprecated use {@link @sequelize/core!sql.where}, {@link @sequelize/core!sql.attribute}, and/or {@link @sequelize/core!sql.jsonPath} instead.
  */
 export function json(
   conditionsOrPath: { [key: string]: any } | string,

--- a/packages/core/src/expression-builders/list.ts
+++ b/packages/core/src/expression-builders/list.ts
@@ -1,7 +1,7 @@
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
- * Use {@link sql.list} instead.
+ * Use {@link @sequelize/core!sql.list} instead.
  */
 export class List extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'list';

--- a/packages/core/src/expression-builders/literal.ts
+++ b/packages/core/src/expression-builders/literal.ts
@@ -1,7 +1,7 @@
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
- * Do not use me directly. Use {@link sql.literal}
+ * Do not use me directly. Use {@link @sequelize/core!sql.literal}
  */
 export class Literal extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'literal';
@@ -17,7 +17,7 @@ export class Literal extends BaseSqlExpression {
 
 /**
  * Creates an object representing a literal, i.e. something that will not be escaped.
- * We recommend using {@link sql} for a better DX.
+ * We recommend using {@link @sequelize/core!sql} for a better DX.
  *
  * @param val literal value
  */

--- a/packages/core/src/expression-builders/random.ts
+++ b/packages/core/src/expression-builders/random.ts
@@ -2,7 +2,7 @@ import type { AbstractDialect } from '../abstract-dialect/dialect';
 import { DialectAwareFn } from './dialect-aware-fn';
 
 /**
- * Do not use me directly. Use {@link sql.random}
+ * Do not use me directly. Use {@link @sequelize/core!sql.random}
  */
 export class Random extends DialectAwareFn {
   get maxArgCount() {

--- a/packages/core/src/expression-builders/sql.ts
+++ b/packages/core/src/expression-builders/sql.ts
@@ -15,7 +15,7 @@ import { Value } from './value.js';
 import { where } from './where.js';
 
 /**
- * The template tag function used to easily create {@link sql.literal}.
+ * The template tag function used to easily create {@link @sequelize/core!sql.literal}.
  *
  * @param rawSql
  * @param values

--- a/packages/core/src/expression-builders/value.ts
+++ b/packages/core/src/expression-builders/value.ts
@@ -3,7 +3,7 @@ import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 /**
  * Used to represent a value that will either be escaped to a literal, or a bind parameter.
  * You do not need to use this function directly, it will be used automatically when you interpolate parameters
- * in a template string tagged with {@link sql}.
+ * in a template string tagged with {@link @sequelize/core!sql}.
  */
 export class Value extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'value';

--- a/packages/core/src/expression-builders/where.ts
+++ b/packages/core/src/expression-builders/where.ts
@@ -9,7 +9,7 @@ import type { Expression } from '../sequelize.js';
 import { BaseSqlExpression, SQL_IDENTIFIER } from './base-sql-expression.js';
 
 /**
- * Do not use me directly. Use {@link sql.where}
+ * Do not use me directly. Use {@link @sequelize/core!sql.where}
  */
 export class Where<Operator extends keyof WhereOperators = typeof Op.eq> extends BaseSqlExpression {
   declare protected readonly [SQL_IDENTIFIER]: 'where';
@@ -78,7 +78,7 @@ If you wish to use custom operators not provided by Sequelize, you can use the "
  * A way of writing an SQL binary operator, or more complex where conditions.
  *
  * This solution is slightly more verbose than the POJO syntax, but allows any value on the left hand side of the operator (unlike the POJO syntax which only accepts attribute names).
- * For instance, either the left or right hand side of the operator can be {@link sql.fn}, {@link sql.col}, {@link sql.literal} etc.
+ * For instance, either the left or right hand side of the operator can be {@link @sequelize/core!sql.fn}, {@link @sequelize/core!sql.col}, {@link @sequelize/core!sql.literal} etc.
  *
  * If your left operand is an attribute name, using the regular POJO syntax (`{ where: { attrName: value }}`) syntax is usually more convenient.
  *
@@ -103,7 +103,7 @@ export function where(
   whereAttributeHashValue: WhereAttributeHashValue<any>,
 ): Where;
 /**
- * This version of `where` is used to opt back into the POJO syntax. Useful in combination with {@link sql}.
+ * This version of `where` is used to opt back into the POJO syntax. Useful in combination with {@link @sequelize/core!sql}.
  *
  * @example
  * ```ts

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -406,8 +406,7 @@ export interface WhereOperators<AttributeType = any> {
   // https://www.postgresql.org/docs/14/functions-json.html jsonb @> jsonb
   // https://www.postgresql.org/docs/14/functions-range.html range @> range ; range @> element
   // https://www.postgresql.org/docs/14/functions-array.html array @> array
-  [Op.contains]?: // RANGE @> ELEMENT
-  AttributeType extends Range<infer RangeType>
+  [Op.contains]?: AttributeType extends Range<infer RangeType> // RANGE @> ELEMENT
     ? OperatorValues<OperatorValues<NonNullable<RangeType>>>
     : // jsonb @> ELEMENT
       AttributeType extends object
@@ -1774,7 +1773,7 @@ export interface AttributeOptions<M extends Model = Model> {
   columnName?: string | undefined;
 
   /**
-   * A literal default value, a JavaScript function, or an SQL function (using {@link sql.fn})
+   * A literal default value, a JavaScript function, or an SQL function (using {@link @sequelize/core!sql.fn})
    */
   defaultValue?: unknown | undefined;
 
@@ -1910,7 +1909,7 @@ export type ModelAttributes<M extends Model = Model, TAttributes = any> = {
 /**
  * Options for model definition.
  *
- * Used by {@link Sequelize.define}, {@link Model.init}, and the {@link decorators-legacy.Table} decorator.
+ * Used by {@link Sequelize.define}, {@link Model.init}, and the {@link @sequelize/core!decorators-legacy.Table} decorator.
  *
  * @see https://sequelize.org/docs/v7/core-concepts/model-basics/
  */
@@ -2631,7 +2630,7 @@ export abstract class Model<
    * before the insert call.
    * However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts
    * and another tries to select before the first one has committed.
-   * In this case, an instance of {@link TimeoutError} will be thrown instead.
+   * In this case, an instance of {@link @sequelize/core!TimeoutError} will be thrown instead.
    *
    * If a transaction is passed, a savepoint will be created instead,
    * and any unique constraint violation will be handled internally.
@@ -3054,7 +3053,7 @@ export abstract class Model<
   /**
    * Validates this instance, and if the validation passes, persists it to the database.
    *
-   * Returns a Promise that resolves to the saved instance (or rejects with a {@link ValidationError},
+   * Returns a Promise that resolves to the saved instance (or rejects with a {@link @sequelize/core!ValidationError},
    * which will have a property for each of the fields for which the validation failed, with the error message for that field).
    *
    * This method is optimized to perform an UPDATE only into the fields that changed.
@@ -3077,7 +3076,7 @@ export abstract class Model<
   /**
    * Runs all validators defined for this model, including non-null validators, DataTypes validators, custom attribute validators and model-level validators.
    *
-   * If validation fails, this method will throw a {@link ValidationError}.
+   * If validation fails, this method will throw a {@link @sequelize/core!ValidationError}.
    */
   validate(options?: ValidationOptions): Promise<void>;
 
@@ -3224,7 +3223,7 @@ declare const NonAttributeBrand: unique symbol;
 /**
  * This is a Branded Type.
  * You can use it to tag fields from your class that are NOT attributes.
- * They will be ignored by {@link InferAttributes} and {@link InferCreationAttributes}
+ * They will be ignored by {@link @sequelize/core!InferAttributes} and {@link @sequelize/core!InferCreationAttributes}
  */
 export type NonAttribute<T> =
   // we don't brand null & undefined as they can't have properties.
@@ -3253,7 +3252,7 @@ export type ForeignKey<T> =
   T extends null | undefined ? T : T & { [ForeignKeyBrand]?: true };
 
 /**
- * Option bag for {@link InferAttributes}.
+ * Option bag for {@link @sequelize/core!InferAttributes}.
  *
  * - omit: properties to not treat as Attributes.
  */
@@ -3331,7 +3330,7 @@ declare const CreationAttributeBrand: unique symbol;
  * You can use it to tag attributes that can be omitted during Model Creation.
  * Use it on attributes that have a default value or are marked as autoIncrement.
  *
- * For use with {@link InferCreationAttributes}.
+ * For use with {@link @sequelize/core!InferCreationAttributes}.
  *
  * @example
  * ```typescript
@@ -3356,7 +3355,7 @@ export type CreationOptional<T> =
 /**
  * Utility type to extract Creation Attributes of a given Model class.
  *
- * Works like {@link InferAttributes}, but fields that are tagged using
+ * Works like {@link @sequelize/core!InferAttributes}, but fields that are tagged using
  *  {@link CreationOptional} will be optional.
  *
  * @example
@@ -3385,7 +3384,7 @@ export type InferCreationAttributes<
 /**
  * @private
  *
- * Internal type used by {@link InferCreationAttributes} and {@link InferAttributes} to exclude
+ * Internal type used by {@link @sequelize/core!InferCreationAttributes} and {@link @sequelize/core!InferAttributes} to exclude
  * attributes that are:
  * - functions
  * - branded using {@link NonAttribute}
@@ -3419,7 +3418,7 @@ type InternalInferAttributeKeysFromFields<
  * Returns the creation attributes of a given Model.
  *
  * This returns the Creation Attributes of a Model, it does not build them.
- * If you need to build them, use {@link InferCreationAttributes}.
+ * If you need to build them, use {@link @sequelize/core!InferCreationAttributes}.
  *
  * @example
  * ```typescript
@@ -3433,7 +3432,7 @@ export type CreationAttributes<M extends Model> = MakeNullishOptional<M['_creati
  * Returns the creation attributes of a given Model.
  *
  * This returns the Attributes of a Model that have already been defined, it does not build them.
- * If you need to build them, use {@link InferAttributes}.
+ * If you need to build them, use {@link @sequelize/core!InferAttributes}.
  *
  * @example
  * ```typescript

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1943,7 +1943,7 @@ ${associationOwner._getAssociationDebugList()}`);
    * before the insert call.
    * However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts
    * and another tries to select before the first one has committed.
-   * In this case, an instance of {@link TimeoutError} will be thrown instead.
+   * In this case, an instance of {@link @sequelize/core!TimeoutError} will be thrown instead.
    *
    * If a transaction is passed, a savepoint will be created instead,
    * and any unique constraint violation will be handled internally.
@@ -3855,7 +3855,7 @@ Instead of specifying a Model, either:
   /**
    * Validates this instance, and if the validation passes, persists it to the database.
    *
-   * Returns a Promise that resolves to the saved instance (or rejects with a {@link ValidationError},
+   * Returns a Promise that resolves to the saved instance (or rejects with a {@link @sequelize/core!ValidationError},
    * which will have a property for each of the fields for which the validation failed, with the error message for that
    * field).
    *

--- a/packages/core/src/sequelize-typescript.ts
+++ b/packages/core/src/sequelize-typescript.ts
@@ -793,7 +793,7 @@ Connection options can be used at the root of the option bag, in the "replicatio
   /**
    * Escape value to be used in raw SQL.
    *
-   * If you are using this to use the value in a {@link sql.literal}, consider using {@link sql} instead, which automatically
+   * If you are using this to use the value in a {@link @sequelize/core!sql.literal}, consider using {@link @sequelize/core!sql} instead, which automatically
    * escapes interpolated values.
    *
    * @param value The value to escape

--- a/packages/core/src/sequelize.d.ts
+++ b/packages/core/src/sequelize.d.ts
@@ -237,12 +237,12 @@ export class Sequelize<
    * @param fn The function you want to call
    * @param args All further arguments will be passed as arguments to the function
    *
-   * @deprecated use top level {@link sql.fn} instead
+   * @deprecated use top level {@link @sequelize/core!sql.fn} instead
    * @hidden
    */
   static fn: typeof fn;
   /**
-   * @deprecated use top level {@link sql.fn} instead
+   * @deprecated use top level {@link @sequelize/core!sql.fn} instead
    * @hidden
    */
   fn: typeof fn;
@@ -253,12 +253,12 @@ export class Sequelize<
    *
    * @param col The name of the column
    *
-   * @deprecated use top level {@link sql.col} instead
+   * @deprecated use top level {@link @sequelize/core!sql.col} instead
    * @hidden
    */
   static col: typeof col;
   /**
-   * @deprecated use top level {@link sql.col} instead
+   * @deprecated use top level {@link @sequelize/core!sql.col} instead
    * @hidden
    */
   col: typeof col;
@@ -284,12 +284,12 @@ export class Sequelize<
    *
    * @param val
    *
-   * @deprecated use top level {@link sql.literal} instead
+   * @deprecated use top level {@link @sequelize/core!sql.literal} instead
    * @hidden
    */
   static literal: typeof literal;
   /**
-   * @deprecated use top level {@link sql.literal} instead
+   * @deprecated use top level {@link @sequelize/core!sql.literal} instead
    * @hidden
    */
   literal: typeof literal;

--- a/packages/core/src/sequelize.internals.ts
+++ b/packages/core/src/sequelize.internals.ts
@@ -117,7 +117,7 @@ export interface PersistedSequelizeOptions<Dialect extends AbstractDialect> exte
    * Set this to "sql" if you want the null to be stored as the SQL NULL value.
    * Set this to "explicit" if you don't want Sequelize to make any assumptions.
    * This means that you won't be able to use the JavaScript null primitive as the top level value of a JSON column,
-   * you will have to use {@link SQL_NULL} or {@link JSON_NULL} instead.
+   * you will have to use {@link @sequelize/core!SQL_NULL} or {@link @sequelize/core!JSON_NULL} instead.
    *
    * This only impacts serialization when inserting or updating values.
    * Comparing always requires to be explicit.
@@ -235,7 +235,7 @@ export interface EphemeralSequelizeOptions<Dialect extends AbstractDialect> {
    * This option is only useful if you created your models using decorators.
    * Models created using {@link Model.init} or {@link Sequelize#define} don't need to be specified in this option.
    *
-   * Use {@link importModels} to load models dynamically:
+   * Use {@link @sequelize/core!importModels} to load models dynamically:
    *
    * @example
    * ```ts

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -627,7 +627,7 @@ Use Sequelize#query if you wish to use replacements.`);
   /**
    * Get the fn for random based on the dialect
    *
-   * @deprecated use {@link sql.random} instead, as it can be used without needing a reference to sequelize.
+   * @deprecated use {@link @sequelize/core!sql.random} instead, as it can be used without needing a reference to sequelize.
    * @returns {Random}
    */
   random() {

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,3 +1,26 @@
 {
-  "$schema": "https://typedoc.org/schema.json"
+  "$schema": "https://typedoc.org/schema.json",
+  "externalSymbolLinkMappings": {
+    "@sequelize/core": {
+      "decorators-legacy.Table": "../functions/_sequelize_core.decorators-legacy.Table.html",
+      "importModels": "../functions/_sequelize_core.index.importModels.html",
+      "InferAttributes": "../types/_sequelize_core.index.InferAttributes.html",
+      "InferCreationAttributes": "../types/_sequelize_core.index.InferCreationAttributes.html",
+      "JSON_NULL": "../variables/_sequelize_core.index.JSON_NULL.html",
+      "SQL_NULL": "../variables/_sequelize_core.index.SQL_NULL.html",
+      "sql": "../functions/_sequelize_core.index.sql.html",
+      "sql.attribute": "../functions/_sequelize_core.index.sql.html#attribute",
+      "sql.cast": "../functions/_sequelize_core.index.sql.html#cast",
+      "sql.col": "../functions/_sequelize_core.index.sql.html#col",
+      "sql.fn": "../functions/_sequelize_core.index.sql.html#fn",
+      "sql.identifier": "../functions/_sequelize_core.index.sql.html#identifier",
+      "sql.jsonPath": "../functions/_sequelize_core.index.sql.html#jsonpath",
+      "sql.list": "../functions/_sequelize_core.index.sql.html#list",
+      "sql.literal": "../functions/_sequelize_core.index.sql.html#literal",
+      "sql.random": "../functions/_sequelize_core.index.sql.html#random",
+      "sql.where": "../functions/_sequelize_core.index.sql.html#where",
+      "TimeoutError": "../classes/_sequelize_core.index.TimeoutError.html",
+      "ValidationError": "../classes/_sequelize_core.index.ValidationError.html"
+    }
+  }
 }

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,7 +1,19 @@
 module.exports = {
   entryPointStrategy: 'packages',
-  // Note: packages/postgres cannot be included until https://github.com/TypeStrong/typedoc/issues/2467 is fixed
-  entryPoints: ['packages/core', 'packages/utils', 'packages/validator-js'],
+  entryPoints: [
+    'packages/core',
+    'packages/db2',
+    'packages/ibmi',
+    'packages/mariadb',
+    'packages/mssql',
+    'packages/mysql',
+    'packages/oracle',
+    'packages/postgres',
+    'packages/snowflake',
+    'packages/sqlite3',
+    'packages/utils',
+    'packages/validator-js',
+  ],
   out: './.typedoc-build',
   readme: 'none',
   plugin: ['typedoc-plugin-missing-exports', 'typedoc-plugin-mdn-links'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,14 +1406,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gerrit0/mini-shiki@npm:^1.24.0":
-  version: 1.27.2
-  resolution: "@gerrit0/mini-shiki@npm:1.27.2"
+"@gerrit0/mini-shiki@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@gerrit0/mini-shiki@npm:3.23.0"
   dependencies:
-    "@shikijs/engine-oniguruma": "npm:^1.27.2"
-    "@shikijs/types": "npm:^1.27.2"
-    "@shikijs/vscode-textmate": "npm:^10.0.1"
-  checksum: 10c0/aee681637d123e0e8c9ec154b117ce166dd8b4b9896341e617fef16d0b21ef91a17f6f90cc874137e33ca85b5898817b59bb8aea178cdb2fa6e75b0fff3640c2
+    "@shikijs/engine-oniguruma": "npm:^3.23.0"
+    "@shikijs/langs": "npm:^3.23.0"
+    "@shikijs/themes": "npm:^3.23.0"
+    "@shikijs/types": "npm:^3.23.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/f9663e0e179edd2d7733207843f1bceda24311ab7b5495d50e0531305129fba8663388784c80645383ac6ae5e3a97c138faefeea8c328e7664da882f4ecb1c3a
   languageName: node
   linkType: hard
 
@@ -2956,9 +2958,9 @@ __metadata:
     prettier-plugin-organize-imports: "npm:4.3.0"
     source-map-support: "npm:0.5.21"
     ts-node: "npm:10.9.2"
-    typedoc: "npm:0.27.9"
+    typedoc: "npm:0.28.19"
     typedoc-plugin-mdn-links: "npm:5.1.1"
-    typedoc-plugin-missing-exports: "npm:3.1.0"
+    typedoc-plugin-missing-exports: "npm:4.1.3"
     typescript: "npm:5.8.3"
   languageName: unknown
   linkType: soft
@@ -3085,27 +3087,45 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@shikijs/engine-oniguruma@npm:^1.27.2":
-  version: 1.29.2
-  resolution: "@shikijs/engine-oniguruma@npm:1.29.2"
+"@shikijs/engine-oniguruma@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/engine-oniguruma@npm:3.23.0"
   dependencies:
-    "@shikijs/types": "npm:1.29.2"
-    "@shikijs/vscode-textmate": "npm:^10.0.1"
-  checksum: 10c0/87d77e05af7fe862df40899a7034cbbd48d3635e27706873025e5035be578584d012f850208e97ca484d5e876bf802d4e23d0394d25026adb678eeb1d1f340ff
+    "@shikijs/types": "npm:3.23.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/40dbda7aef55d5946c45b8cfe56f484eadb611f9f7c9eb77ff21f0dfce2bcc775686a61eda9e06401ddd71195945a522293f51d6522fce49244b1a6b9c0f61f7
   languageName: node
   linkType: hard
 
-"@shikijs/types@npm:1.29.2, @shikijs/types@npm:^1.27.2":
-  version: 1.29.2
-  resolution: "@shikijs/types@npm:1.29.2"
+"@shikijs/langs@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/langs@npm:3.23.0"
   dependencies:
-    "@shikijs/vscode-textmate": "npm:^10.0.1"
+    "@shikijs/types": "npm:3.23.0"
+  checksum: 10c0/513b90cfee0fa167d2063b7fbc2318b303a604f2e1fa156aa8b4659b49792401531a74acf68de622ecfff15738e1947a46cfe92a32fcd6a4ee5e70bcf1d06c66
+  languageName: node
+  linkType: hard
+
+"@shikijs/themes@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/themes@npm:3.23.0"
+  dependencies:
+    "@shikijs/types": "npm:3.23.0"
+  checksum: 10c0/5c99036d4a765765018f9106a354ebe5ccac204c69f00e3cda265828d493f005412659213f6574fa0e187c7d4437b3327bd6dad2e2146b2c472d2bf493d790dd
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:3.23.0, @shikijs/types@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/types@npm:3.23.0"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
-  checksum: 10c0/37b4ac315effc03e7185aca1da0c2631ac55bdf613897476bd1d879105c41f86ccce6ebd0b78779513d88cc2ee371039f7efd95d604f77f21f180791978822b3
+  checksum: 10c0/bd0d1593f830a6b4e55c77871ec1b95cc44855d6e0e26282a948a3c58827237826e4110af27eb4d3231361f1e182c4410434a1dc15ec40aea988dc92dc97e9d6
   languageName: node
   linkType: hard
 
-"@shikijs/vscode-textmate@npm:^10.0.1":
+"@shikijs/vscode-textmate@npm:^10.0.2":
   version: 10.0.2
   resolution: "@shikijs/vscode-textmate@npm:10.0.2"
   checksum: 10c0/36b682d691088ec244de292dc8f91b808f95c89466af421cf84cbab92230f03c8348649c14b3251991b10ce632b0c715e416e992dd5f28ff3221dc2693fd9462
@@ -10624,7 +10644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it@npm:^14.1.0":
+"markdown-it@npm:^14.1.1":
   version: 14.3.1
   resolution: "markdown-it@npm:14.3.1"
   dependencies:
@@ -15494,29 +15514,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-missing-exports@npm:3.1.0":
-  version: 3.1.0
-  resolution: "typedoc-plugin-missing-exports@npm:3.1.0"
+"typedoc-plugin-missing-exports@npm:4.1.3":
+  version: 4.1.3
+  resolution: "typedoc-plugin-missing-exports@npm:4.1.3"
   peerDependencies:
-    typedoc: 0.26.x || 0.27.x
-  checksum: 10c0/516964657833f3235f47e2faf7ebccc741ff32923d32af5c3adfdb9bc1fae94dd85885cb735db77d2605e501aee40d5fbe94e8e18ed965d0c1c0198234a7db44
+    typedoc: ^0.28.1
+  checksum: 10c0/b74c573988e31edc3e784106bb29cf2f850fad77178941f80c65be974f2e66eebf105660858d54506e0cb909f876c04393cd1992122586be316fcbe9c1feb91f
   languageName: node
   linkType: hard
 
-"typedoc@npm:0.27.9":
-  version: 0.27.9
-  resolution: "typedoc@npm:0.27.9"
+"typedoc@npm:0.28.19":
+  version: 0.28.19
+  resolution: "typedoc@npm:0.28.19"
   dependencies:
-    "@gerrit0/mini-shiki": "npm:^1.24.0"
+    "@gerrit0/mini-shiki": "npm:^3.23.0"
     lunr: "npm:^2.3.9"
-    markdown-it: "npm:^14.1.0"
-    minimatch: "npm:^9.0.5"
-    yaml: "npm:^2.6.1"
+    markdown-it: "npm:^14.1.1"
+    minimatch: "npm:^10.2.5"
+    yaml: "npm:^2.8.3"
   peerDependencies:
-    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
+    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10c0/999668d9d23e1824b762e2c411e2c0860d0ce4a2e61f23a2c31d36a1d6337a763553bc75205aee25ce34659e9315315c720694e9eccd7e7e4755873fdfec1192
+  checksum: 10c0/a46ea8ec4e661320dacf27f1d68595bdf9d671383f20060b590f212e6ebbf9a65d4962e698e8a43804a14add1f04a3528381c338801350dc03ddc6baf33fb898
   languageName: node
   linkType: hard
 
@@ -16340,7 +16360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.6.0, yaml@npm:^2.6.1, yaml@npm:^2.8.2":
+"yaml@npm:^2.6.0, yaml@npm:^2.8.2, yaml@npm:^2.8.3":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions? <!-- docs tooling; `yarn docs` is the check -->
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

**Stacked on #18330.** This must land *before* the TypeScript 6.0 PR above it — TypeDoc 0.27 refuses to run on TypeScript 6.0 (`yarn docs` exits 3 with "You are running with an unsupported TypeScript version"), and `docs` is a required CI job.

### Every package is documented now

TypeDoc goes to `0.28.19` and `typedoc-plugin-missing-exports` to `4.1.3`.

[TypeStrong/typedoc#2467](https://github.com/TypeStrong/typedoc/issues/2467) is fixed in 0.28, and that issue is what kept `packages/postgres` — and with it every other dialect package — out of the documentation build:

```js
// Note: packages/postgres cannot be included until TypeStrong/typedoc#2467 is fixed
entryPoints: ['packages/core', 'packages/utils', 'packages/validator-js'],
```

All 12 documented packages are now entry points, so the dialect packages get API docs for the first time. (`packages/cli` is deliberately not included — it has no `typedoc.json`.)

### Link resolution

The `{@link}` targets pointing at `sql` and its members are qualified with `@sequelize/core!`. Unqualified, TypeDoc cannot resolve a member of the `sql` tag function and silently drops the link. Those names are mapped to their generated pages through `externalSymbolLinkMappings` in `typedoc.base.json`.

This accounts for most of the diff and is mechanical.

> **Worth knowing:** the mappings hardcode relative output paths such as `../functions/_sequelize_core.index.sql.html#fn`. Nothing fails loudly if TypeDoc changes its output layout later.

### ⚠️ One change that deserves a second opinion

`Association#foreignKey` becomes a getter, which makes it **read-only**. `association.foreignKey = x` would now fail to compile *and* throw at runtime.

This is **not** required by the compiler — I verified that reverting it still compiles cleanly, including under TypeScript 6.0. It is required only by TypeDoc, which otherwise documents the abstract property and the subclass field as two separate symbols. That is an API change made for a documentation reason, so please weigh it deliberately rather than waving it through; I'm happy to drop it and accept the duplicated symbol instead.

## Verification

`yarn docs` completes with **no warnings** across all 12 packages, on TypeScript 5.8.3. `yarn build`, `yarn test-unit` (2203 passing) and `yarn test-typings` all pass.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgPPfqYYk6PFGbanp5mAFh
