### PR TITLE
meta: make Oracle container startup fail fast instead of hanging

### DIFF
--- a/dev/oracle/latest/docker-compose.yml
+++ b/dev/oracle/latest/docker-compose.yml
@@ -10,10 +10,18 @@ services:
     ports:
       - 1521:1521
     healthcheck:
-      test: ['CMD-SHELL', 'sqlplus system/password@localhost:1521/XEPDB1']
+      # -L makes sqlplus exit non-zero on a failed logon instead of dropping into a logon prompt and exiting 0.
+      # Connecting through the listener to XEPDB1 ensures the PDB service is registered, not just that the listener is up.
+      test:
+        [
+          'CMD-SHELL',
+          'echo "select 1 from dual;" | sqlplus -L -S system/password@localhost:1521/XEPDB1',
+        ]
       interval: 3s
-      timeout: 1s
+      timeout: 5s
       retries: 10
+      # failed probes while the database is still starting up do not count towards `retries`
+      start_period: 120s
 
 networks:
   default:

--- a/dev/oracle/latest/docker-compose.yml
+++ b/dev/oracle/latest/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     ports:
       - 1521:1521
     healthcheck:
-      # -L makes sqlplus exit non-zero on a failed logon instead of dropping into a logon prompt and exiting 0.
-      # Connecting through the listener to XEPDB1 ensures the PDB service is registered, not just that the listener is up.
       test:
         [
           'CMD-SHELL',
@@ -20,7 +18,6 @@ services:
       interval: 3s
       timeout: 5s
       retries: 10
-      # failed probes while the database is still starting up do not count towards `retries`
       start_period: 120s
 
 networks:

--- a/dev/oracle/latest/start.sh
+++ b/dev/oracle/latest/start.sh
@@ -9,10 +9,10 @@ docker compose -p sequelize-oracle-latest up -d
 
 ./../../wait-until-healthy.sh sequelize-oracle-latest
 
-sleep 30s
-
 docker cp ../privileges.sql sequelize-oracle-latest:/opt/oracle/.
 
-docker exec -t sequelize-oracle-latest sqlplus system/password@localhost:1521/XEPDB1 @privileges.sql
+# No -t: without a TTY sqlplus cannot fall into an interactive logon prompt and hang forever.
+# -L: attempt the logon only once and exit non-zero if it fails, so the script fails fast instead of hanging.
+docker exec sequelize-oracle-latest sqlplus -L system/password@localhost:1521/XEPDB1 @privileges.sql
 
 DIALECT=oracle ts-node ../../check-connection.ts

--- a/dev/oracle/latest/start.sh
+++ b/dev/oracle/latest/start.sh
@@ -11,8 +11,6 @@ docker compose -p sequelize-oracle-latest up -d
 
 docker cp ../privileges.sql sequelize-oracle-latest:/opt/oracle/.
 
-# No -t: without a TTY sqlplus cannot fall into an interactive logon prompt and hang forever.
-# -L: attempt the logon only once and exit non-zero if it fails, so the script fails fast instead of hanging.
 docker exec sequelize-oracle-latest sqlplus -L system/password@localhost:1521/XEPDB1 @privileges.sql
 
 DIALECT=oracle ts-node ../../check-connection.ts

--- a/dev/oracle/oldest/docker-compose.yml
+++ b/dev/oracle/oldest/docker-compose.yml
@@ -9,10 +9,18 @@ services:
     ports:
       - 1521:1521
     healthcheck:
-      test: ['CMD-SHELL', 'sqlplus system/password@XEPDB1']
+      # -L makes sqlplus exit non-zero on a failed logon instead of dropping into a logon prompt and exiting 0.
+      # Connecting through the listener to XEPDB1 ensures the PDB service is registered, not just that the listener is up.
+      test:
+        [
+          'CMD-SHELL',
+          'echo "select 1 from dual;" | sqlplus -L -S system/password@localhost:1521/XEPDB1',
+        ]
       interval: 3s
-      timeout: 1s
+      timeout: 5s
       retries: 10
+      # failed probes while the database is still starting up do not count towards `retries`
+      start_period: 120s
 
 networks:
   default:

--- a/dev/oracle/oldest/docker-compose.yml
+++ b/dev/oracle/oldest/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     ports:
       - 1521:1521
     healthcheck:
-      # -L makes sqlplus exit non-zero on a failed logon instead of dropping into a logon prompt and exiting 0.
-      # Connecting through the listener to XEPDB1 ensures the PDB service is registered, not just that the listener is up.
       test:
         [
           'CMD-SHELL',
@@ -19,7 +17,6 @@ services:
       interval: 3s
       timeout: 5s
       retries: 10
-      # failed probes while the database is still starting up do not count towards `retries`
       start_period: 120s
 
 networks:

--- a/dev/oracle/oldest/start.sh
+++ b/dev/oracle/oldest/start.sh
@@ -9,9 +9,9 @@ docker compose -p sequelize-oracle-oldest up -d
 
 ./../../wait-until-healthy.sh sequelize-oracle-oldest
 
-sleep 30s
-
 docker cp ../privileges.sql sequelize-oracle-oldest:/opt/oracle/.
-docker exec -t sequelize-oracle-oldest sqlplus system/password@XEPDB1 @privileges.sql
+# No -t: without a TTY sqlplus cannot fall into an interactive logon prompt and hang forever.
+# -L: attempt the logon only once and exit non-zero if it fails, so the script fails fast instead of hanging.
+docker exec sequelize-oracle-oldest sqlplus -L system/password@localhost:1521/XEPDB1 @privileges.sql
 
 DIALECT=oracle ts-node ../../check-connection.ts

--- a/dev/oracle/oldest/start.sh
+++ b/dev/oracle/oldest/start.sh
@@ -10,8 +10,6 @@ docker compose -p sequelize-oracle-oldest up -d
 ./../../wait-until-healthy.sh sequelize-oracle-oldest
 
 docker cp ../privileges.sql sequelize-oracle-oldest:/opt/oracle/.
-# No -t: without a TTY sqlplus cannot fall into an interactive logon prompt and hang forever.
-# -L: attempt the logon only once and exit non-zero if it fails, so the script fails fast instead of hanging.
 docker exec sequelize-oracle-oldest sqlplus -L system/password@localhost:1521/XEPDB1 @privileges.sql
 
 DIALECT=oracle ts-node ../../check-connection.ts

--- a/dev/oracle/privileges.sql
+++ b/dev/oracle/privileges.sql
@@ -1,5 +1,9 @@
 -- Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved
 
+-- Make sqlplus exit with a failure code on the first error instead of silently continuing.
+whenever sqlerror exit failure;
+whenever oserror exit failure;
+
 create user sequelizetest identified by sequelizepassword;
 grant all privileges to sequelizetest;
 alter user sequelizetest quota unlimited on users;

--- a/dev/oracle/privileges.sql
+++ b/dev/oracle/privileges.sql
@@ -1,6 +1,5 @@
 -- Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved
 
--- Make sqlplus exit with a failure code on the first error instead of silently continuing.
 whenever sqlerror exit failure;
 whenever oserror exit failure;
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions? (N/A - dev tooling)
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (N/A)
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

## Description Of Change

The `oracle latest (Node 22)` job on #18324 hung in `yarn start-oracle-latest` for the full 6 hour job limit ([job](https://github.com/sequelize/sequelize/actions/runs/33390390513/job/99484347313)). Two defects compounded:

1. **The healthcheck was a false positive.** It ran `sqlplus` without `-L` and with no stdin. On a rejected logon sqlplus prompts for credentials, hits EOF and exits 0. The container flipped to healthy 12s after start, as soon as the listener answered, while the `XEPDB1` PDB was not registered yet (`ORA-12514`). The `sleep 30s` in `start.sh` was a band-aid for exactly this.
2. **The start script's sqlplus call could block forever.** It used `docker exec -t` without `-L`. When the logon failed, sqlplus dropped into its interactive logon prompt on the allocated TTY and waited for input that never came.

### Changes

- `docker-compose.yml` (latest + oldest): the healthcheck pipes `select 1 from dual` into `sqlplus -L -S`, so it only passes when a real logon to `XEPDB1` through the listener succeeds. Timeout raised from 1s to 5s and a `start_period` added so boot-time probe failures are not reported as `unhealthy`.
- `start.sh` (latest + oldest): dropped the TTY, added `-L` so a failed logon exits non-zero immediately, removed the blind `sleep 30s`. The oldest script now uses the same easy-connect string as latest.
- `privileges.sql`: `whenever sqlerror` / `whenever oserror` so a failing statement exits non-zero instead of silently continuing.

### Verification (local, against the real images)

| Scenario | Before | After |
|---|---|---|
| Healthcheck, service not registered | exit 0 | exit 1 |
| `start.sh` exec, service not registered | hangs (killed by `timeout 15`) | exit 1 in <1s |
| Re-running `privileges.sql` when user exists | continues | exit 1 (`ORA-01920`) |
| Full start, `gvenzl/oracle-free:23.26.1-slim` | ~42s incl. sleep | ~40s |
| Full start, `gvenzl/oracle-xe:18-slim` | ~42s incl. sleep | ~32s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Other affected jobs

The same mechanism also explains the `oracle oldest` hangs since #18291 landed: [oracle oldest (Node 22) on #18292](https://github.com/sequelize/sequelize/actions/runs/33490429828/job/99802522744) (6h, last log line `ORA-12514: TNS:listener does not currently know of service requested in connect descriptor`), [oracle oldest (Node 24) on #18170](https://github.com/sequelize/sequelize/actions/runs/32070256817/job/95513567216) (6h), and the two `oracle oldest` jobs on #18328 that were cancelled after 1h14m. Both flavours are fixed here.

Not covered: [oracle oldest (Node 22) on #18335](https://github.com/sequelize/sequelize/actions/runs/33760394681/job/100672511262) died with exit code 137 (SIGKILL) while sqlplus was starting, which looks like the runner running out of memory rather than a script problem.

Related: #18340 (retry image pulls), #18341 (db2 startup timeout).