### PR TITLE
fix(postgres): support default values on ARRAY(ENUM) columns

### DIFF
--- a/packages/core/src/abstract-dialect/data-types.ts
+++ b/packages/core/src/abstract-dialect/data-types.ts
@@ -2509,7 +2509,8 @@ export class ARRAY<T extends AbstractDataType<any>> extends AbstractDataType<
 
   attachUsageContext(usageContext: DataTypeUseContext): this {
     if (!isString(this.options.type)) {
-      this.options.type.attachUsageContext(usageContext);
+      // `clone` shares the element type instance, so it must be replaced instead of mutated.
+      this.options.type = this.options.type.withUsageContext(usageContext);
     }
 
     return super.attachUsageContext(usageContext);

--- a/packages/core/src/abstract-dialect/query-interface.js
+++ b/packages/core/src/abstract-dialect/query-interface.js
@@ -15,6 +15,32 @@ import { AbstractDataType } from './data-types';
 import { AbstractQueryInterfaceTypeScript } from './query-interface-typescript';
 
 /**
+ * Attaches the column this attribute will be used for to its DataType, unless it already has a usage context
+ * (which happens when the attribute comes from a Model).
+ *
+ * Some DataTypes, such as postgres ENUMs, need to know which column they belong to to be able to produce their SQL.
+ *
+ * @param {AbstractQueryInterface} queryInterface
+ * @param {object} attribute a normalized attribute. Mutated in place.
+ * @param {string | object} tableName
+ * @param {string} columnName
+ *
+ * @returns {object} the attribute
+ * @private
+ */
+function attachColumnUsageContext(queryInterface, attribute, tableName, columnName) {
+  if (attribute.type instanceof AbstractDataType && !attribute.type.usageContext) {
+    attribute.type = attribute.type.withUsageContext({
+      tableName: queryInterface.queryGenerator.extractTableDetails(tableName),
+      columnName,
+      sequelize: queryInterface.sequelize,
+    });
+  }
+
+  return attribute;
+}
+
+/**
  * The interface that Sequelize uses to talk to all databases
  */
 export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
@@ -95,6 +121,10 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
       tableName.schema = modelTable?.schema || options.schema;
     }
 
+    attributes = mapValues(attributes, (attribute, key) =>
+      attachColumnUsageContext(this, attribute, tableName, attribute.field || key),
+    );
+
     attributes = this.queryGenerator.attributesToSQL(attributes, {
       table: tableName,
       context: 'createTable',
@@ -131,19 +161,12 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
       );
     }
 
-    attribute = this.sequelize.normalizeAttribute(attribute);
-
-    if (
-      attribute.type instanceof AbstractDataType &&
-      // we don't give a context if it already has one, because it could come from a Model.
-      !attribute.type.usageContext
-    ) {
-      attribute.type.attachUsageContext({
-        tableName: table,
-        columnName: key,
-        sequelize: this.sequelize,
-      });
-    }
+    attribute = attachColumnUsageContext(
+      this,
+      this.sequelize.normalizeAttribute(attribute),
+      table,
+      key,
+    );
 
     const { ifNotExists, ...rawQueryOptions } = options;
     const addColumnQueryOptions = ifNotExists ? { ifNotExists } : undefined;
