### PR TITLE
fix(postgres): support postgres 18

### DIFF
--- a/dev/postgres/latest/docker-compose.yml
+++ b/dev/postgres/latest/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres-latest:
     container_name: sequelize-postgres-latest
-    image: postgis/postgis:17-3.5
+    image: postgis/postgis:18-3.6
     environment:
       POSTGRES_USER: sequelize_test
       POSTGRES_PASSWORD: sequelize_test
@@ -9,7 +9,7 @@ services:
     ports:
       - 23010:5432
     volumes:
-      - postgres-latest:/var/lib/postgresql/data
+      - postgres-latest:/var/lib/postgresql
     healthcheck:
       # -h forces a TCP probe. During initdb the entrypoint runs a temporary server that only
       # listens on the unix socket, so a socket probe reports healthy before the real server is up.

--- a/packages/postgres/src/query.js
+++ b/packages/postgres/src/query.js
@@ -316,8 +316,12 @@ export class PostgresQuery extends AbstractQuery {
     const errDetail = err.detail || err.messageDetail;
 
     switch (code) {
+      // postgres 18 reports RESTRICT violations as 23001 (restrict_violation) instead of 23503
+      case '23001':
       case '23503':
-        index = errMessage.match(/violates foreign key constraint "(.+?)"/);
+        index = errMessage.match(
+          /violates (?:RESTRICT setting of )?foreign key constraint "(.+?)"/,
+        );
         index = index ? index[1] : undefined;
         table = errMessage.match(/on table "(.+?)"/);
         table = table ? table[1] : undefined;


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions? <!-- existing integration tests now run against postgres 18 -->
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?
- [x] Did you update the typescript typings accordingly (if applicable)? <!-- n/a -->
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description of Changes

Split out of #18258, as requested in https://github.com/sequelize/sequelize/pull/18258#issuecomment-4972078783.

Bumps the latest postgres container from `postgis/postgis:17-3.5` to `postgis/postgis:18-3.6`. Two things were needed to make that work:

**1. The volume mount had to move.** The postgres 18 Docker images store data in a major-version-specific subdirectory and refuse to start when a volume is mounted at `/var/lib/postgresql/data` (see [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259)):

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
```

So `dev/postgres/latest` now mounts the volume at `/var/lib/postgresql`. `dev/postgres/oldest` (postgres 11) is untouched.

Anyone with an existing local `sequelize-postgres-latest-volume` needs `yarn reset-postgres` (or `bash dev/postgres/latest/reset.sh`) once, since the old volume holds a postgres 17 data directory.

**2. `ForeignKeyConstraintError` stopped being raised for RESTRICT violations.** Postgres 18 reports foreign key `RESTRICT` violations with SQLSTATE `23001` (`restrict_violation`) and a different message, where earlier versions used `23503`:

```
postgres 17: ERROR:  23503: update or delete on table "p" violates foreign key constraint "c_pid_fkey" on table "c"
postgres 18: ERROR:  23001: update or delete on table "p" violates RESTRICT setting of foreign key constraint "c_pid_fkey" on table "c"
```

`ON DELETE NO ACTION` still reports `23503`, so only RESTRICT is affected. `formatError` in `packages/postgres/src/query.js` now handles both codes and both message shapes, so the constraint name is still extracted and a `ForeignKeyConstraintError` is thrown.

That regression was caught by the existing integration tests — the `can restrict deletes` / `can restrict updates` tests for `BelongsTo`, `BelongsToMany`, `HasOne` and `HasMany` (8 failures) — which now pass again.

Verified locally against `postgis/postgis:18-3.6` (PostgreSQL 18.6): `yarn test-integration-postgres` goes from 2087 passing / 8 failing to 2095 passing, 0 failing.

## List of Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of PostgreSQL 18 foreign-key restriction errors, including clearer constraint identification.
  - Updated PostgreSQL development configuration for compatibility with PostGIS 18.3.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->