### PR TITLE
fix(core): run boolean shorthand validators with their defaults

### DIFF
--- a/packages/core/src/instance-validator.js
+++ b/packages/core/src/instance-validator.js
@@ -381,7 +381,10 @@ export class InstanceValidator {
     if (!Array.isArray(validatorArgs)) {
       if (validatorType === 'isImmutable') {
         validatorArgs = [validatorArgs, field, this.modelInstance];
-      } else if (isLocalizedValidator || validatorType === 'isIP') {
+      } else if (validatorArgs === true || isLocalizedValidator || validatorType === 'isIP') {
+        // The boolean shorthand (e.g. `{ isJSON: true }`) just enables the validator, so run it
+        // with its defaults. Forwarding `true` would be passed as the validator's second argument,
+        // which validator.js reads as an options object (isJSON) or a version (isUUID). See #18141.
         validatorArgs = [];
       } else {
         validatorArgs = [validatorArgs];

--- a/packages/core/test/unit/instance-validator.test.js
+++ b/packages/core/test/unit/instance-validator.test.js
@@ -86,6 +86,74 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     });
   });
 
+  describe('builtin validators - boolean shorthand', () => {
+    // The boolean shorthand `{ validatorName: true }` means "run this validator with its
+    // defaults". It must not forward `true` as the validator's second argument, which
+    // validator.js interprets as an options object (isJSON) or a version (isUUID). See #18141.
+
+    it('accepts a valid UUID when isUUID is enabled via the boolean shorthand', async () => {
+      const User = Support.sequelize.define('user', {
+        uuidField: {
+          type: DataTypes.TEXT,
+          validate: {
+            isUUID: true,
+          },
+        },
+      });
+
+      const instanceValidator = new InstanceValidator(
+        User.build({ uuidField: '550e8400-e29b-41d4-a716-446655440000' }),
+      );
+
+      await expect(instanceValidator.validate()).to.be.fulfilled;
+    });
+
+    it('rejects an invalid UUID when isUUID is enabled via the boolean shorthand', async () => {
+      const User = Support.sequelize.define('user', {
+        uuidField: {
+          type: DataTypes.TEXT,
+          validate: {
+            isUUID: true,
+          },
+        },
+      });
+
+      const instanceValidator = new InstanceValidator(User.build({ uuidField: 'not-a-uuid' }));
+
+      await expect(instanceValidator.validate()).to.be.rejectedWith(SequelizeValidationError);
+    });
+
+    it('accepts valid JSON when isJSON is enabled via the boolean shorthand', async () => {
+      const User = Support.sequelize.define('user', {
+        payload: {
+          type: DataTypes.TEXT,
+          validate: {
+            isJSON: true,
+          },
+        },
+      });
+
+      const instanceValidator = new InstanceValidator(User.build({ payload: '{"valid":true}' }));
+
+      await expect(instanceValidator.validate()).to.be.fulfilled;
+    });
+
+    it('rejects invalid JSON when isJSON is enabled via the boolean shorthand', async () => {
+      const User = Support.sequelize.define('user', {
+        payload: {
+          type: DataTypes.TEXT,
+          validate: {
+            isJSON: true,
+          },
+        },
+      });
+
+      const instanceValidator = new InstanceValidator(User.build({ payload: 'not json' }));
+
+      await expect(instanceValidator.validate()).to.be.rejectedWith(SequelizeValidationError);
+    });
+  });
+
   describe('_validateAndRunHooks', () => {
     beforeEach(function () {
       this.successfulInstanceValidator = new InstanceValidator(this.User.build());


### PR DESCRIPTION
## Problem

Enabling a built-in validator with the documented boolean shorthand rejects valid input.

```js
const User = sequelize.define('user', {
  uuidField: { type: DataTypes.TEXT, validate: { isUUID: true } },
  payload:   { type: DataTypes.TEXT, validate: { isJSON: true } },
});

// valid UUID, yet validation fails:
await User.build({ uuidField: '550e8400-e29b-41d4-a716-446655440000' }).validate();
// SequelizeValidationError: Validation isUUID on uuidField failed
```

This is the boolean-shorthand `{ validatorName: true }` case reported in #18141 for `isJSON`.

## Cause

`InstanceValidator._extractValidatorArgs` resolves the shorthand value (`true`) and, because it
isn't an array, wraps it as `[true]`. The validator is then invoked as
`Validator.fn(value, ...[true])` → `Validator.fn(value, true)`, forwarding `true` as the
validator's **second argument**.

validator.js interprets that second argument as configuration, not as "enabled":

- `isUUID(str, true)` treats `true` as the UUID **version**, so a valid UUID is rejected.
- `isJSON(str, true)` treats `true` as the **options object**. Older validator.js releases threw
  / mis-evaluated on a non-object here (the original #18141 report); current releases defensively
  coerce it to `{}`, which masks the symptom for `isJSON` but leaves the incorrect call in place.

The boolean shorthand is only meant to *enable* the validator and run it with its defaults, the
same way `isIP` and the localized validators (`isAlpha`, `isAlphanumeric`, `isMobilePhone`) are
already handled.

## Fix

In `_extractValidatorArgs`, when the resolved argument is boolean `true`, use `[]` so the
validator runs with its own defaults instead of receiving `true` as an argument. `isImmutable`
keeps its existing dedicated branch (checked first), so its behavior is unchanged.

```js
} else if (validatorArgs === true || isLocalizedValidator || validatorType === 'isIP') {
  validatorArgs = [];
}
```

## Testing

Added unit tests in `packages/core/test/unit/instance-validator.test.js` covering the boolean
shorthand for both `isUUID` and `isJSON` (accept valid input, still reject invalid input). The
`isUUID` accept-case fails on `main` and passes with this change.

Full core unit suite:

```
cd packages/core && cross-env DIALECT=sqlite3 yarn _test-unit
# 2269 passing, 6 pending, 0 failing
```

Fixes #18141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Boolean shorthand validation now uses each validator’s default behavior instead of treating `true` as an options or version argument.
  - Validation continues to correctly accept valid values and reject invalid values for built-in validators such as UUID and JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->