@@ -209,7 +232,12 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
 
     const query = this.queryGenerator.attributesToSQL(
       {
-        [attributeName]: this.normalizeAttribute(dataTypeOrOptions),
+        [attributeName]: attachColumnUsageContext(
+          this,
+          this.normalizeAttribute(dataTypeOrOptions),
+          tableName,
+          attributeName,
+        ),
       },
       {
         context: 'changeColumn',

--- a/packages/core/test/integration/query-interface/array-enum-default.test.ts
+++ b/packages/core/test/integration/query-interface/array-enum-default.test.ts
@@ -1,0 +1,92 @@
+import { DataTypes, QueryTypes } from '@sequelize/core';
+import { expect } from 'chai';
+import { sequelize } from '../support';
+
+const queryInterface = sequelize.queryInterface;
+
+// ENUM has no "supports" flag, but the only dialect that supports ARRAY (postgres) also supports ENUM.
+describe('QueryInterface with ARRAY(ENUM) columns that have a default value', () => {
+  if (!sequelize.dialect.supports.dataTypes.ARRAY) {
+    return;
+  }
+
+  const arrayEnum = () => ({
+    type: DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])),
+    allowNull: false,
+    defaultValue: ['foo'],
+  });
+
+  async function getDefault(tableName: string) {
+    await sequelize.query(`INSERT INTO "${tableName}" DEFAULT VALUES`);
+    const rows = await sequelize.query<{ value: string }>(
+      `SELECT "value"::text AS value FROM "${tableName}"`,
+      { type: QueryTypes.SELECT },
+    );
+
+    return rows[0].value;
+  }
+
+  it('creates the column through createTable', async () => {
+    await queryInterface.createTable('users', { value: arrayEnum() });
+
+    expect(await getDefault('users')).to.equal('{foo}');
+  });
+
+  it('creates the column through addColumn', async () => {
+    await queryInterface.createTable('users', { name: DataTypes.STRING });
+    await queryInterface.addColumn('users', 'value', arrayEnum());
+
+    expect(await getDefault('users')).to.equal('{foo}');
+  });
+
+  it('creates the column through sync', async () => {
+    const User = sequelize.define('User', { value: arrayEnum() }, { timestamps: false });
+
+    await User.sync();
+
+    const user = await User.create({});
+    expect(user.get('value')).to.deep.equal(['foo']);
+  });
+
+  it('creates the column through sync({ alter: true })', async () => {
+    sequelize.define('User', { name: DataTypes.STRING }, { timestamps: false });
+    await sequelize.sync();
+
+    const User = sequelize.define(
+      'User',
+      { name: DataTypes.STRING, value: arrayEnum() },
+      { timestamps: false, freezeTableName: false },
+    );
+
+    await User.sync({ alter: true });
+
+    const user = await User.create({});
+    expect(user.get('value')).to.deep.equal(['foo']);
+  });
+
+  it('generates the SQL of changeColumn', async () => {
+    await queryInterface.createTable('users', {
+      value: { type: DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])) },
+    });
+
+    // changeColumn of an enum array currently fails on its USING cast, which is a separate bug,
+    // but it must no longer fail while determining the name of the enum type.
+    const error = await queryInterface
+      .changeColumn('users', 'value', arrayEnum())
+      .catch(error_ => error_);
+
+    expect(String(error?.message ?? '')).to.not.include(
+      'Could not determine the name of this enum',
+    );
+  });
+
+  it('supports re-using a single DataType instance across multiple tables', async () => {
+    const type = DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar']));
+
+    await queryInterface.createTable('users', { value: { type, defaultValue: ['foo'] } });
+    await queryInterface.createTable('projects', { value: { type, defaultValue: ['bar'] } });
+
+    expect(await getDefault('users')).to.equal('{foo}');
+    expect(await getDefault('projects')).to.equal('{bar}');
+  });
+});

--- a/packages/core/test/unit/data-types/arrays.test.ts
+++ b/packages/core/test/unit/data-types/arrays.test.ts
@@ -173,5 +173,57 @@ describe('DataTypes.ARRAY', () => {
         );
       });
     }
+
+    it('escapes array of ENUM using the enum type of the column it is attached to', () => {
+      const type = DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])).withUsageContext({
+        tableName: { tableName: 'myTable' },
+        columnName: 'myColumn',
+        sequelize,
+      });
+
+      expectsql(queryGenerator.escape(['foo'], { type }), {
+        postgres: `ARRAY['foo']::"public"."enum_myTable_myColumn"[]`,
+      });
+    });
+  });
+
+  describe('usage context', () => {
+    if (!dialect.supports.dataTypes.ARRAY) {
+      return;
+    }
+
+    it('propagates the usage context to the element type', () => {
+      const type = DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])).withUsageContext({
+        tableName: { tableName: 'myTable' },
+        columnName: 'myColumn',
+        sequelize,
+      });
+
+      expect(type.options.type).to.have.property('usageContext');
+    });
+
+    it('does not attach the usage context to the element type of the receiver', () => {
+      const elementType = DataTypes.ENUM(['foo', 'bar']);
+      const type = DataTypes.ARRAY(elementType);
+
+      type.withUsageContext({
+        tableName: { tableName: 'myTable' },
+        columnName: 'myColumn',
+        sequelize,
+      });
+
+      expect(type.usageContext).to.equal(undefined);
+      expect(elementType.usageContext).to.equal(undefined);
+      expect(type.options.type).to.have.property('usageContext', undefined);
+    });
+
+    it('can be re-used across multiple columns', () => {
+      const type = DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar']));
+
+      expect(() => {
+        type.withUsageContext({ tableName: { tableName: 'myTable' }, columnName: 'a', sequelize });
+        type.withUsageContext({ tableName: { tableName: 'myTable' }, columnName: 'b', sequelize });
+      }).not.to.throw();
+    });
   });
 });

