### PR TITLE
meta: update pr-auto-update-and-handle-conflicts to 2.1.0

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -34,9 +34,9 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
+          client-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
           private-key: '${{ secrets.SEQUELIZE_BOT_PRIVATE_KEY }}'
-      - uses: sequelize/pr-auto-update-and-handle-conflicts@74929c430b8843e691e7b83d229d8d13d78d89e3 # 2.0.0
+      - uses: sequelize/pr-auto-update-and-handle-conflicts@fcc8633eb414be54676e16dc17f3340ec40dda27 # 2.1.0
         with:
           conflict-label: 'conflicted'
           conflict-requires-ready-state: 'ready_for_review'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
+          client-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
           private-key: '${{ secrets.SEQUELIZE_BOT_PRIVATE_KEY }}'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
+          client-id: '${{ secrets.SEQUELIZE_BOT_APP_ID }}'
           private-key: '${{ secrets.SEQUELIZE_BOT_PRIVATE_KEY }}'
       - name: Draft unfinished PRs
         uses: sequelize/draft-unfinished-prs@dcded35052048b01a1c925cfd8fb7cda473f9b96


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions? (n/a, workflow change only)
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

## Description Of Change

Every `push`-triggered run of the "auto-update PRs & label conflicts" workflow has failed since 13 June 2026 with an HTTP 502 from GitHub's GraphQL API (example: https://github.com/sequelize/sequelize/actions/runs/34457118465/job/102805992017). The PR-triggered runs kept passing, so the effect was that a push to `main` no longer updated auto-merge PRs or flagged new conflicts.

Root cause and fix live in sequelize/pr-auto-update-and-handle-conflicts#7, released as [2.1.0](https://github.com/sequelize/pr-auto-update-and-handle-conflicts/releases/tag/2.1.0). In short: the search query was too expensive for GitHub's time budget with 129 open PRs, pagination never worked, and one PR with a deleted head branch was retried forever.

This PR:

- pins the action to the 2.1.0 commit (`fcc8633`),
- switches `actions/create-github-app-token` from the deprecated `app-id` input to `client-id` in `autoupdate.yml`, `ci.yml` and `stale.yml`. The action forwards `client-id` to the same auth field it used for `app-id`, so the existing `SEQUELIZE_BOT_APP_ID` secret keeps working and the deprecation warning goes away.

## Verification

The rebuilt action was dry-run locally against this repository with a simulated push event before release: 3 pages (50 + 50 + 29 PRs), finished in about 37 seconds. The first push to `main` after this merges is the real test; the job log should show three `Handling PRs` batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated repository workflows to use the current GitHub App token configuration.
  - Upgraded the pull request auto-update and conflict-handling automation to version 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->