### PR TITLE
feat(postgres): support the enableChannelBinding, pipeline and sslnegotiation connection options

### DIFF
--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -39,9 +39,9 @@
   "dependencies": {
     "@sequelize/core": "workspace:*",
     "@sequelize/utils": "workspace:*",
-    "@types/pg": "^8.11.14",
+    "@types/pg": "^8.23.1",
     "lodash": "^4.18.1",
-    "pg": "^8.20.0",
+    "pg": "^8.23.0",
     "pg-hstore": "^2.3.4",
     "pg-types": "^4.1.0",
     "postgres-array": "^3.0.4",

--- a/packages/postgres/src/_internal/connection-options.ts
+++ b/packages/postgres/src/_internal/connection-options.ts
@@ -23,7 +23,9 @@ type BooleanConnectionOptions = PickByType<PostgresConnectionOptions, boolean>;
 
 const BOOLEAN_CONNECTION_OPTION_MAP = {
   binary: undefined,
+  enableChannelBinding: undefined,
   keepAlive: undefined,
+  pipeline: undefined,
   ssl: undefined,
   statement_timeout: undefined,
 } as const satisfies Record<keyof BooleanConnectionOptions, undefined>;
@@ -52,5 +54,6 @@ export const CONNECTION_OPTION_NAMES = getSynchronizedTypeKeys<PostgresConnectio
   ...STRING_CONNECTION_OPTION_MAP,
   ...BOOLEAN_CONNECTION_OPTION_MAP,
   ...NUMBER_CONNECTION_OPTION_MAP,
+  sslnegotiation: undefined,
   stream: undefined,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,11 +3034,11 @@ __metadata:
     "@sequelize/utils": "workspace:*"
     "@types/chai": "npm:4.3.20"
     "@types/mocha": "npm:10.0.10"
-    "@types/pg": "npm:^8.11.14"
+    "@types/pg": "npm:^8.23.1"
     chai: "npm:4.5.0"
     lodash: "npm:^4.18.1"
     mocha: "npm:11.7.5"
-    pg: "npm:^8.20.0"
+    pg: "npm:^8.23.0"
     pg-hstore: "npm:^2.3.4"
     pg-types: "npm:^4.1.0"
     postgres-array: "npm:^3.0.4"
@@ -3934,14 +3934,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pg@npm:^8.11.14":
-  version: 8.20.0
-  resolution: "@types/pg@npm:8.20.0"
+"@types/pg@npm:^8.23.1":
+  version: 8.23.1
+  resolution: "@types/pg@npm:8.23.1"
   dependencies:
     "@types/node": "npm:*"
     pg-protocol: "npm:*"
     pg-types: "npm:^2.2.0"
-  checksum: 10c0/c8b5aa794ea074aa20d0c1ef6c721ce0fe16f2c084d0ccc32b7f12909a08ec969e6b01a094ce8e7019cc425381c4b59f261bd0133daf0c6d4aca5c6c492e8312
+  checksum: 10c0/0e39ff7dbe233e1e50b172d87fe84cca086a52e255adb104ef1d60619cded356c4414427ffbea58e70a5a985c3036603c8e544ca2937fc1cf4050185109973be
   languageName: node
   linkType: hard
 
@@ -13065,10 +13065,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-protocol@npm:*, pg-protocol@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "pg-protocol@npm:1.15.0"
-  checksum: 10c0/f1acad1e693d23ce70f8a5fec108cb960d6b8546b3a3fb2cf9113211069ef0f8890e2cc26b5f94e11bf81ff6d851b11c0643de12327cd07e0d1127ae1cb80791
+"pg-protocol@npm:*, pg-protocol@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "pg-protocol@npm:1.16.0"
+  checksum: 10c0/8ea4a8f4970aa0ca1e5bf9a482da0a41a043d7470fbaf7592736971146b09a2a4003d953c0091b72fc30bf7a7994a0b7fdf897bf50cd219787bd22806b3ffb04
   languageName: node
   linkType: hard
 
@@ -13100,14 +13100,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg@npm:^8.20.0":
-  version: 8.22.0
-  resolution: "pg@npm:8.22.0"
+"pg@npm:^8.23.0":
+  version: 8.23.0
+  resolution: "pg@npm:8.23.0"
   dependencies:
     pg-cloudflare: "npm:^1.4.0"
     pg-connection-string: "npm:^2.14.0"
     pg-pool: "npm:^3.14.0"
-    pg-protocol: "npm:^1.15.0"
+    pg-protocol: "npm:^1.16.0"
     pg-types: "npm:2.2.0"
     pgpass: "npm:1.0.5"
   peerDependencies:
@@ -13118,7 +13118,7 @@ __metadata:
   peerDependenciesMeta:
     pg-native:
       optional: true
-  checksum: 10c0/f26fe81c8146b802ac58b2a67570ab4f64cbd57d0752d0a6d1b2b1d12168adb241948e6129301b771a359bede6767181c5ac1a584a36bcfcd38ffe955237ee26
+  checksum: 10c0/11ce12a71b4239588c18f078531c378d5bcdbcb9ea892e080a6e71f91aaece2b4b8fd93ee5777f94210f9258ff56161f8ed1a45050c32d295aaca037bba12ee8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions? <!-- no behaviour change; covered by the existing suite -->
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Unblocks #17869 (together with the `@sequelize/mariadb` counterpart, #18353).

`@types/pg` 8.23.1 declares three `pg` client options that were missing from our connection option list:

| Option | Type | Added to `pg` in | Purpose |
| --- | --- | --- | --- |
| `enableChannelBinding` | `boolean` | 8.14 | use `SCRAM-SHA-256-PLUS` when the server offers it |
| `sslnegotiation` | `'postgres' \| 'direct'` | 8.22 | direct TLS handshake without the `SSLRequest` round-trip (PostgreSQL 17+) |
| `pipeline` | `boolean` | 8.23 | opt-in query pipelining on the client |

The connection option list is checked against the driver's own option type by `getSynchronizedTypeKeys`, so once the lockfile picks up 8.23.1 the build fails until they are listed. Same mechanism as #18328.

The two booleans join the boolean option map, which also makes them settable through a connection URL. `sslnegotiation` is a string-literal union, and `parseCommonConnectionUrlOptions` only accepts plain `string` options as search parameters, so it goes in the catch-all list next to `stream`: settable via the options object, not via URL.

`pipeline` is passed through as-is. Sequelize awaits each query on a connection before issuing the next, so enabling it changes nothing in how Sequelize drives the client; it is opt-in and off by default.

The minimum ranges move to `pg` `^8.23.0` and `@types/pg` `^8.23.1`, so every listed option is guaranteed to exist in the driver that receives it. `pg-protocol` is deduplicated to 1.16.0 in the lockfile.

Verified locally against PostgreSQL 17 (postgis 17-3.5) with the full refreshed lockfile from #17869: 2092 integration tests passing, 0 failing.

## List of Breaking Changes

None. The minimum `pg` version rises from 8.20.0 to 8.23.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional PostgreSQL connection options, including channel binding, pipeline mode, and SSL negotiation settings.
  * These options provide greater flexibility when configuring PostgreSQL connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->