--- a/packages/core/test/unit/query-interface/add-column.test.ts
+++ b/packages/core/test/unit/query-interface/add-column.test.ts
@@ -1,0 +1,40 @@
+import { DataTypes } from '@sequelize/core';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { expectsql, sequelize } from '../../support';
+
+const dialect = sequelize.dialect;
+
+describe('QueryInterface#addColumn', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // ENUM has no "supports" flag, but the only dialect that supports ARRAY (postgres) also supports ENUM.
+  if (dialect.supports.dataTypes.ARRAY) {
+    it('supports default values on ARRAY(ENUM) columns', async () => {
+      const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], []] as any);
+
+      await sequelize.queryInterface.addColumn('table', 'value', {
+        type: DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])),
+        allowNull: false,
+        defaultValue: ['foo'],
+      });
+
+      expectsql(stub.lastCall.args[0], {
+        postgres: `DO 'BEGIN CREATE TYPE "public"."enum_table_value" AS ENUM(''foo'', ''bar''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "table" ADD COLUMN  "value" "public"."enum_table_value"[] NOT NULL DEFAULT ARRAY['foo']::"public"."enum_table_value"[];`,
+      });
+    });
+
+    it('does not attach a usage context to the DataType it was given', async () => {
+      sinon.stub(sequelize, 'queryRaw').resolves([[], []] as any);
+
+      const type = DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar']));
+
+      await sequelize.queryInterface.addColumn('table', 'a', { type });
+      await sequelize.queryInterface.addColumn('table', 'b', { type });
+
+      expect(type.usageContext).to.equal(undefined);
+    });
+  }
+});

--- a/packages/core/test/unit/query-interface/change-column.test.ts
+++ b/packages/core/test/unit/query-interface/change-column.test.ts
@@ -1,0 +1,31 @@
+import { DataTypes } from '@sequelize/core';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { sequelize } from '../../support';
+
+const dialect = sequelize.dialect;
+
+describe('QueryInterface#changeColumn', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // ENUM has no "supports" flag, but the only dialect that supports ARRAY (postgres) also supports ENUM.
+  if (dialect.supports.dataTypes.ARRAY) {
+    it('supports default values on ARRAY(ENUM) columns', async () => {
+      const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], []] as any);
+
+      await sequelize.queryInterface.changeColumn('table', 'value', {
+        type: DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])),
+        allowNull: false,
+        defaultValue: ['foo'],
+      });
+
+      // Only the DEFAULT clause is asserted here: the rest of the generated statement is covered
+      // by the changeColumn tests of the postgres query generator.
+      expect(stub.lastCall.args[0]).to.include(
+        `ALTER TABLE "table" ALTER COLUMN "value" SET DEFAULT ARRAY['foo']::"public"."enum_table_value"[];`,
+      );
+    });
+  }
+});

--- a/packages/core/test/unit/query-interface/create-table.test.ts
+++ b/packages/core/test/unit/query-interface/create-table.test.ts
@@ -148,4 +148,39 @@ describe('QueryInterface#createTable', () => {
       oracle: `BEGIN EXECUTE IMMEDIATE 'CREATE TABLE "table" ("json" BLOB CHECK ("json" IS JSON))'; EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;`,
     });
   });
