### PR TITLE
meta: retry image pulls in the database start scripts

### DIFF
--- a/dev/db2/latest/start.sh
+++ b/dev/db2/latest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-db2-latest down --remove-orphans
+./../../pull-images.sh sequelize-db2-latest
 docker compose -p sequelize-db2-latest up -d
 
 ./../wait-until-healthy.sh sequelize-db2-latest

--- a/dev/db2/oldest/start.sh
+++ b/dev/db2/oldest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-db2-oldest down --remove-orphans
+./../../pull-images.sh sequelize-db2-oldest
 docker compose -p sequelize-db2-oldest up -d
 
 ./../wait-until-healthy.sh sequelize-db2-oldest

--- a/dev/mariadb/latest/start.sh
+++ b/dev/mariadb/latest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-mariadb-latest down --remove-orphans
+./../../pull-images.sh sequelize-mariadb-latest
 docker compose -p sequelize-mariadb-latest up -d
 
 ./../../wait-until-healthy.sh sequelize-mariadb-latest

--- a/dev/mariadb/oldest/start.sh
+++ b/dev/mariadb/oldest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-mariadb-oldest down --remove-orphans
+./../../pull-images.sh sequelize-mariadb-oldest
 docker compose -p sequelize-mariadb-oldest up -d
 
 ./../../wait-until-healthy.sh sequelize-mariadb-oldest

--- a/dev/mssql/latest/start.sh
+++ b/dev/mssql/latest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-mssql-latest down --remove-orphans
+./../../pull-images.sh sequelize-mssql-latest
 docker compose -p sequelize-mssql-latest up -d
 
 ./../../wait-until-healthy.sh sequelize-mssql-latest

--- a/dev/mssql/oldest/start.sh
+++ b/dev/mssql/oldest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-mssql-oldest down --remove-orphans
+./../../pull-images.sh sequelize-mssql-oldest
 docker compose -p sequelize-mssql-oldest up -d
 
 ./../../wait-until-healthy.sh sequelize-mssql-oldest

--- a/dev/mysql/latest/start.sh
+++ b/dev/mysql/latest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-mysql-latest down --remove-orphans
+./../../pull-images.sh sequelize-mysql-latest
 docker compose -p sequelize-mysql-latest up -d
 
 ./../../wait-until-healthy.sh sequelize-mysql-latest

--- a/dev/mysql/oldest/start.sh
+++ b/dev/mysql/oldest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-mysql-oldest down --remove-orphans
+./../../pull-images.sh sequelize-mysql-oldest
 docker compose -p sequelize-mysql-oldest up -d
 
 ./../../wait-until-healthy.sh sequelize-mysql-oldest

--- a/dev/oracle/latest/start.sh
+++ b/dev/oracle/latest/start.sh
@@ -5,6 +5,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-oracle-latest down --remove-orphans
+./../../pull-images.sh sequelize-oracle-latest
 docker compose -p sequelize-oracle-latest up -d
 
 ./../../wait-until-healthy.sh sequelize-oracle-latest

--- a/dev/oracle/oldest/start.sh
+++ b/dev/oracle/oldest/start.sh
@@ -5,6 +5,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-oracle-oldest down --remove-orphans
+./../../pull-images.sh sequelize-oracle-oldest
 docker compose -p sequelize-oracle-oldest up -d
 
 ./../../wait-until-healthy.sh sequelize-oracle-oldest

--- a/dev/postgres/latest/start.sh
+++ b/dev/postgres/latest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-postgres-latest down --remove-orphans
+./../../pull-images.sh sequelize-postgres-latest
 docker compose -p sequelize-postgres-latest up -d
 
 ./../../wait-until-healthy.sh sequelize-postgres-latest

--- a/dev/postgres/oldest/start.sh
+++ b/dev/postgres/oldest/start.sh
@@ -3,6 +3,7 @@ set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" # https://stackoverflow.com/a/17744637
 
 docker compose -p sequelize-postgres-oldest down --remove-orphans
+./../../pull-images.sh sequelize-postgres-oldest
 docker compose -p sequelize-postgres-oldest up -d
 
 ./../../wait-until-healthy.sh sequelize-postgres-oldest

--- a/dev/pull-images.sh
+++ b/dev/pull-images.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Pulls the images of a docker compose project, retrying on transient registry errors.
+# Docker Hub occasionally answers a pull with "500 Internal Server Error", which
+# otherwise fails the whole CI job within seconds of it starting.
+set -uo pipefail
+
+if [ "$#" -ne 1 ]; then
+  >&2 echo "Please provide the docker compose project name"
+  exit 1
+fi
+
+project=$1
+attempts=${PULL_ATTEMPTS:-3}
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  if docker compose -p "$project" pull --quiet; then
+    exit 0
+  fi
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    delay=$((15 * attempt))
+    >&2 echo "Pulling images for $project failed (attempt $attempt of $attempts), retrying in ${delay}s"
+    sleep "$delay"
+  fi
+done
+
+>&2 echo "Pulling images for $project failed after $attempts attempts"
+exit 1

--- a/dev/pull-images.sh
+++ b/dev/pull-images.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Pulls the images of a docker compose project, retrying on transient registry errors.
-# Docker Hub occasionally answers a pull with "500 Internal Server Error", which
-# otherwise fails the whole CI job within seconds of it starting.
 set -uo pipefail
 
 if [ "$#" -ne 1 ]; then


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions? (N/A - dev tooling)
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (N/A)
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

## Description Of Change

Docker Hub occasionally answers an image pull with `500 Internal Server Error`, which fails the CI job within seconds of the start step beginning. Two recent examples:

- [mariadb oldest (Node 22)](https://github.com/sequelize/sequelize/actions/runs/33490407126/job/99802356662): `mariadb-oldest Error received unexpected HTTP status: 500 Internal Server Error`
- [mysql oldest (Node 20)](https://github.com/sequelize/sequelize/actions/runs/33779383569/job/100731726668): `Head "https://registry-1.docker.io/v2/library/mysql/manifests/8.0.19": received unexpected HTTP status: 500 Internal Server Error`

This is not dialect-specific, so this PR covers every dialect's start script in one go rather than one PR per dialect.

### Changes

- New `dev/pull-images.sh`: pulls a compose project's images, retrying up to 3 times (override with `PULL_ATTEMPTS`) with a 15s/30s delay between attempts.
- Every `dev/*/{oldest,latest}/start.sh` calls it before `docker compose up -d`, so `up` finds the images already present.

### Verification

| Scenario | Result |
|---|---|
| Cached image | pulled, exit 0 |
| Non-existent tag, `PULL_ATTEMPTS=2` | two attempts 15s apart, then exit 1 with the registry error shown |

Note: this touches the same `start.sh` files as #18339 (oracle) and the db2 PR, so expect a trivial merge conflict in whichever lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development environment startup now retrieves the required container images before launching services.
  * Added automatic retry handling for image downloads, improving resilience when pulls temporarily fail.
  * Startup scripts validate the image-pulling operation and report failure if retries are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->