### PR TITLE
meta: disable CodeRabbit tools that cannot run on this repo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  tools:
+    # Sequelize does not use Biome. Every packages/*/src/*.js file is ESM syntax
+    # inside a package declaring "type": "commonjs", because esbuild compiles
+    # these sources to CommonJS in lib/, which is what we publish. Biome resolves
+    # the nearest package.json to decide script vs module and so reports every
+    # import/export as "Illegal use of an import declaration outside of a module".
+    # Biome has no parser option to override that.
+    biome:
+      enabled: false
+    # CodeRabbit runs ESLint 10, which dropped eslintrc support. This repo is
+    # pinned to ESLint 8 and uses .eslintrc.js, so every run fails during config
+    # loading with "A config object is using the parserOptions key, which is not
+    # supported in flat config system". Re-enable if we ever move to flat config.
+    eslint:
+      enabled: false


### PR DESCRIPTION
CodeRabbit runs Biome and ESLint on every review of this repo, and both fail before producing a single finding. This adds a `.coderabbit.yaml` turning those two tools off. There is currently no CodeRabbit config file in the repo at all, so it runs entirely on defaults.

Opening as a draft because this is a maintainer policy call, not a bug fix.

## Biome

Biome is not used by this project: no `biome.json`, no `@biomejs/*` dependency, no mention in `yarn.lock`. CodeRabbit runs it anyway, since `reviews.tools.biome.enabled` defaults to `true`.

It fails because it resolves the nearest `package.json` to decide between script and module parsing. Our dialect packages declare `"type": "commonjs"`, which correctly describes the published output, while `src/*.js` is ESM syntax that `build-packages.mjs` compiles to CommonJS into `lib/`. So Biome reports every `import` and `export` as a syntax error:

```
File contains syntax errors that prevent linting: Line 3: Illegal use of an
import declaration outside of a module; ... Line 31: Illegal use of an export
declaration outside of a module
```

This affects 29 files, every `packages/*/src/**/*.js` using `import`/`export`. Biome exposes no parser option to override the `type` field, so there is no fix on our side short of changing the build or the published module type.

This is not new. On #18309 CodeRabbit posted the same parse error inline on `packages/db2/src/query.js`. Biome 2.5.10 promoted it from an inline nit to a whole-file failure, which is why it is now visible as a tool error.

## ESLint

CodeRabbit bundles ESLint 10.10.0, which removed eslintrc support. This repo is pinned to `eslint@8.57.1` and uses `.eslintrc.js` plus 13 per-package configs. The run aborts during config loading:

```
A config object is using the "parserOptions" key, which is not supported in
flat config system.
```

`parserOptions` is simply the first incompatible key encountered; `env`, `extends`, `overrides`, `ignorePatterns` and `root` would all fail too. This happens on any PR touching a JS or TS file, regardless of content. ESLint findings still worked on #18309 and #18293, so the ESLint 10 bump on CodeRabbit's side is recent.

Two alternatives were considered and rejected:

- `reviews.tools.eslint.config_file` does not help. ESLint 10 cannot parse an eslintrc file at any path.
- Adding an `eslint.config.*` shim just for CodeRabbit is unsafe. ESLint 8.57.1 switches to flat config purely from the presence of `eslint.config.{js,mjs,cjs}` in the working directory, so the file would silently flip `yarn test:format:eslint`, `format:eslint` and lint-staged into flat mode and break CI.

A real flat-config migration would mean ESLint 8 to 9, `@ephys/eslint-config-typescript` 20 to 21, dropping `@rushstack/eslint-patch` and rewriting 14 config files. That has been declined before in #18153, #18104, #17254 and #17320, so this PR deliberately does not go near it. Worth noting that even completing it would not necessarily satisfy CodeRabbit, since the shared config pins ESLint 9 and CodeRabbit runs 10.

## Trade-off

Disabling ESLint does lose real CodeRabbit findings, for example the `jsdoc/require-param` catch on #18309. That value is already lost today because the tool errors out, but this makes the loss explicit. The inline comment records flat-config migration as the re-enable condition.

## Verification

This PR should test itself. CodeRabbit reads `.coderabbit.yaml` from the PR branch, so its review here should no longer carry the "Some tools did not complete" block. `@coderabbitai configuration` will show the resolved config and whether any organisation-level UI settings override it, which I cannot see from outside.

Closes nothing; there is no existing issue for this.

## Related work

This is one of a group of PRs that came out of reviewing #18254. Listing them so reviewers can see the relationship.

| PR | What it does | Issues |
| --- | --- | --- |
| #18254 | PostgreSQL column comments leaking into the type definition, for `changeColumn` and `addColumn` | closes #17894 and #17118 |
| #18361 | Three `changeColumn` bugs on PostgreSQL: the `ARRAY(ENUM)` `USING` cast, `SET DEFAULT` ordering, and a stray `UNIQUE` in the `TYPE` clause | no linked issue |
| #18364 | Missing DataType usage context in `createTable` and `changeColumn`, which broke `ARRAY(ENUM)` columns with a `defaultValue` | closes #11285 |
| #18363 **(this PR)** | Tooling only: a `.coderabbit.yaml` disabling the two CodeRabbit tools that cannot run on this repo | no linked issue |

**How they interact:**

- #18254 and #18361 both edit `changeColumnQuery` in `packages/postgres/src/query-generator.js`. They do not conflict semantically, but whichever merges second will need a small rebase.
- #18361 and #18364 are **both** required for `changeColumn` to an `ARRAY(ENUM)` with a `defaultValue` to work end to end. I verified all four combinations: #18364 alone generates correct SQL but fails on the cast, #18361 alone still throws on the enum name, and together they pass.
- #18362 tracks the underlying structural problem all of these work around: the PostgreSQL generators reconstruct column definitions by parsing generated SQL strings rather than reading the attribute object. No direction is decided there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