+
+  // ENUM has no "supports" flag, but the only dialect that supports ARRAY (postgres) also supports ENUM.
+  if (dialect.supports.dataTypes.ARRAY) {
+    it('supports default values on ARRAY(ENUM) columns', async () => {
+      const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], []] as any);
+
+      await sequelize.queryInterface.createTable('table', {
+        value: {
+          type: DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])),
+          allowNull: false,
+          defaultValue: ['foo'],
+        },
+      });
+
+      expectsql(stub.lastCall.args[0], {
+        postgres: `CREATE TABLE IF NOT EXISTS "table" ("value" "public"."enum_table_value"[] NOT NULL DEFAULT ARRAY['foo']::"public"."enum_table_value"[]);`,
+      });
+    });
+
+    it('supports default values on ARRAY(ENUM) columns that use a custom column name', async () => {
+      const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], []] as any);
+
+      await sequelize.queryInterface.createTable('table', {
+        value: {
+          field: 'custom_value',
+          type: DataTypes.ARRAY(DataTypes.ENUM(['foo', 'bar'])),
+          defaultValue: ['foo'],
+        },
+      });
+
+      expectsql(stub.lastCall.args[0], {
+        postgres: `CREATE TABLE IF NOT EXISTS "table" ("custom_value" "public"."enum_table_custom_value"[] DEFAULT ARRAY['foo']::"public"."enum_table_custom_value"[]);`,
+      });
+    });
+  }
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `yarn test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — no public API change
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Closes #11285. Closed duplicates of the same report: #17087, #10388, #6127.
A previous attempt, #11517, was closed unmerged because it targeted the old `master` branch and was never retargeted at `main`; its approach (stashing `tableName` / `fieldName` onto the attribute object) was also questioned in review. v7 already has a proper mechanism for this — `DataType#attachUsageContext` — so this PR fixes the root cause there instead.

On PostgreSQL, any attribute of type `ARRAY(ENUM(...))` that also has a `defaultValue` threw while generating SQL:

```
Could not determine the name of this enum because it is not attached to an attribute or a column.
```

#### Root cause

PostgreSQL creates a named enum type per column, so `ENUM#toSql` (`packages/postgres/src/_internal/data-types-overrides.ts`) derives its name from the DataType's *usage context* and throws when there is none.

A plain `ENUM` column never hits this: its column type is rendered inline by `attributeToSQL`, and escaping its default value does not need the type name. An `ARRAY(ENUM)` column with a default value does:

```
PostgresQueryGenerator#attributeToSQL      // escape(attribute.defaultValue, { type: attribute.type })
  -> ARRAY#escape                          // appends a `::<elementType>[]` cast
    -> attributeTypeToSql(elementType)
      -> ENUM#toSql                        // throws: no usage context
```

Of the three `QueryInterface` entry points that turn attributes into column SQL, only `addColumn` attached a usage context. `createTable` and `changeColumn` never did, so the nested `ENUM` had no way to learn its column name.

Separately, `ARRAY#attachUsageContext` attached the context to the element type *instance*. Because `AbstractDataType#clone` re-uses the same element type instance, `withUsageContext()` leaked the context onto the receiver, which made a single `DataTypes.ARRAY(DataTypes.ENUM(...))` instance unusable for a second column ("This DataType is already attached to ...").

#### Changes

- `packages/core/src/abstract-dialect/query-interface.js`: extracted the usage-context attachment that `addColumn` already did into a helper, and applied it in `createTable` and `changeColumn` too. It is skipped when the DataType already has a context (i.e. when the attribute comes from a Model), and it no longer mutates the DataType it was given.
- `packages/core/src/abstract-dialect/data-types.ts`: `ARRAY#attachUsageContext` now replaces its element type with a contextualised copy instead of mutating the shared instance.

#### Before / after

Run against a real PostgreSQL with `type: DataTypes.ARRAY(DataTypes.ENUM(['foo','bar'])), allowNull: false, defaultValue: ['foo']`:

| Entry point | `main` | this PR |
| --- | --- | --- |
| `queryInterface.createTable` | ❌ Could not determine the name of this enum… | ✅ |
| `queryInterface.addColumn` | ✅ | ✅ |
| `queryInterface.changeColumn` | ❌ Could not determine the name of this enum… | ✅ SQL generated (see note) |
| `Model.sync()` | ✅ | ✅ |
| `Model.sync({ alter: true })` (new column) | ✅ | ✅ |
| same DataType instance re-used for two columns | ❌ Could not determine the name of this enum… | ✅ |
| default actually applied by the database | ❌ Could not determine the name of this enum… | ✅ `{foo}` |

`sync()` was already fine, because `ModelDefinition` attaches a usage context to every attribute type; the bug only affected attributes that do not come from a Model.

Generated SQL after this change:

