### PR TITLE
fix(oracle): reject insert queries combining returning with replacement parameters

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -157,6 +157,16 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       parameterStyle = ParameterStyle.REPLACEMENT;
     }
 
+    if (
+      this.dialect.supports.returnIntoValues &&
+      options.returning &&
+      parameterStyle !== ParameterStyle.BIND
+    ) {
+      throw new Error(
+        `The ${this.dialect.name} dialect requires bind parameters for insert queries that use the returning option.`,
+      );
+    }
+
     if (parameterStyle === ParameterStyle.BIND) {
       bind = this.dialect.supports.returnIntoValues && options.bind ? options.bind : pojo();
       bindParam = createBindParamGenerator(bind, this.dialect.name === 'oracle');

--- a/packages/core/test/unit/query-generator/insert-query.test.ts
+++ b/packages/core/test/unit/query-generator/insert-query.test.ts
@@ -129,6 +129,25 @@ describe('QueryGenerator#insertQuery', () => {
     expect(bind).to.be.undefined;
   });
 
+  it('throws an error if returning is used with parameterStyle: REPLACEMENT on a dialect that returns into binds', () => {
+    if (!dialect.supports.returnIntoValues) {
+      return;
+    }
+
+    const { User } = vars;
+
+    expect(() => {
+      queryGenerator.insertQuery(
+        User.table,
+        { firstName: 'John' },
+        {},
+        { returning: true, parameterStyle: ParameterStyle.REPLACEMENT },
+      );
+    }).to.throw(
+      `The ${dialect.name} dialect requires bind parameters for insert queries that use the returning option.`,
+    );
+  });
+
   // This test was added due to a regression where these values were being converted to strings
   it('binds number values', () => {
     if (!sequelize.dialect.supports.dataTypes.ARRAY) {


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Fixes #18345.

`insertQuery` only builds the `bind` map when the resolved parameter style is `BIND`, but it passes `Object.keys(bind).length` to `populateInsertQueryReturnIntoBinds` whenever the dialect supports `RETURNING INTO` and `returning` is set. On oracle with `parameterStyle: ParameterStyle.REPLACEMENT` that threw `TypeError: Cannot convert undefined or null to object` from inside the query generator.

The out binds of a `RETURNING ... INTO` clause need a bind array at execution time, so the combination cannot work with replacement parameters. `insertQuery` now throws a clear error for it instead of the TypeError.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Insert queries using `returning` now require bind parameters for dialects that use output binds, preventing unsupported query configurations.
  * Clearer errors identify when bind parameters are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->