### PR TITLE
fix(mssql,oracle): keep defaultValue on enum and boolean columns

### DIFF
--- a/packages/core/test/integration/query-interface/createTable.test.js
+++ b/packages/core/test/integration/query-interface/createTable.test.js
@@ -183,6 +183,24 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         }
       });
 
+      it('applies the default value of an enum column', async function () {
+        await this.queryInterface.createTable('SomeTable', {
+          id: { type: DataTypes.INTEGER, primaryKey: true },
+          someEnum: {
+            type: DataTypes.ENUM(['pending', 'complete']),
+            defaultValue: 'pending',
+          },
+        });
+
+        await this.queryInterface.insert(null, 'SomeTable', { id: 1 });
+
+        const [rows] = await this.sequelize.query(
+          `SELECT ${this.queryInterface.queryGenerator.quoteIdentifier('someEnum')} FROM ${this.queryInterface.queryGenerator.quoteTable('SomeTable')}`,
+        );
+
+        expect(rows[0].someEnum).to.equal('pending');
+      });
+
       it('should work with multiple enums', async function () {
         await this.queryInterface.createTable('SomeTable', {
           someEnum: DataTypes.ENUM('value1', 'value2', 'value3'),

--- a/packages/core/test/unit/sql/add-column.test.js
+++ b/packages/core/test/unit/sql/add-column.test.js
@@ -95,6 +95,30 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     }
 
+    it('keeps the default value of an enum column', () => {
+      return expectsql(
+        queryGenerator.addColumnQuery(
+          User.table,
+          'level_id',
+          current.normalizeAttribute({
+            type: DataTypes.ENUM(['pending', 'complete']),
+            defaultValue: 'pending',
+          }),
+        ),
+        {
+          'mariadb mysql':
+            "ALTER TABLE `Users` ADD `level_id` ENUM('pending', 'complete') DEFAULT 'pending';",
+          postgres: `DO 'BEGIN CREATE TYPE "public"."enum_Users_level_id" AS ENUM(''pending'', ''complete''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "Users" ADD COLUMN  "level_id" "public"."enum_Users_level_id" DEFAULT 'pending';`,
+          sqlite3: "ALTER TABLE `Users` ADD `level_id` TEXT DEFAULT 'pending';",
+          snowflake: `ALTER TABLE "Users" ADD "level_id" VARCHAR(255) DEFAULT 'pending';`,
+          db2: `ALTER TABLE "Users" ADD "level_id" VARCHAR(255) CHECK ("level_id" IN('pending', 'complete')) DEFAULT 'pending';`,
+          ibmi: `ALTER TABLE "Users" ADD "level_id" VARCHAR(255) CHECK ("level_id" IN('pending', 'complete')) DEFAULT 'pending'`,
+          mssql: `ALTER TABLE [Users] ADD [level_id] NVARCHAR(255) DEFAULT N'pending' CHECK ([level_id] IN(N'pending', N'complete'));`,
+          oracle: `ALTER TABLE "Users" ADD "level_id" VARCHAR2(512) DEFAULT 'pending' CHECK ("level_id" IN('pending', 'complete'));`,
+        },
+      );
+    });
+
     it('defaults the schema to the one set in the Sequelize options', () => {
       const User = customSequelize.define('User', {}, { timestamps: false });
 

--- a/packages/core/test/unit/sql/change-column.test.js
+++ b/packages/core/test/unit/sql/change-column.test.js
@@ -94,4 +94,26 @@ describe('QueryInterface#changeColumn', () => {
           EXECUTE IMMEDIATE 'ALTER TABLE "users" ADD FOREIGN KEY ("level_id") REFERENCES "level" ("id") ON DELETE CASCADE'; END;`,
     });
   });
+
+  it('properly generates alter queries for enums with a default value', async () => {
+    const { User } = vars;
+
+    const sql = await sequelize.queryInterface.changeColumn(User.table, 'level_id', {
+      type: DataTypes.ENUM(['pending', 'complete']),
+      defaultValue: 'pending',
+    });
+
+    expectsql(sql, {
+      'mariadb mysql':
+        "ALTER TABLE `users` CHANGE `level_id` `level_id` ENUM('pending', 'complete') DEFAULT 'pending';",
+      postgres: `ALTER TABLE "users" ALTER COLUMN "level_id" DROP NOT NULL;ALTER TABLE "users" ALTER COLUMN "level_id" SET DEFAULT 'pending';DO 'BEGIN CREATE TYPE "public"."enum_users_level_id" AS ENUM(''pending'', ''complete''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "users" ALTER COLUMN "level_id" TYPE "public"."enum_users_level_id" USING ("level_id"::"public"."enum_users_level_id");`,
+      snowflake: `ALTER TABLE "users" ALTER COLUMN "level_id" DROP NOT NULL;ALTER TABLE "users" ALTER COLUMN "level_id" SET DEFAULT 'pending';ALTER TABLE "users" ALTER COLUMN "level_id" TYPE VARCHAR(255);`,
+      db2: `ALTER TABLE "users" ALTER COLUMN "level_id" SET DATA TYPE VARCHAR(255) CHECK ("level_id" IN('pending', 'complete')) DEFAULT 'pending';`,
+      ibmi: `ALTER TABLE "users" ALTER COLUMN "level_id" SET DATA TYPE VARCHAR(255) ADD CHECK ("level_id" IN('pending', 'complete')) DEFAULT 'pending'`,
+      // MSSQL cannot set a default through ALTER COLUMN: this statement is rejected by the
+      // server. See https://github.com/sequelize/sequelize/issues/14294
+      mssql: `ALTER TABLE [users] ALTER COLUMN [level_id] NVARCHAR(255) DEFAULT N'pending' CHECK ([level_id] IN(N'pending', N'complete'));`,
+      oracle: `DECLARE CONS_NAME VARCHAR2(200); BEGIN BEGIN EXECUTE IMMEDIATE 'ALTER TABLE "users" MODIFY "level_id" VARCHAR2(512) DEFAULT ''pending'' CHECK ("level_id" IN(''pending'', ''complete''))'; EXCEPTION WHEN OTHERS THEN  IF SQLCODE = -1442 OR SQLCODE = -1451 THEN    EXECUTE IMMEDIATE 'ALTER TABLE "users" MODIFY "level_id" VARCHAR2(512) DEFAULT ''pending'' CHECK ("level_id" IN(''pending'', ''complete''))';  ELSE    RAISE;  END IF; END; END;`,
+    });
+  });
 });

--- a/packages/mssql/src/query-generator.js
+++ b/packages/mssql/src/query-generator.js
@@ -476,6 +476,11 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
     if (attribute.type instanceof DataTypes.ENUM) {
       // enums are a special case
       template = attribute.type.toSql({ dialect: this.dialect });
+
+      if (defaultValueSchemable(attribute.defaultValue, this.dialect)) {
+        template += ` DEFAULT ${this.escape(attribute.defaultValue, { ...options, type: attribute.type })}`;
+      }
+
       template += ` CHECK (${this.quoteIdentifier(attribute.field)} IN(${attribute.type.options.values
         .map(value => {
           return this.escape(value, options);

--- a/packages/oracle/src/query-generator.js
+++ b/packages/oracle/src/query-generator.js
@@ -871,6 +871,11 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
     if (attribute.type instanceof DataTypes.ENUM) {
       // enums are a special case
       template = attribute.type.toSql({ dialect: this.dialect });
+
+      if (defaultValueSchemable(attribute.defaultValue, this.dialect)) {
+        template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+      }
+
       template += ` CHECK (${this.quoteIdentifier(options.attributeName)} IN(${attribute.type.options.values
         .map(value => {
           return this.escape(value, undefined, {});
@@ -881,6 +886,7 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
     }
 
     if (attribute.type instanceof DataTypes.JSON) {
+      // Oracle stores JSON in a BLOB, which rejects a string DEFAULT with ORA-01465.
       template = attribute.type.toSql();
       template += ` CHECK (${this.quoteIdentifier(options.attributeName)} IS JSON)`;
 
@@ -889,6 +895,11 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
 
     if (attribute.type instanceof DataTypes.BOOLEAN) {
       template = attribute.type.toSql();
+
+      if (defaultValueSchemable(attribute.defaultValue, this.dialect)) {
+        template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+      }
+
       template += ` CHECK (${this.quoteIdentifier(options.attributeName)} IN('1', '0'))`;
 
       return template;


### PR DESCRIPTION
## The bug

`attributeToSQL` returns early for `ENUM` columns on MSSQL, and for `ENUM` and `BOOLEAN` columns on Oracle, so that it can append the `CHECK` constraint that emulates those types. That early return skips the shared `DEFAULT` handling further down the method, so the attribute's `defaultValue` is silently dropped — from `createTable` and `addColumn` as well as `changeColumn`.

Reproduction, against real databases on `main`:

```js
await queryInterface.createTable('SomeTable', {
  id: { type: DataTypes.INTEGER, primaryKey: true },
  someEnum: { type: DataTypes.ENUM(['pending', 'complete']), defaultValue: 'pending' },
});
await queryInterface.insert(null, 'SomeTable', { id: 1 });
// oracle + mssql: someEnum === null
// every other dialect: someEnum === 'pending'
```

Generated SQL before this PR:

```sql
-- mssql
ALTER TABLE [users] ADD [level_id] NVARCHAR(255) CHECK ([level_id] IN(N'pending', N'complete'));
-- oracle
ALTER TABLE "users" ADD "level_id" VARCHAR2(512) CHECK ("level_id" IN('pending', 'complete'));
```

and after:

```sql
-- mssql
ALTER TABLE [users] ADD [level_id] NVARCHAR(255) DEFAULT N'pending' CHECK ([level_id] IN(N'pending', N'complete'));
-- oracle
ALTER TABLE "users" ADD "level_id" VARCHAR2(512) DEFAULT 'pending' CHECK ("level_id" IN('pending', 'complete'));
```

This is not a deliberate limitation. The early return dates back to e9699b8 (2014, MSSQL) and was copied verbatim into the Oracle dialect in #18050; neither carries a comment or a linked discussion about defaults, and every other dialect emits `DEFAULT` for the same attribute.

Oracle's `BOOLEAN` is affected too (`CHAR(1) CHECK (... IN('1','0'))`). Oracle's `JSON` branch is deliberately left alone: JSON is stored in a `BLOB` there, and `BLOB DEFAULT 'null'` is rejected with `ORA-01465: invalid hex number`. The existing `supports JSON_NULL default values` unit test already documents that, and I've added an inline note so the next person doesn't "fix" it.

## Verified on real databases

Against `gvenzl/oracle-free:23.26.1` and `mcr.microsoft.com/mssql/server` (local dev containers):

| | before | after |
|---|---|---|
| oracle `createTable` (ENUM + BOOLEAN defaults) | `null`, `null` | `'complete'`, `'0'` |
| oracle `addColumn` (ENUM default) | `null` | `'b'` |
| oracle `changeColumn` (ENUM default) | `null` | `'complete'` |
| mssql `createTable` (ENUM default) | `null` | `'pending'` |
| mssql `addColumn` (ENUM default) | `null` | `'b'` |

The new integration test fails with `expected null to equal 'pending'` on both dialects without the source change.

## Known remaining gaps (not addressed here)

* **MSSQL `changeColumn` cannot set a default at all.** `ALTER TABLE ... ALTER COLUMN ... DEFAULT x` is invalid T-SQL; the server answers `Incorrect syntax near the keyword 'DEFAULT'`. That is #14294 (open, also #7403 / #12797 / #10101 / #17405, and an abandoned attempt in #3442). It is unchanged by this PR — the generic MSSQL path already emitted that invalid `DEFAULT`, and the ENUM path now does too. Fixing it properly means teaching `changeColumnQuery` the named-constraint dance:

  ```sql
  DECLARE @name nvarchar(256);
  SELECT @name = dc.name FROM sys.default_constraints dc
    JOIN sys.columns c ON c.object_id = dc.parent_object_id AND c.column_id = dc.parent_column_id
    WHERE dc.parent_object_id = OBJECT_ID(N'[users]') AND c.name = N'level_id';
  IF @name IS NOT NULL EXEC('ALTER TABLE [users] DROP CONSTRAINT [' + @name + ']');
  ALTER TABLE [users] ALTER COLUMN [level_id] NVARCHAR(255);
  ALTER TABLE [users] ADD DEFAULT N'pending' FOR [level_id];
  ```

  `changeColumnQuery` currently receives already-stringified column definitions and would have to regex the `DEFAULT` back out of them — the anti-pattern #18362 is about. Doing it right needs the attribute object, which is the territory of #14687.

* **MSSQL `changeColumn` on an ENUM column fails regardless of defaults**, because `ALTER COLUMN ... CHECK (...)` is also invalid T-SQL (`Incorrect syntax near the keyword 'CHECK'`). Pre-existing, untracked as far as I can tell; happy to open a separate issue.

* **MSSQL `describeTable` mangles string defaults**: `(N'b')` is reported as `(Nb`. Cosmetic, pre-existing, out of scope.

* Oracle's ENUM/BOOLEAN branches also drop `allowNull: false`, `primaryKey`, `unique` and `references` for the same early-return reason. Also out of scope here.

## ⚠️ Overlaps with #18361

#18361 adds a test named `properly generates alter queries for enums with a default value` to `packages/core/test/unit/sql/change-column.test.js` that asserts the **current** MSSQL and Oracle output, with a comment noting that they drop the default. This PR adds a test with the same name to the same file asserting the **new** output. Whichever lands second must drop the stale expectation rather than end up with two same-named tests.

## Tests

* unit: `packages/core/test/unit/sql/add-column.test.js` and `change-column.test.js` — cross-dialect expectations for an ENUM column with a `defaultValue`.
* integration: `packages/core/test/integration/query-interface/createTable.test.js` — creates the table, inserts a row without the column, asserts the default landed. Runs on every dialect, no dialect guard needed.

Full unit suite green on all nine dialects. `query-interface`, `model/sync` and `data-types` integration suites green on mssql; on oracle the same four pre-existing failures occur with and without this change (three `DATE` timezone assertions, plus the `listTables` ordering flake).

## Related work

One of a group of PRs that came out of reviewing #18254. Listed so reviewers can see the relationship.

| PR | What it does | Issues |
| --- | --- | --- |
| #18254 | PostgreSQL column comments leaking into the type definition, for `changeColumn` and `addColumn` | closes #17894, #17118 |
| #18361 | Three `changeColumn` bugs on PostgreSQL: the `ARRAY(ENUM)` `USING` cast, `SET DEFAULT` ordering, and a stray `UNIQUE` in the `TYPE` clause | none |
| #18364 | Missing DataType usage context in `createTable` and `changeColumn`, which broke `ARRAY(ENUM)` columns with a `defaultValue` | closes #11285 |
| #18365 **(this PR)** | MSSQL and Oracle silently dropping `defaultValue` on enum and boolean columns | relates to #14294 |
| #18363 | Tooling only, a `.coderabbit.yaml` for CodeRabbit. Closed, a different approach is planned | none |

**How they interact:**

- #18254 and #18361 both edit `changeColumnQuery` in `packages/postgres/src/query-generator.js`. No semantic conflict, but whichever merges second needs a small rebase.
- #18361 and #18364 are **both** required for `changeColumn` to an `ARRAY(ENUM)` with a `defaultValue` to work end to end. All four combinations were checked: #18364 alone generates correct SQL but fails on the cast, #18361 alone still throws on the enum name, together they pass.
- #18361 and #18365 **collide directly**. Both add a test called `properly generates alter queries for enums with a default value` to `packages/core/test/unit/sql/change-column.test.js`, asserting different output. #18365 is branched off `main`, so its PostgreSQL expectation also encodes the `SET DEFAULT` ordering that #18361 fixes. Whichever merges second must delete the stale test and correct the PostgreSQL, MSSQL and Oracle expectations.
- #18362 tracks the underlying structural problem these all work around: the PostgreSQL generators reconstruct column definitions by parsing generated SQL strings rather than reading the attribute object. No direction is decided there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enum columns now correctly preserve and apply configured default values when creating, altering, or adding columns across supported database dialects.
  - Default values are now generated correctly for enum columns on Microsoft SQL Server and Oracle.
  - Oracle boolean columns now include supported default values in generated schema SQL.
- **Tests**
  - Added cross-dialect coverage for enum defaults during table creation and column changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->