```sql
-- createTable
CREATE TABLE IF NOT EXISTS "table" ("value" "public"."enum_table_value"[] NOT NULL DEFAULT ARRAY['foo']::"public"."enum_table_value"[]);

-- addColumn
DO 'BEGIN CREATE TYPE "public"."enum_table_value" AS ENUM(''foo'', ''bar''); EXCEPTION WHEN duplicate_object THEN null; END';
ALTER TABLE "table" ADD COLUMN "value" "public"."enum_table_value"[] NOT NULL DEFAULT ARRAY['foo']::"public"."enum_table_value"[];
```

#### Note on `changeColumn`

This PR makes `changeColumn` generate SQL instead of throwing. Executing it then hits a **separate, pre-existing** bug: `changeColumnQuery` builds the `USING` cast without the `[]` suffix, so PostgreSQL rejects `cannot cast type enum_x_y[] to enum_x_y`. That bug reproduces on `main` without any default value, and is fixed by #18361. Verified locally that with both changes applied, `changeColumn` on an `ARRAY(ENUM)` column with a default value succeeds end to end. The two changes touch different files and do not conflict.

#### Tests

New tests fail on `main` and pass here (verified by reverting the two source files and re-running):

- `packages/core/test/unit/query-interface/create-table.test.ts` — default values on `ARRAY(ENUM)` columns, including a custom column name
- `packages/core/test/unit/query-interface/add-column.test.ts` (new) — same, plus that the given DataType instance is not mutated
- `packages/core/test/unit/query-interface/change-column.test.ts` (new) — the generated `SET DEFAULT` clause
- `packages/core/test/unit/data-types/arrays.test.ts` — `ARRAY` usage-context propagation, non-mutation and re-use
- `packages/core/test/integration/query-interface/array-enum-default.test.ts` (new) — `createTable`, `addColumn`, `sync`, `sync({ alter: true })`, `changeColumn` and DataType re-use, guarded on `dialect.supports.dataTypes.ARRAY`

`DIALECT=postgres` unit suite: 2843 passing. Full `DIALECT=postgres` integration suite: 2098 passing, 0 failing.

## Related work

One of a group of PRs that came out of reviewing #18254. Listed so reviewers can see the relationship.

| PR | What it does | Issues |
| --- | --- | --- |
| #18254 | PostgreSQL column comments leaking into the type definition, for `changeColumn` and `addColumn` | closes #17894, #17118 |
| #18361 | Three `changeColumn` bugs on PostgreSQL: the `ARRAY(ENUM)` `USING` cast, `SET DEFAULT` ordering, and a stray `UNIQUE` in the `TYPE` clause | none |
| #18364 **(this PR)** | Missing DataType usage context in `createTable` and `changeColumn`, which broke `ARRAY(ENUM)` columns with a `defaultValue` | closes #11285 |
| #18365 | MSSQL and Oracle silently dropping `defaultValue` on enum and boolean columns | relates to #14294 |
| #18363 | Tooling only, a `.coderabbit.yaml` for CodeRabbit. Closed, a different approach is planned | none |

**How they interact:**

- #18254 and #18361 both edit `changeColumnQuery` in `packages/postgres/src/query-generator.js`. No semantic conflict, but whichever merges second needs a small rebase.
- #18361 and #18364 are **both** required for `changeColumn` to an `ARRAY(ENUM)` with a `defaultValue` to work end to end. All four combinations were checked: #18364 alone generates correct SQL but fails on the cast, #18361 alone still throws on the enum name, together they pass.
- #18361 and #18365 **collide directly**. Both add a test called `properly generates alter queries for enums with a default value` to `packages/core/test/unit/sql/change-column.test.js`, asserting different output. #18365 is branched off `main`, so its PostgreSQL expectation also encodes the `SET DEFAULT` ordering that #18361 fixes. Whichever merges second must delete the stale test and correct the PostgreSQL, MSSQL and Oracle expectations.
- #18362 tracks the underlying structural problem these all work around: the PostgreSQL generators reconstruct column definitions by parsing generated SQL strings rather than reading the attribute object. No direction is decided there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `ARRAY(ENUM)` columns with default values across table creation, column additions, synchronization, and column changes.
  - Prevented shared data type instances from being unintentionally modified when reused across multiple columns or tables.
  - Ensured enum usage context is correctly applied per column, including custom field names.

- **Tests**
  - Added coverage for PostgreSQL `ARRAY(ENUM)` defaults, escaping, reuse, and generated SQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->